### PR TITLE
fix: include account ID in Cognito domain prefix for global uniqueness

### DIFF
--- a/05-blueprints/customer-support-agent-with-agentcore/cdk/lib/stacks/agentcore-stack.ts
+++ b/05-blueprints/customer-support-agent-with-agentcore/cdk/lib/stacks/agentcore-stack.ts
@@ -152,7 +152,7 @@ export class AgentCoreStack extends cdk.Stack {
 
         cognitoUserPool.addDomain(`${props.appName}-CognitoDomain`, {
             cognitoDomain: {
-                domainPrefix: `${props.appName.toLowerCase()}-${region}`,
+                domainPrefix: `${props.appName.toLowerCase()}-${cdk.Aws.ACCOUNT_ID}-${region}`,
             },
         });
 
@@ -484,7 +484,7 @@ export class AgentCoreStack extends cdk.Stack {
         new cdk.CfnOutput(this, 'UserPoolId', { value: cognitoUserPool.userPoolId });
         new cdk.CfnOutput(this, 'ClientId', { value: cognitoUserAppClient.userPoolClientId });
         new cdk.CfnOutput(this, 'CognitoDomain', {
-            value: `${props.appName.toLowerCase()}-${region}.auth.${region}.amazoncognito.com`,
+            value: `${props.appName.toLowerCase()}-${accountId}-${region}.auth.${region}.amazoncognito.com`,
         });
         new cdk.CfnOutput(this, 'Region', { value: region });
         new cdk.CfnOutput(this, 'AccountId', { value: accountId });


### PR DESCRIPTION
## Summary
- Adds the AWS account ID to the Cognito domain prefix in the customer support agent blueprint CDK stack
- Prevents domain name collisions when multiple AWS accounts deploy the same stack in the same region
- Updates both the domain creation and the corresponding `CfnOutput`

## Test plan
- [x] Deploy the CDK stack and verify the Cognito domain is created with the account ID in the prefix
- [x] Confirm the `CognitoDomain` output includes the account ID