### PR TITLE
Add SRE Agent with AgentCore Migration and SSL Support

### DIFF
--- a/02-use-cases/04-SRE-agent/backend/openapi_specs/k8s_api.yaml
+++ b/02-use-cases/04-SRE-agent/backend/openapi_specs/k8s_api.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: API for accessing Kubernetes cluster data and analysis
 servers:
-  - url: http://mcpgateway.ddns.net:8011
+  - url: https://your-backend-domain.com:8011
     description: Remote development server for K8s API
-  - url: http://localhost:8011
+  - url: https://localhost:8011
     description: Local development server for K8s API
 
 security:

--- a/02-use-cases/04-SRE-agent/backend/openapi_specs/logs_api.yaml
+++ b/02-use-cases/04-SRE-agent/backend/openapi_specs/logs_api.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: API for accessing and analyzing application logs
 servers:
-  - url: http://mcpgateway.ddns.net:8012
+  - url: https://your-backend-domain.com:8012
     description: Remote development server for Logs API
-  - url: http://localhost:8012
+  - url: https://localhost:8012
     description: Local development server for Logs API
 
 security:

--- a/02-use-cases/04-SRE-agent/backend/openapi_specs/metrics_api.yaml
+++ b/02-use-cases/04-SRE-agent/backend/openapi_specs/metrics_api.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: API for accessing application performance metrics
 servers:
-  - url: http://mcpgateway.ddns.net:8013
+  - url: https://your-backend-domain.com:8013
     description: Remote development server for Metrics API
-  - url: http://localhost:8013
+  - url: https://localhost:8013
     description: Local development server for Metrics API
 
 security:

--- a/02-use-cases/04-SRE-agent/backend/openapi_specs/runbooks_api.yaml
+++ b/02-use-cases/04-SRE-agent/backend/openapi_specs/runbooks_api.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: API for accessing DevOps runbooks and playbooks
 servers:
-  - url: http://mcpgateway.ddns.net:8014
+  - url: https://your-backend-domain.com:8014
     description: Remote development server for Runbooks API
-  - url: http://localhost:8014
+  - url: https://localhost:8014
     description: Local development server for Runbooks API
 
 security:

--- a/02-use-cases/04-SRE-agent/backend/scripts/start_demo_backend.sh
+++ b/02-use-cases/04-SRE-agent/backend/scripts/start_demo_backend.sh
@@ -7,6 +7,48 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_ROOT="$(cd "$BACKEND_DIR/.." && pwd)"
 
+# Default SSL certificate paths (can be overridden)
+SSL_KEYFILE="${SSL_KEYFILE:-}"
+SSL_CERTFILE="${SSL_CERTFILE:-}"
+HOST="${HOST:-localhost}"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ssl-keyfile)
+            SSL_KEYFILE="$2"
+            shift 2
+            ;;
+        --ssl-certfile)
+            SSL_CERTFILE="$2"
+            shift 2
+            ;;
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--host HOSTNAME] [--ssl-keyfile PATH] [--ssl-certfile PATH]"
+            echo "  --host HOSTNAME       Hostname to bind to (default: localhost)"
+            echo "  --ssl-keyfile PATH    Path to SSL private key file"
+            echo "  --ssl-certfile PATH   Path to SSL certificate file"
+            echo ""
+            echo "Environment variables:"
+            echo "  HOST                  Hostname to bind to"
+            echo "  SSL_KEYFILE           SSL private key file path"
+            echo "  SSL_CERTFILE          SSL certificate file path"
+            echo ""
+            echo "IMPORTANT: If using SSL, ensure your certificate is valid for the specified hostname."
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
 echo "🚀 Starting SRE Agent Demo Backend..."
 
 # Check if we're in the right directory
@@ -18,6 +60,20 @@ fi
 # Create logs directory
 mkdir -p "$PROJECT_ROOT/logs"
 
+# Prepare server arguments
+SERVER_ARGS="--host '$HOST'"
+if [ -n "$SSL_KEYFILE" ] && [ -n "$SSL_CERTFILE" ]; then
+    SERVER_ARGS="$SERVER_ARGS --ssl-keyfile '$SSL_KEYFILE' --ssl-certfile '$SSL_CERTFILE'"
+    echo "🔒 Using SSL certificates:"
+    echo "   Host: $HOST"
+    echo "   Key: $SSL_KEYFILE"
+    echo "   Cert: $SSL_CERTFILE"
+    echo "⚠️  IMPORTANT: Ensure your SSL certificate is valid for hostname '$HOST'"
+else
+    echo "🌐 Running without SSL (HTTP mode)"
+    echo "   Host: $HOST"
+fi
+
 # Start FastAPI servers using the proper server implementations
 echo "📊 Starting FastAPI servers..."
 
@@ -26,28 +82,35 @@ cd "$BACKEND_DIR/servers"
 
 # K8s API Server (Port 8011)
 echo "🏗️  Starting Kubernetes API server on port 8011..."
-nohup python3 k8s_server.py > "$PROJECT_ROOT/logs/k8s_server.log" 2>&1 &
+nohup bash -c "python3 k8s_server.py $SERVER_ARGS" > "$PROJECT_ROOT/logs/k8s_server.log" 2>&1 &
 
 # Logs API Server (Port 8012)
 echo "📋 Starting Logs API server on port 8012..."
-nohup python3 logs_server.py > "$PROJECT_ROOT/logs/logs_server.log" 2>&1 &
+nohup bash -c "python3 logs_server.py $SERVER_ARGS" > "$PROJECT_ROOT/logs/logs_server.log" 2>&1 &
 
 # Metrics API Server (Port 8013)
 echo "📈 Starting Metrics API server on port 8013..."
-nohup python3 metrics_server.py > "$PROJECT_ROOT/logs/metrics_server.log" 2>&1 &
+nohup bash -c "python3 metrics_server.py $SERVER_ARGS" > "$PROJECT_ROOT/logs/metrics_server.log" 2>&1 &
 
 # Runbooks API Server (Port 8014)
 echo "📚 Starting Runbooks API server on port 8014..."
-nohup python3 runbooks_server.py > "$PROJECT_ROOT/logs/runbooks_server.log" 2>&1 &
+nohup bash -c "python3 runbooks_server.py $SERVER_ARGS" > "$PROJECT_ROOT/logs/runbooks_server.log" 2>&1 &
 
 # Wait a moment for servers to start
 sleep 2
 
+# Determine protocol for display
+if [ -n "$SSL_KEYFILE" ] && [ -n "$SSL_CERTFILE" ]; then
+    PROTOCOL="https"
+else
+    PROTOCOL="http"
+fi
+
 echo "✅ Demo backend started successfully!"
-echo "📊 K8s API: http://localhost:8011"
-echo "📋 Logs API: http://localhost:8012" 
-echo "📈 Metrics API: http://localhost:8013"
-echo "📚 Runbooks API: http://localhost:8014"
+echo "📊 K8s API: $PROTOCOL://$HOST:8011"
+echo "📋 Logs API: $PROTOCOL://$HOST:8012" 
+echo "📈 Metrics API: $PROTOCOL://$HOST:8013"
+echo "📚 Runbooks API: $PROTOCOL://$HOST:8014"
 echo ""
 echo "📝 Logs are being written to $PROJECT_ROOT/logs/"
 echo "🛑 Use './scripts/stop_demo_backend.sh' to stop all servers"

--- a/02-use-cases/04-SRE-agent/backend/servers/k8s_server.py
+++ b/02-use-cases/04-SRE-agent/backend/servers/k8s_server.py
@@ -459,12 +459,36 @@ async def health_check(api_key: str = Depends(_validate_api_key)):
 if __name__ == "__main__":
     import uvicorn
     import sys
+    import argparse
     from pathlib import Path
 
     # Add parent directory to path to import config_utils
     sys.path.append(str(Path(__file__).parent.parent))
     from config_utils import get_server_port
 
-    port = get_server_port("k8s")
-    logging.info(f"Starting K8s server on port {port}")
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    parser = argparse.ArgumentParser(description="K8s API Server")
+    parser.add_argument("--host", type=str, required=True, 
+                       help="Host to bind to (REQUIRED - must match SSL certificate hostname if using SSL)")
+    parser.add_argument("--ssl-keyfile", type=str, help="Path to SSL private key file")
+    parser.add_argument("--ssl-certfile", type=str, help="Path to SSL certificate file")
+    parser.add_argument("--port", type=int, help="Port to bind to (overrides config)")
+    
+    args = parser.parse_args()
+    
+    port = args.port if args.port else get_server_port("k8s")
+    
+    # Configure SSL if both cert files are provided
+    ssl_config = {}
+    if args.ssl_keyfile and args.ssl_certfile:
+        ssl_config = {
+            "ssl_keyfile": args.ssl_keyfile,
+            "ssl_certfile": args.ssl_certfile
+        }
+        protocol = "HTTPS"
+        logging.warning(f"⚠️  SSL CERTIFICATE HOSTNAME WARNING: Ensure your SSL certificate is valid for hostname '{args.host}'")
+        logging.warning(f"⚠️  If using self-signed certificates, generate with: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN={args.host}'")
+    else:
+        protocol = "HTTP"
+    
+    logging.info(f"Starting K8s server on {protocol}://{args.host}:{port}")
+    uvicorn.run(app, host=args.host, port=port, **ssl_config)

--- a/02-use-cases/04-SRE-agent/backend/servers/logs_server.py
+++ b/02-use-cases/04-SRE-agent/backend/servers/logs_server.py
@@ -295,12 +295,36 @@ async def health_check(api_key: str = Depends(_validate_api_key)):
 if __name__ == "__main__":
     import uvicorn
     import sys
+    import argparse
     from pathlib import Path
 
     # Add parent directory to path to import config_utils
     sys.path.append(str(Path(__file__).parent.parent))
     from config_utils import get_server_port
 
-    port = get_server_port("logs")
-    logging.info(f"Starting Logs server on port {port}")
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    parser = argparse.ArgumentParser(description="Logs API Server")
+    parser.add_argument("--host", type=str, required=True, 
+                       help="Host to bind to (REQUIRED - must match SSL certificate hostname if using SSL)")
+    parser.add_argument("--ssl-keyfile", type=str, help="Path to SSL private key file")
+    parser.add_argument("--ssl-certfile", type=str, help="Path to SSL certificate file")
+    parser.add_argument("--port", type=int, help="Port to bind to (overrides config)")
+    
+    args = parser.parse_args()
+    
+    port = args.port if args.port else get_server_port("logs")
+    
+    # Configure SSL if both cert files are provided
+    ssl_config = {}
+    if args.ssl_keyfile and args.ssl_certfile:
+        ssl_config = {
+            "ssl_keyfile": args.ssl_keyfile,
+            "ssl_certfile": args.ssl_certfile
+        }
+        protocol = "HTTPS"
+        logging.warning(f"⚠️  SSL CERTIFICATE HOSTNAME WARNING: Ensure your SSL certificate is valid for hostname '{args.host}'")
+        logging.warning(f"⚠️  If using self-signed certificates, generate with: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN={args.host}'")
+    else:
+        protocol = "HTTP"
+    
+    logging.info(f"Starting Logs server on {protocol}://{args.host}:{port}")
+    uvicorn.run(app, host=args.host, port=port, **ssl_config)

--- a/02-use-cases/04-SRE-agent/backend/servers/metrics_server.py
+++ b/02-use-cases/04-SRE-agent/backend/servers/metrics_server.py
@@ -320,12 +320,36 @@ async def health_check(api_key: str = Depends(_validate_api_key)):
 if __name__ == "__main__":
     import uvicorn
     import sys
+    import argparse
     from pathlib import Path
 
     # Add parent directory to path to import config_utils
     sys.path.append(str(Path(__file__).parent.parent))
     from config_utils import get_server_port
 
-    port = get_server_port("metrics")
-    logging.info(f"Starting Metrics server on port {port}")
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    parser = argparse.ArgumentParser(description="Metrics API Server")
+    parser.add_argument("--host", type=str, required=True, 
+                       help="Host to bind to (REQUIRED - must match SSL certificate hostname if using SSL)")
+    parser.add_argument("--ssl-keyfile", type=str, help="Path to SSL private key file")
+    parser.add_argument("--ssl-certfile", type=str, help="Path to SSL certificate file")
+    parser.add_argument("--port", type=int, help="Port to bind to (overrides config)")
+    
+    args = parser.parse_args()
+    
+    port = args.port if args.port else get_server_port("metrics")
+    
+    # Configure SSL if both cert files are provided
+    ssl_config = {}
+    if args.ssl_keyfile and args.ssl_certfile:
+        ssl_config = {
+            "ssl_keyfile": args.ssl_keyfile,
+            "ssl_certfile": args.ssl_certfile
+        }
+        protocol = "HTTPS"
+        logging.warning(f"⚠️  SSL CERTIFICATE HOSTNAME WARNING: Ensure your SSL certificate is valid for hostname '{args.host}'")
+        logging.warning(f"⚠️  If using self-signed certificates, generate with: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN={args.host}'")
+    else:
+        protocol = "HTTP"
+    
+    logging.info(f"Starting Metrics server on {protocol}://{args.host}:{port}")
+    uvicorn.run(app, host=args.host, port=port, **ssl_config)

--- a/02-use-cases/04-SRE-agent/backend/servers/run_all_servers.py
+++ b/02-use-cases/04-SRE-agent/backend/servers/run_all_servers.py
@@ -80,12 +80,12 @@ def _run_servers():
     logging.info("Test URLs:")
     for name, _, port in servers:
         service_name = name.split()[0].lower()
-        logging.info(f"  {name:<15}: http://localhost:{port}/")
+        logging.info(f"  {name:<15}: https://localhost:{port}/")
 
     logging.info("\nAPI Documentation (add /docs to any URL):")
     for name, _, port in servers:
         service_name = name.split()[0].lower()
-        logging.info(f"  {name} Docs: http://localhost:{port}/docs")
+        logging.info(f"  {name} Docs: https://localhost:{port}/docs")
 
     try:
         # Keep the script running

--- a/02-use-cases/04-SRE-agent/docs/auth.md
+++ b/02-use-cases/04-SRE-agent/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication and Authorization Setup
 
-This document covers the setup requirements for IAM permissions and identity provider (IDP) configuration needed for Genesis Gateway.
+This document covers the setup requirements for IAM permissions and identity provider (IDP) configuration needed for AgentCore Gateway.
 
 ## IAM Permissions Setup
 
@@ -69,9 +69,9 @@ If the Gateway Target is of Smithy Target type:
 - Execution role must include any AWS permissions for the tools/APIs you wish to invoke
 - Example: Adding a gateway target for S3 → add relevant S3 permissions to the role
 
-### Trust Policy for Genesis Service
+### Trust Policy for AgentCore Service
 
-You need to trust the Genesis service's beta account to assume the role:
+You need to trust the AgentCore service's beta account to assume the role:
 
 ```json
 {
@@ -101,7 +101,7 @@ If the Lambda is in another account, configure a resource-based policy (RBP) on 
             "Sid": "cross-account-access",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::<gateway-account>:role/GenesisBetaLambdaExecuteRole"
+                "AWS": "arn:aws:iam::<gateway-account>:role/AgentCoreBetaLambdaExecuteRole"
             },
             "Action": "lambda:InvokeFunction",
             "Resource": "arn:aws:lambda:us-west-2:<account-with-lambda>:function:TestLambda"
@@ -114,7 +114,7 @@ If the Lambda is in another account, configure a resource-based policy (RBP) on 
 
 ### Important: Cognito vs Auth0/Okta Authentication Differences
 
-**Critical Distinction for Genesis Gateway Configuration:**
+**Critical Distinction for AgentCore Gateway Configuration:**
 
 | Provider | JWT Claim Used | Gateway Configuration | Token Contains |
 |----------|---------------|---------------------|----------------|
@@ -124,7 +124,7 @@ If the Lambda is in another account, configure a resource-based policy (RBP) on 
 
 **Why this matters:**
 - Cognito client credentials tokens do NOT include an `aud` (audience) claim
-- Genesis Gateway with `allowedAudience` will reject Cognito tokens (401 error)
+- AgentCore Gateway with `allowedAudience` will reject Cognito tokens (401 error)
 - For Cognito, you MUST use `allowedClients` with your app client ID
 - For Auth0/Okta, you MUST use `allowedAudience` with your API identifier
 
@@ -147,7 +147,7 @@ Create a machine-to-machine user pool:
 # Create user pool
 aws cognito-idp create-user-pool \
     --region us-west-2 \
-    --pool-name "test-genesis-user-pool"
+    --pool-name "test-agentcore-user-pool"
 
 # List user pools to get the pool ID
 aws cognito-idp list-user-pools \
@@ -167,8 +167,8 @@ https://cognito-idp.us-west-2.amazonaws.com/<UserPoolId>/.well-known/openid-conf
 aws cognito-idp create-resource-server \
     --region us-west-2 \
     --user-pool-id <UserPoolId> \
-    --identifier "test-genesis-server" \
-    --name "TestGenesisServer" \
+    --identifier "test-agentcore-server" \
+    --name "TestAgentCoreServer" \
     --scopes '[{"ScopeName":"read","ScopeDescription":"Read access"}, {"ScopeName":"write","ScopeDescription":"Write access"}]'
 ```
 
@@ -178,10 +178,10 @@ aws cognito-idp create-resource-server \
 aws cognito-idp create-user-pool-client \
     --region us-west-2 \
     --user-pool-id <UserPoolId> \
-    --client-name "test-genesis-client" \
+    --client-name "test-agentcore-client" \
     --generate-secret \
     --allowed-o-auth-flows client_credentials \
-    --allowed-o-auth-scopes "test-genesis-server/read" "test-genesis-server/write" \
+    --allowed-o-auth-scopes "test-agentcore-server/read" "test-agentcore-server/write" \
     --allowed-o-auth-flows-user-pool-client \
     --supported-identity-providers "COGNITO"
 ```

--- a/02-use-cases/04-SRE-agent/docs/cli-reference.md
+++ b/02-use-cases/04-SRE-agent/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Command Line Arguments Reference
 
-This document describes all command line arguments available for the Genesis Gateway Management Tool.
+This document describes all command line arguments available for the AgentCore Gateway Management Tool.
 
 ## Usage
 
@@ -19,7 +19,7 @@ python main.py [-h] [--region REGION] [--endpoint-url ENDPOINT_URL] --role-arn R
 
 ### `gateway_name`
 - **Type**: String
-- **Description**: Name for the Genesis Gateway
+- **Description**: Name for the AgentCore Gateway
 
 ## AWS Configuration
 
@@ -58,7 +58,7 @@ python main.py [-h] [--region REGION] [--endpoint-url ENDPOINT_URL] --role-arn R
 
 ### `--description-for-gateway`
 - **Type**: String
-- **Default**: "Genesis Gateway created via SDK"
+- **Default**: "AgentCore Gateway created via SDK"
 - **Description**: Gateway description
 
 ### `--description-for-target`

--- a/02-use-cases/04-SRE-agent/gateway/README.md
+++ b/02-use-cases/04-SRE-agent/gateway/README.md
@@ -4,7 +4,7 @@ This directory contains the MCP (Model Context Protocol) gateway management tool
 
 ## 📁 Files
 
-- `main.py` - Genesis Gateway Management Tool for creating and managing AWS Genesis Gateways
+- `main.py` - AgentCore Gateway Management Tool for creating and managing AWS AgentCore Gateways
 - `mcp_cmds.sh` - Shell script for MCP gateway operations and setup
 - `generate_token.py` - JWT token generation for gateway authentication
 - `openapi_s3_target_cognito.sh` - Script for adding OpenAPI targets with S3 and Cognito integration
@@ -47,7 +47,7 @@ This setup process will:
 
 ### Gateway Management (`main.py`)
 The main gateway management tool provides functionality to:
-- Create and manage AWS Genesis Gateways
+- Create and manage AWS AgentCore Gateways
 - Support MCP protocol integration
 - Handle JWT authorization
 - Add OpenAPI targets from S3 or inline schemas

--- a/02-use-cases/04-SRE-agent/gateway/config.yaml.example
+++ b/02-use-cases/04-SRE-agent/gateway/config.yaml.example
@@ -13,7 +13,7 @@ user_pool_id: "YOUR_USER_POOL_ID"
 client_id: "YOUR_CLIENT_ID"
 
 # S3 Configuration
-s3_bucket: "your-genesis-schemas-bucket"
+s3_bucket: "your-agentcore-schemas-bucket"
 s3_path_prefix: "devops-multiagent-demo"  # Path prefix for OpenAPI schema files
 
 # Provider Configuration
@@ -21,8 +21,8 @@ s3_path_prefix: "devops-multiagent-demo"  # Path prefix for OpenAPI schema files
 provider_arn: "arn:aws:bedrock-agentcore:REGION:ACCOUNT_ID:token-vault/default/apikeycredentialprovider/YOUR_PROVIDER_NAME"
 
 # Gateway Configuration
-gateway_name: "MyGenesisGateway"
-gateway_description: "Genesis Gateway for API Integration"
+gateway_name: "MyAgentCoreGateway"
+gateway_description: "AgentCore Gateway for API Integration"
 
 # Target Configuration
 target_description: "S3 target for OpenAPI schema"

--- a/02-use-cases/04-SRE-agent/gateway/create_gateway.sh
+++ b/02-use-cases/04-SRE-agent/gateway/create_gateway.sh
@@ -176,7 +176,7 @@ python generate_token.py
 
 echo ""
 # Build the command with multiple S3 URIs and descriptions
-echo "Creating Genesis Gateway with multiple S3 targets for DevOps Multi-Agent Demo..."
+echo "Creating AgentCore Gateway with multiple S3 targets for DevOps Multi-Agent Demo..."
 echo "APIs to be configured:"
 for i in "${!S3_URIS[@]}"; do
     api_name=$(basename "${S3_URIS[$i]}" .yaml)
@@ -227,4 +227,4 @@ echo "   - OpenAPI schemas uploaded to S3: ${#API_SCHEMAS[@]} files"
 echo "   - Gateway created with ${#S3_URIS[@]} API targets"
 echo "   - APIs: Kubernetes, Logs, Metrics, Runbooks"
 echo "   - All targets configured with Cognito authentication"
-echo "   - Ready for MCP integration with Genesis Gateway"
+echo "   - Ready for MCP integration with AgentCore Gateway"

--- a/02-use-cases/04-SRE-agent/gateway/generate_token.py
+++ b/02-use-cases/04-SRE-agent/gateway/generate_token.py
@@ -3,7 +3,7 @@
 Cognito Token Generator
 
 This script generates OAuth2 access tokens from Amazon Cognito using client credentials
-and saves them to a .access_token file for use with Genesis Gateway.
+and saves them to a .access_token file for use with AgentCore Gateway.
 """
 
 import argparse

--- a/02-use-cases/04-SRE-agent/gateway/main.py
+++ b/02-use-cases/04-SRE-agent/gateway/main.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Genesis Gateway Management Tool
+AgentCore Gateway Management Tool
 
-This tool provides functionality to create and manage AWS Genesis Gateways
+This tool provides functionality to create and manage AWS AgentCore Gateways
 with MCP protocol support and JWT authorization. It supports creating
 gateways and adding OpenAPI targets from S3 or inline schemas.
 """
@@ -26,13 +26,13 @@ logging.basicConfig(
 )
 
 
-def _create_genesis_client(region: str, endpoint_url: str) -> Any:
+def _create_agentcore_client(region: str, endpoint_url: str) -> Any:
     """
-    Create and return a Genesis client for interacting with the AWS service.
+    Create and return an AgentCore client for interacting with the AWS service.
 
     Args:
         region: AWS region name
-        endpoint_url: Genesis endpoint URL
+        endpoint_url: AgentCore endpoint URL
 
     Returns:
         Configured boto3 client for bedrock-agentcore-control
@@ -41,10 +41,10 @@ def _create_genesis_client(region: str, endpoint_url: str) -> Any:
         client = boto3.client(
             "bedrock-agentcore-control", region_name=region, endpoint_url=endpoint_url
         )
-        logging.info(f"Created Genesis client for region {region}")
+        logging.info(f"Created AgentCore client for region {region}")
         return client
     except Exception as e:
-        logging.error(f"Failed to create Genesis client: {e}")
+        logging.error(f"Failed to create AgentCore client: {e}")
         raise
 
 
@@ -127,7 +127,7 @@ def _check_gateway_exists(client: Any, gateway_name: str) -> str:
     Check if a gateway with the given name already exists.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_name: Name of the gateway to check
 
     Returns:
@@ -157,7 +157,7 @@ def _delete_gateway_targets(client: Any, gateway_id: str) -> None:
     Delete all targets associated with a gateway.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway ID whose targets to delete
     """
     try:
@@ -199,7 +199,7 @@ def _delete_gateway(client: Any, gateway_id: str) -> None:
     Delete a gateway by ID, including all its targets.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway ID to delete
     """
     try:
@@ -225,15 +225,15 @@ def create_gateway(
     discovery_url: str,
     allowed_audience: str = None,
     allowed_clients: list = None,
-    description: str = "Genesis Gateway created via SDK",
+    description: str = "AgentCore Gateway created via SDK",
     search_type: str = "SEMANTIC",
     protocol_version: str = "2025-03-26",
 ) -> Dict[str, Any]:
     """
-    Create a new Genesis Gateway with JWT authorization.
+    Create a new AgentCore Gateway with JWT authorization.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_name: Name for the gateway
         role_arn: IAM role ARN with necessary permissions
         discovery_url: JWT discovery URL
@@ -293,7 +293,7 @@ def create_s3_target(
     Create a gateway target from an S3 OpenAPI schema.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway identifier
         s3_uri: S3 URI of the OpenAPI schema
         provider_arn: OAuth credential provider ARN
@@ -355,7 +355,7 @@ def create_inline_target(
     Create a gateway target from an inline OpenAPI schema.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway identifier
         openapi_schema: Inline OpenAPI schema as string
         provider_arn: OAuth credential provider ARN
@@ -396,7 +396,7 @@ def verify_gateway(client: Any, gateway_id: str) -> Dict[str, Any]:
     Verify gateway creation by fetching its details.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway identifier
 
     Returns:
@@ -418,7 +418,7 @@ def list_gateway_targets(client: Any, gateway_id: str) -> Dict[str, Any]:
     List all targets for a gateway.
 
     Args:
-        client: Genesis client
+        client: AgentCore client
         gateway_id: Gateway identifier
 
     Returns:
@@ -438,11 +438,11 @@ def list_gateway_targets(client: Any, gateway_id: str) -> Dict[str, Any]:
 def main():
     """Main function to orchestrate gateway creation and management."""
     parser = argparse.ArgumentParser(
-        description="Create and manage AWS Genesis Gateways with MCP protocol support"
+        description="Create and manage AWS AgentCore Gateways with MCP protocol support"
     )
 
     # Required arguments
-    parser.add_argument("gateway_name", help="Name for the Genesis Gateway")
+    parser.add_argument("gateway_name", help="Name for the AgentCore Gateway")
 
     # AWS configuration
     parser.add_argument(
@@ -450,8 +450,8 @@ def main():
     )
     parser.add_argument(
         "--endpoint-url",
-        default="https://gamma.us-east-1.gatewaycp.genesis-primitives.aws.dev/",
-        help="Genesis endpoint URL",
+        default="https://bedrock-agentcore-control.us-east-1.amazonaws.com",
+        help="AgentCore endpoint URL",
     )
     parser.add_argument(
         "--role-arn", required=True, help="IAM Role ARN with gateway permissions"
@@ -473,7 +473,7 @@ def main():
     # Gateway configuration
     parser.add_argument(
         "--description-for-gateway",
-        default="Genesis Gateway created via SDK",
+        default="AgentCore Gateway created via SDK",
         help="Gateway description",
     )
     parser.add_argument(
@@ -528,8 +528,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Create Genesis client
-    client = _create_genesis_client(args.region, args.endpoint_url)
+    # Create AgentCore client
+    client = _create_agentcore_client(args.region, args.endpoint_url)
 
     # Check if gateway already exists and handle deletion if requested
     existing_gateway_id = _check_gateway_exists(client, args.gateway_name)

--- a/02-use-cases/04-SRE-agent/gateway/mcp_cmds.sh
+++ b/02-use-cases/04-SRE-agent/gateway/mcp_cmds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # MCP Commands Script
-# This script contains various MCP commands for testing Genesis Gateway
+# This script contains various MCP commands for testing AgentCore Gateway
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/02-use-cases/04-SRE-agent/sre_agent/config/agent_config.yaml
+++ b/02-use-cases/04-SRE-agent/sre_agent/config/agent_config.yaml
@@ -48,5 +48,5 @@ global_tools:
 
 # Gateway configuration
 gateway:
-  uri: "https://sre-gateway-fvt1oavwmi.gateway.bedrock-agentcore.us-east-1.amazonaws.com"
+  uri: "https://sre-gateway-3j1jc7fmbb.gateway.bedrock-agentcore.us-east-1.amazonaws.com"
 

--- a/02-use-cases/04-SRE-agent/sre_agent/multi_agent_langgraph.py
+++ b/02-use-cases/04-SRE-agent/sre_agent/multi_agent_langgraph.py
@@ -249,7 +249,7 @@ async def create_multi_agent_system(
         client = create_mcp_client()
         all_mcp_tools = await client.get_tools()
 
-        # Don't filter out x-amz-genesis-search as it's a global tool
+        # Don't filter out x-amz-agentcore-search as it's a global tool
         mcp_tools = all_mcp_tools
 
         logger.info(f"Retrieved {len(mcp_tools)} tools from MCP")


### PR DESCRIPTION
## Summary
- Adds SRE Agent multi-agent system to the AgentCore samples repository
- Replaces all previous product references with AgentCore terminology  
- Implements SSL certificate support for backend servers with mandatory host parameter
- Updates OpenAPI specifications to use HTTPS with configurable domain placeholders

## Key Features Added
- **Multi-Agent SRE System**: Kubernetes, Logs, Metrics, and Runbooks agents
- **SSL/HTTPS Support**: Backend servers now require SSL certificates for AgentCore Gateway compatibility
- **AgentCore Integration**: Complete migration from previous product references
- **Comprehensive Documentation**: SSL setup instructions, EC2 metadata commands, and domain configuration

## Technical Changes
- Backend servers now accept `--ssl-keyfile` and `--ssl-certfile` command-line arguments
- Made `--host` parameter mandatory for SSL certificate hostname matching
- Updated all OpenAPI specs to use HTTPS URLs with `your-backend-domain.com` placeholders
- Added sed commands for bulk domain replacement in OpenAPI specifications
- Updated production endpoint URLs throughout the codebase

## SSL Requirements
- AgentCore Gateway requires HTTPS endpoints exclusively
- Includes EC2 instance metadata commands for IP retrieval
- Documents SSL certificate setup with Let's Encrypt recommendations
- Provides example configurations for domain-based SSL certificates