### PR TITLE
Add barge-in support, user transcription, and VPC setup docs

### DIFF
--- a/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/README.md
+++ b/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/README.md
@@ -25,7 +25,32 @@ bedrock-iam-policy.json - Minimal IAM policy for Nova Sonic
 
 - **Python 3.12+** (required for aws-sdk-bedrock-runtime)
 - AWS credentials configured
-- **VPC with a private subnet and a public subnet (with NAT and Internet Gateway)** for AgentCore Runtime deployment — the agent needs internet egress to reach KVS TURN servers. See [Internet access considerations](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-vpc.html#:~:text=region%20if%20different.-,Internet%20access%20considerations,-When%20you%20connect).
+- **VPC with internet egress** for AgentCore Runtime deployment (see setup below)
+
+## VPC Setup for AgentCore Runtime
+
+The agent needs internet egress to reach KVS TURN servers for WebRTC connectivity. If you already have a VPC with a private subnet that has NAT gateway access, skip to [Deploying to AgentCore Runtime](#deploying-to-agentcore-runtime).
+
+### 1. Create a VPC with public and private subnets
+
+1. Open the [VPC console](https://console.aws.amazon.com/vpc/)
+2. Click **Create VPC**
+3. Select **VPC and more**
+4. Set a name (e.g. `webrtc-bot-example`)
+5. Keep the default CIDR (`10.0.0.0/16`)
+6. Set **Number of Availability Zones** to **1**
+7. Set **Number of public subnets** to **1**
+8. Set **Number of private subnets** to **1**
+9. Set **NAT gateways** to **In 1 AZ**
+10. Click **Create VPC**
+
+### 2. Note the IDs
+
+From the VPC console, copy:
+- **Private subnet ID** (e.g. `subnet-0123456789abcdef0`) — this is where the agent runs
+- **Security group ID** — the default security group created with the VPC (e.g. `sg-0123456789abcdef0`)
+
+You'll use these in the `agentcore configure` step below.
 
 ## Local Setup
 
@@ -80,7 +105,7 @@ agentcore configure \
   --non-interactive
 ```
 
-VPC mode is required so the agent can reach KVS TURN servers for WebRTC connectivity.
+VPC network mode is required because PUBLIC network mode does not support outbound UDP connectivity. 
 
 ### 3. Deploy
 

--- a/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/agent/audio.py
+++ b/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/agent/audio.py
@@ -49,6 +49,7 @@ class OutputTrack(MediaStreamTrack):
         self._fifo = av.AudioFifo()
         self._start_time = None
         self._timestamp = 0
+        self._muted = False
 
     async def recv(self):
         """Return the next 20ms audio frame, paced to real-time."""
@@ -66,10 +67,13 @@ class OutputTrack(MediaStreamTrack):
         if delay > 0:
             await asyncio.sleep(delay)
 
-        # Read exactly one frame from FIFO, or silence if not enough buffered
-        frame = self._fifo.read(SAMPLES_PER_FRAME, partial=False)
-        if frame is None:
+        # Return silence if muted (barge-in) or buffer empty
+        if self._muted:
             frame = _SILENCE
+        else:
+            frame = self._fifo.read(SAMPLES_PER_FRAME, partial=False)
+            if frame is None:
+                frame = _SILENCE
 
         frame.pts = self._timestamp
         frame.time_base = fractions.Fraction(1, OUTPUT_SAMPLE_RATE)
@@ -77,8 +81,14 @@ class OutputTrack(MediaStreamTrack):
         self._frame_count += 1
         return frame
 
+    def clear(self):
+        """Stop playback and discard all buffered audio (barge-in)."""
+        self._muted = True
+        self._fifo = av.AudioFifo()
+
     def add_audio(self, audio_bytes):
         """Buffer PCM bytes from Nova Sonic. AudioFifo handles chunking."""
+        self._muted = False
         frame = AudioFrame(
             format="s16", layout="mono", samples=len(audio_bytes) // BYTES_PER_SAMPLE
         )

--- a/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/agent/nova_sonic.py
+++ b/01-tutorials/01-AgentCore-runtime/06-bi-directional-streaming-webrtc/agent/nova_sonic.py
@@ -187,6 +187,7 @@ async def run_session(audio_in, audio_out, region, pc_id):
     # The ready event gates audio sending until Nova Sonic acknowledges the session.
     # The 0.5s timeout is a fallback in case the first event is delayed.
     ready = asyncio.Event()
+    content_roles = {}  # contentId -> role
 
     async def receive_responses():
         try:
@@ -201,12 +202,30 @@ async def run_session(audio_in, audio_out, region, pc_id):
                 if not ready.is_set():
                     ready.set()
 
-                if "audioOutput" in event:
+                if "contentStart" in event:
+                    cs = event["contentStart"]
+                    if cid := cs.get("contentId"):
+                        content_roles[cid] = cs.get("role", "ASSISTANT")
+                elif "audioOutput" in event:
                     audio_out.add_audio(
                         base64.b64decode(event["audioOutput"]["content"])
                     )
                 elif "textOutput" in event:
-                    logger.info(f"Nova Sonic: {event['textOutput']['content']}")
+                    to = event["textOutput"]
+                    content = to["content"]
+                    role = content_roles.get(to.get("contentId"), "ASSISTANT")
+                    # Barge-in: Nova Sonic sends this before contentEnd INTERRUPTED
+                    if "interrupted" in content and "true" in content:
+                        logger.info("Barge-in detected, clearing audio queue")
+                        audio_out.clear()
+                    else:
+                        label = "User" if role == "USER" else "Nova Sonic"
+                        logger.info(f"{label}: {content}")
+                elif "contentEnd" in event:
+                    ce = event["contentEnd"]
+                    if ce.get("stopReason") == "INTERRUPTED":
+                        audio_out.clear()
+                    content_roles.pop(ce.get("contentId"), None)
         except Exception as e:
             logger.error(f"Receive error: {e}")
 


### PR DESCRIPTION
- Implement barge-in per Nova Sonic spec (mute flag + FIFO clear in OutputTrack)
- Detect interruption from textOutput for reliable barge-in in deployed environments
- Add user speech transcription via contentStart role tracking
- Add VPC setup console instructions to README

# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**:

### Concise description of the PR

```
Changes to ..., because ...
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [ ] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [ ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [ ] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
