### PR TITLE
fix: improve cognito-user.py UX for email and password handling

### DIFF
--- a/05-blueprints/customer-support-agent-with-agentcore/scripts/cognito-user.py
+++ b/05-blueprints/customer-support-agent-with-agentcore/scripts/cognito-user.py
@@ -312,7 +312,6 @@ def _check_port_available(port):
 
 def run_callback_server(port=3000):
     """Start local HTTP server to capture callback."""
-    _check_port_available(port)
     server = http.server.HTTPServer(("localhost", port), CallbackHandler)
     server.timeout = 120
     server.handle_request()
@@ -337,6 +336,7 @@ def do_logout():
 
 def do_login(export_mode=False):
     """Run OAuth PKCE login flow. In export mode, print only the export line to stdout."""
+    _check_port_available(3000)
     code_verifier, code_challenge = generate_pkce()
     auth_url = build_auth_url(code_challenge)
 


### PR DESCRIPTION
## Summary
- Replace free-text email input with a numbered menu (1/2) to prevent users from entering emails that don't match the backend mock data
- Display password requirements upfront before the password prompt
- Catch `InvalidPasswordException` and show a friendly error message instead of a raw stacktrace

## Test plan
- [ ] Run `uv run scripts/cognito-user.py --create` and verify numbered email menu works
- [ ] Enter an invalid choice (e.g. `3`) and verify it exits with error
- [ ] Enter a weak password and verify friendly error message appears instead of stacktrace