### PR TITLE
fix(e2e-workshop): fix gateway race condition and model_id typo in lab-03

### DIFF
--- a/01-tutorials/09-AgentCore-E2E/strands-agents/lab-03-agentcore-gateway.ipynb
+++ b/01-tutorials/09-AgentCore-E2E/strands-agents/lab-03-agentcore-gateway.ipynb
@@ -102,6 +102,7 @@
     "import sys\n",
     "import boto3\n",
     "import json\n",
+    "import time\n",
     "\n",
     "from strands import Agent\n",
     "from strands.models import BedrockModel\n",
@@ -317,6 +318,9 @@
     "    put_ssm_parameter(\n",
     "        \"/app/customersupport/agentcore/gateway_url\", create_response[\"gatewayUrl\"]\n",
     "    )\n",
+    "\n",
+    "    time.sleep(3)\n",
+    "    \n",
     "    print(f\"✅ Gateway created successfully with ID: {gateway_id}\")\n",
     "\n",
     "except Exception:\n",
@@ -436,10 +440,11 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "d2937ba5e1f5065",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from lab_helpers.lab1_strands_agent import (\n",
     "    get_product_info,\n",
@@ -469,7 +474,7 @@
     "    )\n",
     "\n",
     "# Initialize the Bedrock model\n",
-    "model_id = \"global.amazon.nova-2-lite-v1:0\"\"\n",
+    "model_id = \"global.amazon.nova-2-lite-v1:0\"\n",
     "model = BedrockModel(\n",
     "    model_id=model_id,\n",
     "    temperature=0.3,  # Balanced between creativity and consistency\n",
@@ -500,8 +505,7 @@
     "\n",
     "\n",
     "print(\"✅ Customer support agent created successfully!\")"
-   ],
-   "id": "d2937ba5e1f5065"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Add `time.sleep(3)` after gateway creation in Step 5 to prevent Step 6 from failing when cells run in quick succession (e.g. "Run All Cells")
- Remove extra trailing quote from `model_id` that caused `SyntaxError: unterminated string literal`

Fixes #1145