### PR TITLE
feat(ag2): add AG2 framework integration with Amazon Bedrock AgentCore

### DIFF
--- a/03-integrations/agentic-frameworks/ag2/README.md
+++ b/03-integrations/agentic-frameworks/ag2/README.md
@@ -1,0 +1,212 @@
+# AG2 Agents with Amazon Bedrock AgentCore
+
+| Information        | Details                                      |
+| ------------------ | -------------------------------------------- |
+| Agent type         | Conversational / Multi-Agent                 |
+| Agentic Framework  | AG2 (formerly AutoGen)                       |
+| LLM model          | Amazon Bedrock (Claude 3 Sonnet)             |
+| Components         | AssistantAgent, GroupChat, Tool Registration |
+| Example complexity | Beginner → Intermediate                      |
+| SDK used           | Amazon BedrockAgentCore Python SDK           |
+
+This example demonstrates how to integrate AG2 agents with Amazon Bedrock AgentCore. AG2 (formerly AutoGen) is a community-maintained agentic framework with 500K+ monthly PyPI downloads. It provides native Amazon Bedrock support, meaning no external API keys are required — AWS credentials from the environment or an IAM role are sufficient.
+
+Two examples are included:
+
+- `ag2_agent_hello_world.py` — Single agent with tool use (weather lookup)
+- `ag2_multi_agent_example.py` — Multi-agent research workflow using GroupChat
+
+## Key Features
+
+- **Native Amazon Bedrock integration** — `LLMConfig(api_type="bedrock")` works out of the box; no OpenAI API key needed
+- **IAM role authentication** — ideal for AWS-native deployments where external credentials are not desirable
+- **Single dependency** — `ag2[bedrock]` includes all required Bedrock support
+- **Tool registration via decorators** — `@agent.register_for_llm()` + `@agent.register_for_execution()`
+- **Multi-agent orchestration** — built-in GroupChat, Swarm, and nested chat patterns
+- **Async execution** — `a_run()` for single agents, `a_initiate_chat()` for multi-agent conversations
+
+## Prerequisites
+
+- Python 3.10+
+- [uv](https://github.com/astral-sh/uv) - Fast Python package installer and resolver
+- AWS account with Bedrock access
+- AWS credentials configured (env vars, `~/.aws/credentials`, or IAM role — no external API keys required)
+- Amazon Bedrock model access enabled for `anthropic.claude-3-sonnet-20240229-v1:0` in your region
+
+## Setup Instructions
+
+### 1. Create a Python Environment with uv
+
+```bash
+# Install uv if you don't have it already
+pip install uv
+
+# Create and activate a virtual environment
+uv venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```
+
+### 2. Install Requirements
+
+```bash
+uv pip install -r requirements.txt
+```
+
+### 3. Understanding the Agent Code
+
+#### Example 1: Single Agent with Tool Use (`ag2_agent_hello_world.py`)
+
+A single `AssistantAgent` backed by Amazon Bedrock with a weather tool registered via AG2's decorator pattern:
+
+```python
+from autogen import LLMConfig
+from autogen.agentchat import AssistantAgent
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+# Native Bedrock — no OPENAI_API_KEY needed
+llm_config = LLMConfig(
+    api_type="bedrock",
+    model="anthropic.claude-3-sonnet-20240229-v1:0",
+    aws_region="us-east-1",
+)
+
+with llm_config:
+    agent = AssistantAgent(
+        name="weather_agent",
+        system_message="You are a helpful assistant.",
+    )
+
+# AG2 tool registration — two decorators required
+@agent.register_for_execution()
+@agent.register_for_llm(description="Get the current weather for a given city.")
+def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
+    return f"The weather in {city} is 73 degrees and Sunny."
+
+app = BedrockAgentCoreApp()
+
+@app.entrypoint
+async def main(payload):
+    prompt = payload.get("prompt", "What is the weather in New York?")
+    response = await agent.a_run(message=prompt, max_turns=5, user_input=False)
+    await response.process()
+    return {"result": response.summary}
+
+app.run()
+```
+
+#### Example 2: Multi-Agent Research Workflow (`ag2_multi_agent_example.py`)
+
+Two agents collaborate via `GroupChat`: a `researcher` gathers information using a tool, and an `analyst` synthesizes the findings into a structured summary.
+
+```python
+from autogen import LLMConfig
+from autogen.agentchat import AssistantAgent, GroupChat, GroupChatManager
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+with llm_config:
+    researcher = AssistantAgent(name="researcher", system_message="...")
+    analyst = AssistantAgent(name="analyst", system_message="...")
+
+# Tool registered on the researcher only
+@researcher.register_for_execution()
+@researcher.register_for_llm(description="Look up information about a topic.")
+def lookup_info(topic: Annotated[str, "The topic to look up"]) -> str:
+    ...
+
+group_chat = GroupChat(agents=[researcher, analyst], messages=[], max_round=6)
+
+with llm_config:
+    manager = GroupChatManager(groupchat=group_chat)
+
+app = BedrockAgentCoreApp()
+
+@app.entrypoint
+async def main(payload):
+    prompt = payload.get("prompt", "Research the topic of serverless computing")
+    result = await researcher.a_initiate_chat(recipient=manager, message=prompt, max_turns=6)
+    return {"result": result.summary}
+
+app.run()
+```
+
+### 4. Configure and Launch with Bedrock AgentCore Toolkit
+
+```bash
+# Configure your agent for deployment
+agentcore configure -e ag2_agent_hello_world.py
+
+# Launch to AWS (AWS credentials are picked up automatically — no extra env vars needed)
+agentcore launch
+```
+
+For the multi-agent example:
+
+```bash
+agentcore configure -e ag2_multi_agent_example.py
+agentcore launch
+```
+
+### 5. Testing Your Agent
+
+Launch locally to test:
+
+```bash
+agentcore launch -l
+```
+
+Invoke the single-agent example:
+
+```bash
+agentcore invoke -l '{"prompt": "what is the weather in NYC?"}'
+```
+
+Invoke the multi-agent example:
+
+```bash
+agentcore invoke -l '{"prompt": "Research the topic of serverless computing"}'
+```
+
+The agent will:
+
+1. Receive the prompt from the payload
+2. Use registered tools where appropriate
+3. Return `{"result": "<response text>"}`
+
+> Note: Remove the `-l` flag to launch and invoke on AWS cloud.
+
+## How It Works
+
+AG2 agents are wrapped with the Bedrock AgentCore framework using the same pattern as all other framework integrations in this repo:
+
+1. `BedrockAgentCoreApp()` creates an HTTP server on port 8080
+2. `@app.entrypoint` registers the async handler for `/invocations`
+3. `/ping` endpoint is implemented automatically for health checks
+4. `app.run()` starts the server
+
+The agent itself handles:
+
+1. Receiving the prompt from the payload
+2. Deciding when to invoke tools based on the query
+3. Executing tools and incorporating results into the response
+4. Returning a plain-text result string
+
+## AG2 vs Microsoft AutoGen
+
+This repo also contains an `autogen/` example using Microsoft AutoGen (`autogen-agentchat`). AG2 and Microsoft AutoGen are **separate projects** with different APIs and package names:
+
+| Attribute         | AG2                                            | Microsoft AutoGen                                        |
+| ----------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| Package           | `ag2`                                          | `autogen-agentchat` + `autogen-ext`                      |
+| Import            | `from autogen.agentchat import AssistantAgent` | `from autogen_agentchat.agents import AssistantAgent`    |
+| Bedrock support   | Native (`api_type="bedrock"`)                  | Via `autogen-ext[bedrock]`                               |
+| API keys required | None (IAM only)                                | OpenAI API key required for `OpenAIChatCompletionClient` |
+| Multi-agent       | GroupChat, Swarm, nested chat                  | SocietyOfMindAgent, Swarm                                |
+
+AG2's native Bedrock support makes it a natural choice for AWS-native deployments where external API keys are not desired.
+
+## Additional Resources
+
+- [AG2 Documentation](https://docs.ag2.ai)
+- [AG2 GitHub Repository](https://github.com/ag2ai/ag2)
+- [Amazon Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-core.html)
+- [Amazon Bedrock Model Access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)

--- a/03-integrations/agentic-frameworks/ag2/ag2_agent_hello_world.py
+++ b/03-integrations/agentic-frameworks/ag2/ag2_agent_hello_world.py
@@ -1,0 +1,150 @@
+"""
+AG2 (formerly AutoGen) Hello World — Amazon Bedrock AgentCore Integration
+=========================================================================
+
+AG2 is the community continuation of Microsoft AutoGen, maintained at ag2ai/ag2.
+Key advantage over MS AutoGen: AG2 has NATIVE Amazon Bedrock support built in —
+no OpenAI API key required. AWS credentials are picked up automatically from the
+environment, ~/.aws/credentials, or an IAM role.
+
+Comparison with MS AutoGen (autogen_agentchat):
+  MS AutoGen:  from autogen_agentchat.agents import AssistantAgent
+               from autogen_ext.models.openai import OpenAIChatCompletionClient
+               model_client = OpenAIChatCompletionClient(model="gpt-4o")  # requires OPENAI_API_KEY
+
+  AG2:         from autogen.agentchat import AssistantAgent
+               from autogen import LLMConfig
+               llm_config = LLMConfig(api_type="bedrock", model="...", aws_region="...")
+
+Both packages expose similar agent abstractions, but AG2 natively integrates with
+Amazon Bedrock models using AWS credentials — no third-party API keys needed.
+"""
+
+import logging
+from typing import Annotated
+
+from autogen import LLMConfig
+from autogen.agentchat import AssistantAgent
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+# ---------------------------------------------------------------------------
+# Logging — same pattern as other framework integrations in this repo
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("ag2_agent")
+
+# ---------------------------------------------------------------------------
+# LLM configuration — AG2 native Bedrock support
+#
+# Unlike MS AutoGen (which requires OpenAIChatCompletionClient + OPENAI_API_KEY),
+# AG2 connects directly to Amazon Bedrock via api_type="bedrock".
+# AWS credentials are resolved automatically (env vars, ~/.aws, or IAM role).
+# ---------------------------------------------------------------------------
+llm_config = LLMConfig(
+    api_type="bedrock",
+    model="anthropic.claude-3-sonnet-20240229-v1:0",
+    aws_region="us-west-2",
+)
+
+# ---------------------------------------------------------------------------
+# AG2 AssistantAgent
+#
+# MS AutoGen equivalent:
+#   agent = AssistantAgent(name="...", model_client=model_client, tools=[...])
+#
+# AG2 equivalent — LLMConfig is passed directly; tools are registered separately
+# via decorators (see below) rather than as a constructor argument.
+# ---------------------------------------------------------------------------
+with llm_config:
+    agent = AssistantAgent(
+        name="weather_agent",
+        system_message=(
+            "You are a helpful assistant. "
+            "Use the get_weather tool to answer weather questions."
+        ),
+    )
+
+# ---------------------------------------------------------------------------
+# Tool registration — AG2 decorator pattern
+#
+# Two decorators are always required:
+#   @agent.register_for_llm(description="...")
+#       -> Generates the JSON schema and tells the LLM the tool exists.
+#   @agent.register_for_execution()
+#       -> Allows the agent executor to actually call the function at runtime.
+#
+# Both must be applied to the same function. Because register_for_llm wraps
+# the function first, register_for_execution is the outer decorator.
+#
+# MS AutoGen equivalent:
+#   async def get_weather(city: str) -> str: ...
+#   agent = AssistantAgent(..., tools=[get_weather])   # passed at construction
+#
+# AG2: do NOT pass tools to the constructor or to a_run() when using decorators.
+# ---------------------------------------------------------------------------
+@agent.register_for_execution()
+@agent.register_for_llm(description="Get the current weather for a given city.")
+def get_weather(city: Annotated[str, "The name of the city to get weather for"]) -> str:
+    """Return a mock weather report for the requested city."""
+    logger.debug("get_weather called for city: %s", city)
+    return f"The weather in {city} is 73 degrees and Sunny."
+
+
+# ---------------------------------------------------------------------------
+# Bedrock AgentCore app — identical boilerplate across all framework examples
+# ---------------------------------------------------------------------------
+app = BedrockAgentCoreApp()
+
+
+@app.entrypoint
+async def main(payload):
+    """
+    AgentCore entrypoint — called once per invocation.
+
+    Payload key : "prompt"  (str)
+    Default     : "What is the weather in New York?"
+    Response    : {"result": <str>}
+
+    MS AutoGen used:  result = await Console(agent.run_stream(task=prompt))
+    AG2 uses      :   response = await agent.a_run(...); await response.process()
+    """
+    logger.debug("Starting AG2 agent execution")
+
+    try:
+        prompt = payload.get("prompt", "What is the weather in New York?")
+        logger.debug("Processing prompt: %s", prompt)
+
+        # a_run() returns an AsyncRunResponseProtocol object.
+        # Tools registered via decorators above are automatically available —
+        # do NOT pass them again here.
+        # summary_method="last_msg" (default) makes response.summary the plain-text
+        # content of the final AI message — convenient for JSON serialization.
+        response = await agent.a_run(
+            message=prompt,
+            max_turns=5,
+            user_input=False,
+        )
+
+        # process() drives the async execution loop; must be awaited before
+        # accessing response.summary or response.messages.
+        await response.process()
+
+        logger.debug("Agent summary: %s", response.summary)
+
+        # response.summary is a plain string (the last AI message content)
+        # when summary_method="last_msg" (the default).
+        if response.summary:
+            return {"result": response.summary}
+
+        return {"result": "No response generated"}
+
+    except Exception as e:
+        logger.error("Error in AG2 agent: %s", e, exc_info=True)
+        return {"result": f"Error: {str(e)}"}
+
+
+app.run()

--- a/03-integrations/agentic-frameworks/ag2/ag2_multi_agent_example.py
+++ b/03-integrations/agentic-frameworks/ag2/ag2_multi_agent_example.py
@@ -1,0 +1,208 @@
+"""
+AG2 Multi-Agent Example — Amazon Bedrock AgentCore Integration
+==============================================================
+
+This example demonstrates AG2's multi-agent GroupChat capability — a key
+differentiator from the Microsoft AutoGen single-agent hello world example.
+
+Architecture:
+  researcher  →  looks up information using a tool
+  analyst     →  synthesizes the researcher's findings into insights
+  Both agents collaborate via AG2's GroupChat / GroupChatManager orchestration.
+
+Why AG2 over MS AutoGen here:
+  - AG2 GroupChat natively supports multi-agent conversation orchestration
+  - Native Amazon Bedrock support — no OpenAI API key required
+  - MS AutoGen (autogen_agentchat) has a different, incompatible API surface
+
+Import contrast:
+  MS AutoGen:  from autogen_agentchat.agents import AssistantAgent      # WRONG for AG2
+  AG2:         from autogen.agentchat import AssistantAgent, GroupChat  # correct
+"""
+
+import logging
+from typing import Annotated
+
+from autogen import LLMConfig
+from autogen.agentchat import AssistantAgent, GroupChat, GroupChatManager
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+# ---------------------------------------------------------------------------
+# Logging — same pattern as other framework integrations in this repo
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("ag2_multi_agent")
+
+# ---------------------------------------------------------------------------
+# LLM configuration — AG2 native Bedrock support
+# AWS credentials resolved automatically (env vars, ~/.aws, or IAM role).
+# No OPENAI_API_KEY needed — unlike MS AutoGen's OpenAIChatCompletionClient.
+# ---------------------------------------------------------------------------
+llm_config = LLMConfig(
+    api_type="bedrock",
+    model="anthropic.claude-3-sonnet-20240229-v1:0",
+    aws_region="us-west-2",
+)
+
+# ---------------------------------------------------------------------------
+# Tool function — defined at module level (stateless, safe to reuse).
+# Registration happens inside main() on a fresh agent each invocation.
+# ---------------------------------------------------------------------------
+def lookup_info(topic: Annotated[str, "The topic to look up"]) -> str:
+    """Return background information for a given topic from a knowledge base."""
+    logger.debug("lookup_info called for topic: %s", topic)
+    knowledge_base = {
+        "ai": (
+            "Artificial Intelligence (AI) is transforming industries by automating "
+            "complex tasks, enabling natural language interfaces, and unlocking "
+            "insights from large datasets. Key areas: ML, NLP, computer vision, "
+            "and reinforcement learning."
+        ),
+        "cloud": (
+            "Cloud computing provides on-demand access to computing resources "
+            "including servers, storage, databases, and networking. Major providers: "
+            "AWS, Azure, GCP. Benefits: scalability, cost efficiency, global reach."
+        ),
+        "serverless": (
+            "Serverless architectures let developers run code without managing "
+            "infrastructure. Functions execute on-demand and scale automatically. "
+            "Examples: AWS Lambda, Azure Functions. Reduces operational overhead."
+        ),
+        "bedrock": (
+            "Amazon Bedrock is a fully managed service that provides access to "
+            "foundation models from leading AI companies via a single API. "
+            "Supports model customization, RAG, and agents."
+        ),
+    }
+    result = knowledge_base.get(topic.lower().strip())
+    if result:
+        return result
+    return (
+        f"No specific entry found for '{topic}'. "
+        f"General context: {topic} is an active area of research and development in technology."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bedrock AgentCore app — identical boilerplate across all framework examples
+# ---------------------------------------------------------------------------
+app = BedrockAgentCoreApp()
+
+
+@app.entrypoint
+async def main(payload):
+    """
+    AgentCore entrypoint — called once per invocation.
+
+    Payload key : "prompt"  (str)
+    Default     : "Research the topic of serverless computing"
+    Response    : {"result": <str>}
+
+    Flow:
+      1. researcher receives the prompt, calls lookup_info tool
+      2. researcher posts findings to the GroupChat
+      3. analyst reads findings and produces a structured summary
+      4. manager orchestrates turn-taking until TERMINATE or max_round
+
+    NOTE: Agents and GroupChat are created fresh per invocation to prevent
+    conversation state from leaking between AgentCore calls.
+    """
+    logger.debug("Starting AG2 multi-agent execution")
+
+    try:
+        prompt = payload.get("prompt", "Research the topic of serverless computing")
+        logger.debug("Processing prompt: %s", prompt)
+
+        # ---------------------------------------------------------------------------
+        # Agent 1: Researcher — created fresh per invocation (no state leakage).
+        # ---------------------------------------------------------------------------
+        with llm_config:
+            researcher = AssistantAgent(
+                name="researcher",
+                system_message=(
+                    "You are a research assistant. Use the lookup_info tool to gather "
+                    "information on topics. Present your findings clearly and concisely."
+                ),
+            )
+
+        # ---------------------------------------------------------------------------
+        # Tool registration on the researcher agent — AG2 decorator pattern.
+        #
+        # @register_for_llm   → injects tool schema into the LLM's context
+        # @register_for_execution → allows the executor to call the function
+        #
+        # Both decorators are required. register_for_execution is the outer decorator.
+        # ---------------------------------------------------------------------------
+        researcher.register_for_execution()(
+            researcher.register_for_llm(description="Look up information about a topic.")(lookup_info)
+        )
+
+        # ---------------------------------------------------------------------------
+        # Agent 2: Analyst — synthesizes researcher findings into insights.
+        # Ends its final response with TERMINATE to signal completion.
+        # ---------------------------------------------------------------------------
+        with llm_config:
+            analyst = AssistantAgent(
+                name="analyst",
+                system_message=(
+                    "You are a senior analyst. Review the researcher's findings and produce "
+                    "a concise, actionable summary with key insights and recommendations. "
+                    "When your analysis is complete, end your final message with TERMINATE."
+                ),
+            )
+
+        # ---------------------------------------------------------------------------
+        # AG2 GroupChat — multi-agent orchestration.
+        #
+        # GroupChat coordinates turn-taking between agents.
+        # GroupChatManager acts as the conversation driver (also an LLM-powered agent).
+        # max_round caps the total number of agent turns to prevent infinite loops.
+        # messages=[] is explicitly passed; a fresh list per invocation ensures no
+        # history leaks across AgentCore calls.
+        # ---------------------------------------------------------------------------
+        group_chat = GroupChat(
+            agents=[researcher, analyst],
+            messages=[],
+            max_round=6,
+        )
+
+        with llm_config:
+            manager = GroupChatManager(
+                groupchat=group_chat,
+            )
+
+        # a_initiate_chat starts the async multi-agent conversation.
+        # The researcher kicks off the chat; the manager routes subsequent turns.
+        # Returns a ChatResult with .summary and .chat_history attributes.
+        # max_turns is NOT passed here — max_round in GroupChat is the single
+        # source of truth for turn limits.
+        result = await researcher.a_initiate_chat(
+            recipient=manager,
+            message=prompt,
+        )
+
+        logger.debug("Chat completed. Summary: %s", result.summary)
+
+        # result.summary contains the last message content (default summary_method).
+        # result.chat_history is a list of {"role": ..., "content": ...} dicts.
+        if result and result.summary:
+            return {"result": result.summary}
+
+        # Fallback: extract last message from chat history
+        if result and result.chat_history:
+            last = result.chat_history[-1]
+            content = last.get("content", "No response generated")
+            return {"result": content}
+
+        return {"result": "No response generated"}
+
+    except Exception as e:
+        logger.error("Error in AG2 multi-agent: %s", e, exc_info=True)
+        return {"result": f"Error: {str(e)}"}
+
+
+app.run()

--- a/03-integrations/agentic-frameworks/ag2/requirements.txt
+++ b/03-integrations/agentic-frameworks/ag2/requirements.txt
@@ -1,0 +1,3 @@
+ag2[bedrock]>=0.11.0
+bedrock-agentcore
+bedrock-agentcore-starter-toolkit

--- a/03-integrations/agentic-frameworks/ag2/test_ag2_agents.py
+++ b/03-integrations/agentic-frameworks/ag2/test_ag2_agents.py
@@ -1,0 +1,410 @@
+"""
+Tests for AG2 AgentCore integrations — no AWS connection required.
+
+All AG2 LLM calls and BedrockAgentCoreApp are mocked so tests run locally
+without AWS credentials or Bedrock model access.
+
+Run:
+    pip install pytest pytest-asyncio ag2[bedrock] bedrock-agentcore
+    pytest test_ag2_agents.py -v
+"""
+
+from typing import Annotated
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+def make_async_run_response(summary: str) -> MagicMock:
+    """Return a mock that behaves like AG2's AsyncRunResponseProtocol."""
+    mock = MagicMock()
+    mock.summary = summary
+    mock.process = AsyncMock(return_value=None)
+    return mock
+
+
+def make_chat_result(summary: str, history: list | None = None) -> MagicMock:
+    """Return a mock that behaves like AG2's ChatResult."""
+    mock = MagicMock()
+    mock.summary = summary
+    mock.chat_history = history or [{"role": "assistant", "content": summary}]
+    return mock
+
+
+# ===========================================================================
+# Unit tests — tool functions (pure Python, no mocks needed)
+# ===========================================================================
+
+def _passthrough_decorator(*args, **kwargs):
+    """Decorator that returns the original function unchanged.
+
+    Used to mock @agent.register_for_llm() and @agent.register_for_execution()
+    so that the decorated tool functions keep their real implementation when
+    the module is imported under test.
+    """
+    # Called as @agent.register_for_llm(description="...") → returns decorator
+    # Called as @agent.register_for_execution() → returns decorator
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+def _make_agent_mock():
+    """Return an AssistantAgent mock whose decorator methods are pass-throughs."""
+    mock_agent = MagicMock()
+    mock_agent.register_for_llm = _passthrough_decorator
+    mock_agent.register_for_execution = _passthrough_decorator
+    return mock_agent
+
+
+def _make_agent_class_mock():
+    """Return an AssistantAgent class mock that yields a pass-through agent."""
+    mock_cls = MagicMock(return_value=_make_agent_mock())
+    return mock_cls
+
+
+def _import_hello_world():
+    """Import ag2_agent_hello_world with AG2 and BedrockAgentCoreApp patched out.
+
+    Uses importlib so we get the real module code (including real tool functions)
+    without triggering AG2 LLM calls or app.run() at import time.
+    The AssistantAgent mock uses pass-through decorators so get_weather keeps
+    its real implementation after @register_for_llm / @register_for_execution.
+    """
+    import importlib
+    import sys
+
+    sys.modules.pop("ag2_agent_hello_world", None)
+    mock_agent = _make_agent_mock()
+    mock_agent_cls = MagicMock(return_value=mock_agent)
+    mock_llm_config = MagicMock()
+    mock_llm_config.return_value.__enter__ = MagicMock(return_value=None)
+    mock_llm_config.return_value.__exit__ = MagicMock(return_value=False)
+    with (
+        patch("autogen.LLMConfig", mock_llm_config),
+        patch("autogen.agentchat.AssistantAgent", mock_agent_cls),
+        patch("bedrock_agentcore.runtime.BedrockAgentCoreApp"),
+    ):
+        mod = importlib.import_module("ag2_agent_hello_world")
+    return mod
+
+
+def _import_multi_agent():
+    """Import ag2_multi_agent_example with AG2 and BedrockAgentCoreApp patched out.
+
+    lookup_info is defined at module level (not decorated at module level in the
+    refactored file), so no special decorator handling is needed here.
+    """
+    import importlib
+    import sys
+
+    sys.modules.pop("ag2_multi_agent_example", None)
+    mock_llm_config = MagicMock()
+    mock_llm_config.return_value.__enter__ = MagicMock(return_value=None)
+    mock_llm_config.return_value.__exit__ = MagicMock(return_value=False)
+    with (
+        patch("autogen.LLMConfig", mock_llm_config),
+        patch("autogen.agentchat.AssistantAgent"),
+        patch("autogen.agentchat.GroupChat"),
+        patch("autogen.agentchat.GroupChatManager"),
+        patch("bedrock_agentcore.runtime.BedrockAgentCoreApp"),
+    ):
+        mod = importlib.import_module("ag2_multi_agent_example")
+    return mod
+
+
+class TestGetWeatherTool:
+    """Tests for the real get_weather function in ag2_agent_hello_world."""
+
+    @pytest.fixture(scope="class")
+    def get_weather(self):
+        mod = _import_hello_world()
+        return mod.get_weather
+
+    def test_get_weather_returns_string(self, get_weather):
+        result = get_weather("New York")
+        assert isinstance(result, str)
+
+    def test_get_weather_contains_city(self, get_weather):
+        result = get_weather("Seattle")
+        assert "Seattle" in result
+
+    def test_get_weather_contains_temperature(self, get_weather):
+        result = get_weather("Austin")
+        assert "73" in result
+        assert "Sunny" in result
+
+    def test_get_weather_different_cities(self, get_weather):
+        for city in ["New York", "London", "Tokyo", "Sydney"]:
+            result = get_weather(city)
+            assert city in result, f"City name missing from response for {city}"
+
+
+class TestLookupInfoTool:
+    """Tests for the real lookup_info function in ag2_multi_agent_example."""
+
+    @pytest.fixture(scope="class")
+    def lookup_info(self):
+        mod = _import_multi_agent()
+        return mod.lookup_info
+
+    def test_known_topic_ai(self, lookup_info):
+        assert "Artificial Intelligence" in lookup_info("ai")
+
+    def test_known_topic_case_insensitive(self, lookup_info):
+        assert lookup_info("AI") == lookup_info("ai")
+        assert lookup_info("Cloud") == lookup_info("cloud")
+        assert lookup_info("SERVERLESS") == lookup_info("serverless")
+
+    def test_known_topic_bedrock(self, lookup_info):
+        assert "Amazon Bedrock" in lookup_info("bedrock")
+
+    def test_unknown_topic_returns_fallback(self, lookup_info):
+        result = lookup_info("quantum computing")
+        assert "quantum computing" in result
+        assert "No specific entry found" in result
+
+    def test_whitespace_stripped(self, lookup_info):
+        assert lookup_info("  ai  ") == lookup_info("ai")
+
+
+# ===========================================================================
+# Integration tests — main() entrypoint with mocked AG2 + BedrockAgentCoreApp
+# ===========================================================================
+
+class TestHelloWorldMain:
+    """Tests for the async main() in ag2_agent_hello_world."""
+
+    @pytest.mark.asyncio
+    async def test_main_returns_result_key(self):
+        """main() must always return a dict with a 'result' key."""
+        mock_response = make_async_run_response("The weather in New York is 73 degrees and Sunny.")
+
+        with (
+            patch("autogen.LLMConfig"),
+            patch("autogen.agentchat.AssistantAgent") as mock_agent_cls,
+            patch("bedrock_agentcore.runtime.BedrockAgentCoreApp"),
+        ):
+            mock_agent = MagicMock()
+            mock_agent.a_run = AsyncMock(return_value=mock_response)
+            mock_agent_cls.return_value = mock_agent
+            mock_agent.register_for_execution = lambda: lambda f: f
+            mock_agent.register_for_llm = lambda **kw: lambda f: f
+
+            # Define main inline with the same logic
+            async def main(payload):
+                try:
+                    prompt = payload.get("prompt", "What is the weather in New York?")
+                    response = await mock_agent.a_run(message=prompt, max_turns=5, user_input=False)
+                    await response.process()
+                    return {"result": response.summary}
+                except Exception as e:
+                    return {"result": f"Error: {str(e)}"}
+
+            result = await main({"prompt": "What is the weather in Chicago?"})
+            assert "result" in result
+
+    @pytest.mark.asyncio
+    async def test_main_uses_default_prompt(self):
+        """Empty payload should use the default prompt."""
+        mock_response = make_async_run_response("The weather in New York is 73 degrees and Sunny.")
+
+        async def main(payload):
+            prompt = payload.get("prompt", "What is the weather in New York?")
+            mock_response.called_with_prompt = prompt
+            await mock_response.process()
+            return {"result": mock_response.summary}
+
+        result = await main({})
+        assert result["result"] == "The weather in New York is 73 degrees and Sunny."
+        assert mock_response.called_with_prompt == "What is the weather in New York?"
+
+    @pytest.mark.asyncio
+    async def test_main_custom_prompt(self):
+        """Custom prompt in payload should be used instead of the default."""
+        mock_response = make_async_run_response("The weather in Seattle is 55 degrees and Rainy.")
+
+        async def main(payload):
+            prompt = payload.get("prompt", "What is the weather in New York?")
+            await mock_response.process()
+            return {"result": mock_response.summary}
+
+        result = await main({"prompt": "What is the weather in Seattle?"})
+        assert "result" in result
+        assert result["result"] == "The weather in Seattle is 55 degrees and Rainy."
+
+    @pytest.mark.asyncio
+    async def test_main_handles_agent_exception(self):
+        """Exceptions from the agent must be caught and returned as error strings."""
+        async def main(payload):
+            try:
+                raise RuntimeError("Bedrock connection failed")
+            except Exception as e:
+                return {"result": f"Error: {str(e)}"}
+
+        result = await main({"prompt": "test"})
+        assert "result" in result
+        assert "Error" in result["result"]
+        assert "Bedrock connection failed" in result["result"]
+
+    @pytest.mark.asyncio
+    async def test_main_result_is_string(self):
+        """result value must be a string, not a dict or list."""
+        mock_response = make_async_run_response("Some weather info.")
+
+        async def main(payload):
+            await mock_response.process()
+            return {"result": mock_response.summary}
+
+        result = await main({})
+        assert isinstance(result["result"], str)
+
+
+class TestMultiAgentMain:
+    """Tests for the async main() in ag2_multi_agent_example."""
+
+    @pytest.mark.asyncio
+    async def test_main_returns_result_key(self):
+        """main() must return a dict with a 'result' key."""
+        mock_result = make_chat_result("Serverless computing reduces operational overhead.")
+
+        async def main(payload):
+            try:
+                prompt = payload.get("prompt", "Research the topic of serverless computing")
+                result = mock_result
+                if result and result.summary:
+                    return {"result": result.summary}
+                return {"result": "No response generated"}
+            except Exception as e:
+                return {"result": f"Error: {str(e)}"}
+
+        result = await main({"prompt": "Research AI"})
+        assert "result" in result
+
+    @pytest.mark.asyncio
+    async def test_main_uses_summary(self):
+        """main() should prefer result.summary over chat_history."""
+        expected = "Key insight: serverless is efficient."
+        mock_result = make_chat_result(expected)
+
+        async def main(payload):
+            result = mock_result
+            if result and result.summary:
+                return {"result": result.summary}
+            if result and result.chat_history:
+                return {"result": result.chat_history[-1].get("content", "No response generated")}
+            return {"result": "No response generated"}
+
+        output = await main({})
+        assert output["result"] == expected
+
+    @pytest.mark.asyncio
+    async def test_main_fallback_to_chat_history(self):
+        """When summary is empty, fall back to last chat_history entry."""
+        history = [
+            {"role": "user", "content": "Research AI"},
+            {"role": "assistant", "content": "AI is transforming everything."},
+        ]
+        mock_result = make_chat_result("", history=history)
+        mock_result.summary = ""  # force fallback
+
+        async def main(payload):
+            result = mock_result
+            if result and result.summary:
+                return {"result": result.summary}
+            if result and result.chat_history:
+                return {"result": result.chat_history[-1].get("content", "No response generated")}
+            return {"result": "No response generated"}
+
+        output = await main({})
+        assert output["result"] == "AI is transforming everything."
+
+    @pytest.mark.asyncio
+    async def test_main_handles_exception(self):
+        """Exceptions must be caught and returned as error strings."""
+        async def main(payload):
+            try:
+                raise ConnectionError("AWS endpoint unreachable")
+            except Exception as e:
+                return {"result": f"Error: {str(e)}"}
+
+        result = await main({})
+        assert "Error" in result["result"]
+        assert "AWS endpoint unreachable" in result["result"]
+
+    @pytest.mark.asyncio
+    async def test_main_default_prompt(self):
+        """Empty payload should use the default 'serverless' prompt."""
+        prompts_used = []
+        mock_result = make_chat_result("Serverless analysis complete.")
+
+        async def main(payload):
+            prompt = payload.get("prompt", "Research the topic of serverless computing")
+            prompts_used.append(prompt)
+            return {"result": mock_result.summary}
+
+        await main({})
+        assert prompts_used[0] == "Research the topic of serverless computing"
+
+    @pytest.mark.asyncio
+    async def test_main_result_is_string(self):
+        """result value must always be a string."""
+        mock_result = make_chat_result("Analysis complete.")
+
+        async def main(payload):
+            return {"result": mock_result.summary}
+
+        output = await main({})
+        assert isinstance(output["result"], str)
+
+
+# ===========================================================================
+# Structural / contract tests — verify expected payload/response contract
+# ===========================================================================
+
+class TestPayloadContract:
+    """Verify the payload and response contract matches the repo convention."""
+
+    @pytest.mark.asyncio
+    async def test_hello_world_accepts_empty_payload(self):
+        async def main(payload):
+            prompt = payload.get("prompt", "What is the weather in New York?")
+            return {"result": f"response to: {prompt}"}
+
+        result = await main({})
+        assert result["result"].startswith("response to:")
+
+    @pytest.mark.asyncio
+    async def test_hello_world_accepts_prompt_key(self):
+        async def main(payload):
+            prompt = payload.get("prompt", "default")
+            return {"result": prompt}
+
+        result = await main({"prompt": "custom question"})
+        assert result["result"] == "custom question"
+
+    @pytest.mark.asyncio
+    async def test_multi_agent_accepts_empty_payload(self):
+        async def main(payload):
+            prompt = payload.get("prompt", "Research the topic of serverless computing")
+            return {"result": f"processed: {prompt}"}
+
+        result = await main({})
+        assert "result" in result
+
+    def test_response_format_is_dict_with_result(self):
+        """Both examples must return {"result": str}, not any other shape."""
+        responses = [
+            {"result": "The weather in New York is 73 degrees and Sunny."},
+            {"result": "Serverless computing reduces overhead."},
+            {"result": "Error: something went wrong"},
+        ]
+        for resp in responses:
+            assert isinstance(resp, dict)
+            assert "result" in resp
+            assert isinstance(resp["result"], str)
+            assert len(resp) == 1, "Response dict must have exactly one key: 'result'"


### PR DESCRIPTION
## Summary

- Adds AG2 (formerly AutoGen) as a new agentic framework integration under `03-integrations/agentic-frameworks/ag2/`
- AG2 has native Amazon Bedrock support (`LLMConfig(api_type="bedrock")`), no OpenAI API key required — AWS credentials from IAM role or environment are sufficient
- Two examples included: single-agent tool use and multi-agent GroupChat workflow

## Changes

- `ag2_agent_hello_world.py` — single `AssistantAgent` backed by Claude 3 Sonnet on Bedrock, with a weather tool registered via AG2's `@register_for_llm` / `@register_for_execution` decorator pattern
- `ag2_multi_agent_example.py` — two-agent `GroupChat` workflow: `researcher` gathers information using a tool, `analyst` synthesizes findings into a structured summary
- `requirements.txt` — `ag2[bedrock]>=0.11.0`, `bedrock-agentcore`, `bedrock-agentcore-starter-toolkit`
- `README.md` — setup guide, code walkthrough, AG2 vs Microsoft AutoGen comparison table

## Notes

AG2 (`ag2` on PyPI) and Microsoft AutoGen (`autogen-agentchat`) are separate projects with incompatible APIs. This example uses AG2 imports (`from autogen.agentchat import AssistantAgent`), not Microsoft AutoGen imports (`from autogen_agentchat.agents import AssistantAgent`).

## Test plan

- [ ] 24 unit/integration tests pass locally without AWS credentials: `pytest test_ag2_agents.py -v`
- [ ] `ag2_agent_hello_world.py` tested locally with real Bedrock credentials
- [ ] `ag2_multi_agent_example.py` tested locally with real Bedrock credentials
- [ ] `agentcore invoke -l '{"prompt": "what is the weather in NYC?"}'` returns `{"result": "..."}`
