### PR TITLE
fix: add missing tsconfig.json for VPC resources CDK tutorial (#1245)

### DIFF
--- a/01-tutorials/01-AgentCore-runtime/03-advanced-concepts/07-connect-to-vpc-resources/tsconfig.json
+++ b/01-tutorials/01-AgentCore-runtime/03-advanced-concepts/07-connect-to-vpc-resources/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["es2022"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}


### PR DESCRIPTION
## Summary

Adds the missing `tsconfig.json` in `01-tutorials/01-AgentCore-runtime/03-advanced-concepts/07-connect-to-vpc-resources/`.

## Context

Issue #1245 reported that `tsconfig.json` is missing from this tutorial. The directory ships a TypeScript CDK project:

- `bin/app.ts`, `lib/vpc-fargate-stack.ts` (TypeScript sources)
- `cdk.json` with `"app": "npx ts-node --prefer-ts-exts bin/app.ts"`
- `package.json` with `"build": "tsc"` and devDependencies: `typescript`, `ts-node`, `aws-cdk`

Without `tsconfig.json`, `npm run build`, `cdk synth`, and `cdk deploy` all fail with TypeScript compiler errors.

## Fix

Added a standard CDK TypeScript `tsconfig.json` (the same template generated by `cdk init app --language typescript`).

## Verification

Ran locally in the tutorial directory:

```
npm install
./node_modules/.bin/tsc --noEmit    # exits 0, no errors
./node_modules/.bin/cdk synth       # produces valid CloudFormation template
```

Fixes #1245