### PR TITLE
fix: add npm cache preflight check and fix agentcore CLI commands in deploy.sh

### DIFF
--- a/05-blueprints/customer-support-agent-with-agentcore/README.md
+++ b/05-blueprints/customer-support-agent-with-agentcore/README.md
@@ -78,7 +78,7 @@ scripts/deploy.sh
 
 > **Note:** The first deploy takes a while — CDK builds a Docker image, pushes it to ECR, and provisions all resources (Runtime, Gateway, Memory, Cognito, Lambdas).
 
-> **Already deployed?** Run `agentcore status` first. If the agent shows `READY` or `ACTIVE`, skip to Step 2.
+> **Already deployed?** Run `uv run agentcore status` first. If the agent shows `READY` or `ACTIVE`, skip to Step 2.
 
 This deploys:
 - **AgentCore Runtime** — containerized agent running Claude Sonnet 4.5
@@ -90,7 +90,7 @@ This deploys:
 Verify it's running:
 
 ```bash
-agentcore status
+uv run agentcore status
 ```
 
 ---
@@ -129,7 +129,7 @@ This opens your browser for a Cognito login, then sets the bearer token as an en
 With your token set, invoke the agent:
 
 ```bash
-agentcore invoke '{"prompt": "Who am I?"}'
+uv run agentcore invoke '{"prompt": "Who am I?"}'
 ```
 
 The agent identifies you from the JWT token — your email, group, and permissions. No API keys or service accounts. Real user identity flows end-to-end.
@@ -137,11 +137,11 @@ The agent identifies you from the JWT token — your email, group, and permissio
 Now try fetching orders and processing a refund:
 
 ```bash
-agentcore invoke '{"prompt": "Show me my recent orders"}'
+uv run agentcore invoke '{"prompt": "Show me my recent orders"}'
 ```
 
 ```bash
-agentcore invoke '{"prompt": "I need a refund for order ORD-12420. The phone case was damaged."}'
+uv run agentcore invoke '{"prompt": "I need a refund for order ORD-12420. The phone case was damaged."}'
 ```
 
 The refund succeeds. At this point there is **no policy restricting** the refund amount — the agent can process any amount.
@@ -153,7 +153,7 @@ The refund succeeds. At this point there is **no policy restricting** the refund
 Try a large refund to establish a baseline:
 
 ```bash
-agentcore invoke '{"prompt": "I need a refund of $399 for order ORD-12430. The monitor has dead pixels."}'
+uv run agentcore invoke '{"prompt": "I need a refund of $399 for order ORD-12430. The monitor has dead pixels."}'
 ```
 
 The refund goes through because no Cedar policy is in place to block it. The agent has unrestricted access to the `process_refund` tool.
@@ -213,7 +213,7 @@ User Request → AgentCore Runtime → AgentCore Gateway → Cedar Policy Engine
 Try the same large refund again:
 
 ```bash
-agentcore invoke '{"prompt": "I need a full refund for order ORD-12300. The shoes dont fit."}'
+uv run agentcore invoke '{"prompt": "I need a full refund for order ORD-12300. The shoes dont fit."}'
 ```
 
 This time the refund is **blocked** by the AgentCore policy. The agent receives a policy violation from the Gateway and informs the user.
@@ -227,7 +227,7 @@ The key takeaway: the agent can be jailbroken, the model can hallucinate, but th
 | Problem | Solution |
 |---------|----------|
 | `aws: error: argument command: Invalid choice 'login'` | AWS CLI version is below v2.32.0. [Update to latest](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) |
-| `agentcore: command not found` | Run `uv pip install bedrock-agentcore-starter-toolkit` |
+| `agentcore: command not found` | Use `uv run agentcore` (installed in project venv), or install globally: `uv pip install bedrock-agentcore-starter-toolkit` |
 | Token script fails to open browser | Copy the URL from terminal output and open manually |
 | "Unauthorized" when invoking | Token expired (1 hour). Re-run `eval $(uv run scripts/cognito-user.py --login --export)` |
 | CDK deploy fails | Ensure Docker is running. Check credentials: `aws sts get-caller-identity` |
@@ -259,13 +259,13 @@ No custom logging code is required. AgentCore instruments all of this automatica
 
 ### Session IDs
 
-By default, each `agentcore invoke` call generates a new session. To start a named session, pass a session ID with the `-s` flag once — the AgentCore CLI remembers it for subsequent invocations:
+By default, each `uv run agentcore invoke` call generates a new session. To start a named session, pass a session ID with the `-s` flag once — the AgentCore CLI remembers it for subsequent invocations:
 
 ```bash
-agentcore invoke -s $(uuidgen) '{"prompt": "Show me my recent orders"}'
+uv run agentcore invoke -s $(uuidgen) '{"prompt": "Show me my recent orders"}'
 
 # Subsequent calls automatically use the same session
-agentcore invoke '{"prompt": "Refund the headphones"}'
+uv run agentcore invoke '{"prompt": "Refund the headphones"}'
 ```
 
 The agent runtime and memory (preferences, facts, session summaries) is scoped per session and user. Using the same session lets the agent reference earlier parts of the conversation.

--- a/05-blueprints/customer-support-agent-with-agentcore/scripts/deploy.sh
+++ b/05-blueprints/customer-support-agent-with-agentcore/scripts/deploy.sh
@@ -49,6 +49,18 @@ if ! docker info &>/dev/null 2>&1; then
     exit 1
 fi
 
+# Check npm cache ownership (root-owned files from a previous sudo npm install will cause EACCES)
+NPM_CACHE_DIR="${HOME}/.npm"
+if [ -d "$NPM_CACHE_DIR" ]; then
+    NPM_CACHE_OWNER=$(ls -ld "$NPM_CACHE_DIR" | awk '{print $3}')
+    if [ "$NPM_CACHE_OWNER" != "$(whoami)" ]; then
+        echo "ERROR: npm cache directory ($NPM_CACHE_DIR) is owned by '$NPM_CACHE_OWNER' instead of '$(whoami)'." >&2
+        echo "       This was likely caused by a previous 'sudo npm install'." >&2
+        echo "       Fix: sudo chown -R \$(whoami) $NPM_CACHE_DIR" >&2
+        exit 1
+    fi
+fi
+
 # Check Bedrock model access for required model (Claude Sonnet 4.5)
 # Bedrock auto-enables all serverless models, but Anthropic requires a one-time usage form.
 REQUIRED_MODEL="anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -195,7 +207,7 @@ echo ""
 echo "Next steps:"
 echo ""
 echo "  1. Check agent status:"
-echo "       agentcore status"
+echo "       uv run agentcore status"
 echo ""
 echo "  2. Create a Cognito user:"
 echo "       uv run scripts/cognito-user.py --create"
@@ -204,7 +216,7 @@ echo "  3. Log in and set your bearer token:"
 echo "       eval \$(uv run scripts/cognito-user.py --login --export)"
 echo ""
 echo "  4. Invoke the agent:"
-echo "       agentcore invoke '{\"prompt\": \"Who am I?\"}'"
+echo "       uv run agentcore invoke '{\"prompt\": \"Who am I?\"}'"
 echo ""
 echo "  To tear down all resources later:"
 echo "       scripts/teardown.sh"


### PR DESCRIPTION
## Summary

- **npm cache ownership check** (deploy.sh): Adds a pre-flight check that detects root-owned `~/.npm` directories before `npm install` runs. A previous `sudo npm install` leaves root-owned cache files that cause cryptic EACCES permission errors. The check gives users the exact fix command.
- **Fix agentcore CLI commands** (deploy.sh + README.md): All `agentcore status` and `agentcore invoke` commands updated to `uv run agentcore status` / `uv run agentcore invoke`, since the CLI is installed in the project's virtual environment via `uv sync`, not globally.
- **Add `botocore[crt]` dependency** (pyproject.toml + uv.lock): Required for `aws login` credential provider. Without it, any boto3 call (e.g., `cognito-user.py --create`) fails with `MissingDependencyException`. The README instructs users to authenticate via `aws login`, so this must be in the venv.

## Context

All three issues were reported by an external user running the customer-support-agent-with-agentcore demo end-to-end for the first time.

## Test plan

- [x] Verified deploy.sh runs end-to-end successfully
- [x] Verified npm cache check catches root-owned `~/.npm` and prints actionable error
- [x] Verified `uv run agentcore status` and `uv run agentcore invoke` work after deploy
- [x] Verified `uv lock` resolves with `awscrt` added
- [ ] Verify `uv run scripts/cognito-user.py --create` works after `uv sync` with new deps