### PR TITLE
SRE-Agent: Implement automatic S3 bucket creation during gateway setup

### DIFF
--- a/02-use-cases/SRE-agent/docs/configuration.md
+++ b/02-use-cases/SRE-agent/docs/configuration.md
@@ -156,7 +156,15 @@ user_pool_id: "YOUR_USER_POOL_ID"
 client_id: "YOUR_CLIENT_ID"
 
 # S3 Configuration
-s3_bucket: "your-agentcore-schemas-bucket"
+# OPTION 1: Auto-Create (Recommended)
+# Leave s3_bucket empty or unspecified, and create_gateway.sh will automatically create a bucket
+# with name format: sreagent-{uuid}
+s3_bucket: ""  # Leave empty for auto-creation
+
+# OPTION 2: Manual Bucket
+# Uncomment below and specify your own bucket name if you prefer to manage the bucket yourself
+# s3_bucket: "your-custom-bucket-name"
+
 s3_path_prefix: "devops-multiagent-demo"  # Path prefix for OpenAPI schema files
 
 # Provider Configuration
@@ -210,6 +218,16 @@ target_description: "S3 target for OpenAPI schema"
 - **Purpose**: User personas and preferences for memory-enhanced personalization
 - **Setup**: Edit directly to add or modify user personas
 - **Content**: Predefined user preferences (Alice: technical, Carol: executive)
+
+### S3 Bucket Configuration
+- **Location**: Specified in `gateway/config.yaml` under `s3_bucket` parameter
+- **Purpose**: Storage for OpenAPI specification files used by the gateway
+- **Auto-Creation**:
+  - If `s3_bucket` is empty or not specified in config, the `create_gateway.sh` script will automatically create a bucket
+  - Auto-created bucket naming format: `sreagent-{uuid}` (e.g., `sreagent-550e8400-e29b-41d4-a716-446655440000`)
+  - This format complies with AWS S3 bucket naming restrictions
+- **Manual Bucket**: You can also specify your own bucket name in `gateway/config.yaml` if you prefer to create and manage the bucket yourself
+- **Note**: Requires AWS credentials with S3 bucket creation permissions (`s3:CreateBucket`, `s3:PutObject`)
 
 ### OpenAPI Specifications
 - **Location**: `backend/openapi_specs/*.yaml`

--- a/02-use-cases/SRE-agent/gateway/config.yaml.example
+++ b/02-use-cases/SRE-agent/gateway/config.yaml.example
@@ -20,7 +20,10 @@ user_pool_id: "YOUR_USER_POOL_ID"
 client_id: "YOUR_CLIENT_ID"
 
 # S3 Configuration
-s3_bucket: "your-agentcore-schemas-bucket"
+# AUTO-CREATE (Recommended): Leave s3_bucket empty and the create_gateway.sh script will
+# automatically create a bucket with name format: sreagent-{uuid}
+# MANUAL: Specify your own bucket name if you prefer to manage the bucket yourself
+s3_bucket: ""  # Leave empty for auto-creation, or specify your bucket name
 s3_path_prefix: "devops-multiagent-demo"  # Path prefix for OpenAPI schema files
 
 # Provider Configuration


### PR DESCRIPTION
## Summary

Simplifies SRE-Agent gateway setup by automating S3 bucket creation. Previously, users had to manually create an S3 bucket before running the gateway setup script. This change reduces setup friction and improves user experience.

## Changes

### Modified Files

**`02-use-cases/SRE-agent/gateway/create_gateway.sh`**:
- Added `_generate_bucket_name()` function to generate UUID-based bucket names
- Added `_create_s3_bucket()` function that:
  - Detects if `s3_bucket` is empty or contains placeholder text
  - Automatically creates a bucket with format: `sreagent-{uuid}`
  - Handles region-specific S3 bucket creation (LocationConstraint for non-us-east-1)
  - Maintains backward compatibility with manually-specified buckets
- Integrated bucket creation into setup flow before schema upload
- Updated configuration display to show bucket status

**`02-use-cases/SRE-agent/gateway/config.yaml.example`**:
- Updated S3 bucket configuration with clear instructions for both options
- Default changed to empty string (enables auto-creation)

**`02-use-cases/SRE-agent/docs/configuration.md`**:
- Added comprehensive S3 Bucket Configuration section
- Updated gateway configuration template with OPTION 1 (auto-create) and OPTION 2 (manual)
- Documented bucket naming format and required permissions

## Benefits

- **Reduced Setup Friction**: No need to manually create S3 bucket beforehand
- **Fewer Prerequisites**: Simplifies the setup workflow
- **Backward Compatible**: Users can still specify their own bucket if desired
- **Compliant Naming**: Bucket names follow AWS S3 naming restrictions (3-63 chars, lowercase + hyphens)
- **Unique by Default**: UUID component ensures no naming collisions
- **Error Handling**: Graceful failures with clear error messages

## UUID Bucket Naming Format

Auto-generated bucket names follow the pattern: `sreagent-{uuid}`

Example: `sreagent-550e8400-e29b-41d4-a716-446655440000` (53 characters)

This format is **fully compliant** with AWS S3 bucket naming restrictions:
- 3-63 characters ✓
- Lowercase letters, numbers, and hyphens only ✓
- Starts and ends with alphanumeric character ✓
- No underscores or consecutive periods ✓

## Testing Recommendations

- [ ] Test auto-creation with empty s3_bucket in config
- [ ] Test auto-creation with placeholder text (e.g., "your-bucket-name")
- [ ] Test with manually-specified bucket name (backward compatibility)
- [ ] Test in us-east-1 region
- [ ] Test in non-us-east-1 regions (LocationConstraint handling)
- [ ] Verify bucket is created and contains uploaded OpenAPI specs
- [ ] Test with AWS credentials lacking S3 permissions (error handling)

## Related Issue

Resolves #563: SRE-Agent: Implement automatic S3 bucket creation during gateway setup