### PR TITLE
docs: add migration guide from Starter Toolkit to AgentCore CLI

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -133,6 +133,7 @@ agentcore invoke
 - **Idempotent** — You can safely re-run `agentcore import` if something goes wrong. Already-imported resources are skipped.
 - **Undeployed agents** — Agents that haven't been deployed yet (no `agent_id` in YAML) are imported as config-only — no CloudFormation operations are performed for them.
 - **Memory environment variables** — If your agent code references memory IDs via environment variables, the import will display a diff-style hint showing any mismatches to address.
+- **Execution role** — The existing execution role on your runtime is preserved during import. The imported agent will continue to use its original execution role, and the CLI will not manage or modify it.
 - **Shared memory** — If multiple agents share the same memory, the import deduplicates it into a single memory resource.
 
 ## Project Structure Comparison


### PR DESCRIPTION
## Summary

- Adds `MIGRATION.md` with step-by-step instructions for migrating existing Bedrock AgentCore Starter Toolkit projects to the AgentCore CLI
- Documents the new `agentcore import` command (from [aws/agentcore-cli#620](https://github.com/aws/agentcore-cli/pull/620)) including prerequisites, usage, options, and what gets migrated
- Includes project structure comparison, troubleshooting tips, and important notes on idempotency, undeployed agents, and shared memory handling

## Test plan

- [x] Verify markdown renders correctly on GitHub
- [x] Confirm all links are valid
- [x] Cross-reference with `agentcore import` command behavior from agentcore-cli PR #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)