### PR TITLE
docs: improve prerequisites for customer-support-agent-with-agentcore

### DIFF
--- a/05-blueprints/customer-support-agent-with-agentcore/README.md
+++ b/05-blueprints/customer-support-agent-with-agentcore/README.md
@@ -20,16 +20,51 @@ A production-ready AI customer support agent built on **Amazon Bedrock AgentCore
 
 ## Prerequisites
 
+> **Tip:** `scripts/deploy.sh` runs pre-flight checks for all of the below — tools, CLI version, AWS credentials, Docker, and Bedrock model access — and will warn you with actionable guidance if anything is missing.
+
+### Tools
+
 | Tool | Version | Install |
 |------|---------|---------|
 | **uv** (Python + packages) | Latest | [Install guide](https://docs.astral.sh/uv/getting-started/installation/). `uv` automatically downloads Python 3.10+ when you run `uv sync`. |
 | **Node.js** | 20+ | Install via [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) — `nvm install 20 && nvm use 20` |
 | **Docker** | Latest | [Docker Desktop](https://docs.docker.com/desktop/setup/install/mac-install/) or [Finch](https://runfinch.com/docs/getting-started/installation/) |
-| **AWS CDK** | v2 | [Install guide](https://docs.aws.amazon.com/cdk/v2/guide/prerequisites.html) |
-| **AWS CLI** | v2 | [Install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) |
-| **AgentCore CLI** | Latest | Added to project's dev dependency so automatically installed with `uv sync`, alternatively run `uv pip install bedrock-agentcore-starter-toolkit` |
+| **AWS CLI** | **v2.32.0+** | [Install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) |
+| **AWS CDK** | v2 | Auto-installed as a project dependency by `scripts/deploy.sh` via `npm install` |
+| **AgentCore CLI** | Latest | Auto-installed as a project dependency by `scripts/deploy.sh` via `uv sync` |
 
-You will also need **AWS credentials** configured with permissions to your account. This can be accessed via `aws login`, [more details](https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html). For minimum IAM permissions required, see [AgentCore Starter Toolkit permissions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html#runtime-permissions-starter-toolkit).
+> **Important:** The `aws login` command requires AWS CLI **v2.32.0 or later**. Run `aws --version` to check. If your version is older, [update the CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) before proceeding.
+
+### AWS Credentials & Permissions
+
+1. **Attach IAM policies** to your IAM user. The demo deploys CDK stacks (Lambda, Cognito, ECR, IAM roles, CloudWatch) and uses the AgentCore Starter Toolkit, which together require broad permissions. For the simplest setup, attach **`AdministratorAccess`**. You will also need **`SignInLocalDevelopmentAccess`** for `aws login` to work. Both can be attached in the IAM Console → Users → your user → Add permissions → Attach policies directly.
+
+   For minimum permissions, see [AgentCore Starter Toolkit permissions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html#runtime-permissions-starter-toolkit).
+
+2. **Log in** via the AWS CLI:
+
+   ```bash
+   aws login
+   ```
+
+   This opens your browser — sign in with your AWS console credentials. [More details](https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html).
+
+3. **Verify credentials:**
+
+   ```bash
+   aws sts get-caller-identity
+   ```
+
+### Enable Anthropic Model Access
+
+The agent uses **Anthropic Claude Sonnet 4.5** via a [global inference profile](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). Since October 2025, Amazon Bedrock [auto-enables all serverless foundation models](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-bedrock-automatic-enablement-serverless-foundation-models/). However, **Anthropic models require a one-time usage form** before first use:
+
+1. Open the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/) and go to the **Playground**
+2. Select any **Anthropic Claude** model
+3. Complete the one-time usage form when prompted
+4. If completed from your AWS organization management account, this enables Anthropic models across all member accounts
+
+> **Note:** You can also complete this form via the API. See the [simplified model access blog post](https://aws.amazon.com/blogs/security/simplified-amazon-bedrock-model-access/) for details.
 
 ---
 
@@ -191,6 +226,7 @@ The key takeaway: the agent can be jailbroken, the model can hallucinate, but th
 
 | Problem | Solution |
 |---------|----------|
+| `aws: error: argument command: Invalid choice 'login'` | AWS CLI version is below v2.32.0. [Update to latest](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) |
 | `agentcore: command not found` | Run `uv pip install bedrock-agentcore-starter-toolkit` |
 | Token script fails to open browser | Copy the URL from terminal output and open manually |
 | "Unauthorized" when invoking | Token expired (1 hour). Re-run `eval $(uv run scripts/cognito-user.py --login --export)` |

--- a/05-blueprints/customer-support-agent-with-agentcore/scripts/deploy.sh
+++ b/05-blueprints/customer-support-agent-with-agentcore/scripts/deploy.sh
@@ -25,10 +25,21 @@ check_cmd npm      "Comes with Node.js"
 check_cmd docker   "Install: https://docs.docker.com/desktop/setup/install/mac-install/"
 check_cmd aws      "Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
 
+# Verify AWS CLI version >= 2.32.0 (required for `aws login`)
+REQUIRED_CLI_VERSION="2.32.0"
+AWS_CLI_VERSION=$(aws --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ -n "$AWS_CLI_VERSION" ]; then
+    if [ "$(printf '%s\n' "$REQUIRED_CLI_VERSION" "$AWS_CLI_VERSION" | sort -V | head -n1)" != "$REQUIRED_CLI_VERSION" ]; then
+        echo "WARNING: AWS CLI version $AWS_CLI_VERSION detected. 'aws login' requires v$REQUIRED_CLI_VERSION+." >&2
+        echo "         Update: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2
+    fi
+fi
+
 # Verify AWS credentials
 if ! aws sts get-caller-identity &>/dev/null; then
     echo "ERROR: AWS credentials are not configured or expired." >&2
-    echo "       Run 'aws configure' or refresh your credentials first." >&2
+    echo "       Run 'aws login' to authenticate, or 'aws configure' to set up credentials." >&2
+    echo "       Details: https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html" >&2
     exit 1
 fi
 
@@ -36,6 +47,18 @@ fi
 if ! docker info &>/dev/null 2>&1; then
     echo "ERROR: Docker daemon is not running. Start Docker Desktop or the Docker service." >&2
     exit 1
+fi
+
+# Check Bedrock model access for required model (Claude Sonnet 4.5)
+# Bedrock auto-enables all serverless models, but Anthropic requires a one-time usage form.
+REQUIRED_MODEL="anthropic.claude-sonnet-4-5-20250929-v1:0"
+if ! aws bedrock get-foundation-model --model-identifier "$REQUIRED_MODEL" \
+    --query 'modelDetails.modelLifecycle.status' --output text 2>/dev/null | grep -qi "ACTIVE"; then
+    echo "WARNING: Could not verify Bedrock model access for Claude Sonnet 4.5 ($REQUIRED_MODEL)." >&2
+    echo "         Anthropic models require a one-time usage form. Complete it in the Bedrock" >&2
+    echo "         console Playground by selecting any Anthropic Claude model." >&2
+    echo "         Details: https://aws.amazon.com/blogs/security/simplified-amazon-bedrock-model-access/" >&2
+    echo "         The deploy will continue, but the agent will fail to invoke without model access." >&2
 fi
 
 echo "    All checks passed."


### PR DESCRIPTION
## Summary

- Expand the Prerequisites section in the customer-support-agent-with-agentcore blueprint with inline guidance that was previously missing, causing first-time users to fail at setup
- Add pre-flight checks to `deploy.sh` for AWS CLI version and Bedrock model access

## Problem

External users following the demo hit immediate setup failures because:
1. `aws login` requires CLI v2.32.0+ but the README only says "v2" — users with older CLIs get `Invalid choice 'login'`
2. No guidance on which IAM policies to attach — just a link to a dense permissions doc page
3. No mention of enabling Bedrock model access — deploy succeeds but agent invocation fails
4. `deploy.sh` checks that `aws` exists but not its version, and doesn't check model access

## Changes

**README.md:**
- Specify AWS CLI **v2.32.0+** requirement with callout explaining why
- Add "AWS Credentials & Permissions" subsection with step-by-step guidance recommending `AdministratorAccess` + `SignInLocalDevelopmentAccess`
- Add "Enable Bedrock Model Access" subsection noting the specific model (Claude Sonnet 4.5 via global inference profile)
- Add troubleshooting row for the `Invalid choice 'login'` error

**scripts/deploy.sh:**
- Add AWS CLI version check (warns if below v2.32.0)
- Add Bedrock model access check for `anthropic.claude-sonnet-4-5-20250929-v1:0` (warns if not accessible)
- Improve credential error message to reference `aws login`

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Run `deploy.sh` with CLI < v2.32.0 — confirm version warning appears
- [ ] Run `deploy.sh` with CLI >= v2.32.0 — confirm no warning
- [ ] Run `deploy.sh` without Bedrock model access enabled — confirm model warning appears
- [ ] Run `deploy.sh` with model access enabled — confirm no warning
- [ ] Full deploy + invoke cycle to confirm no regressions