### PR TITLE
Fix: prevent unbound variable error when AWS_REGION is unset

### DIFF
--- a/01-tutorials/07-AgentCore-E2E/scripts/prereq.sh
+++ b/01-tutorials/07-AgentCore-E2E/scripts/prereq.sh
@@ -11,7 +11,7 @@ INFRA_TEMPLATE_FILE="prerequisite/infrastructure.yaml"
 COGNITO_TEMPLATE_FILE="prerequisite/cognito.yaml"
 
 # First try to get region from environment variable
-if [ -z "${AWS_REGION}" ]; then
+if [ -z "${AWS_REGION-}" ]; then
     # If AWS_REGION is not set, try to get it from AWS CLI config
     REGION=$(aws configure get region 2>/dev/null || echo "us-west-2")
     # Export it as an environment variable


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**:  #553

### Concise description of the PR

```
Changes to /01-tutorials/07-AgentCore-E2E/scripts/prereq.sh
to prevent an "AWS_REGION: unbound variable" error when the environment variable is not defined.
Replaced ${AWS_REGION} with ${AWS_REGION-} to safely handle unset variables under set -u.
```

### User experience

Before:
Running the script without AWS_REGION defined caused an immediate failure:
```
./prereq.sh: line 14: AWS_REGION: unbound variable
```
After:
The script now automatically detects the region from AWS CLI config
or defaults to `us-west-2`, allowing normal execution.
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [ ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
