### PR TITLE
Use SDK-native certificates parameter for Code Interpreter

### DIFF
--- a/01-tutorials/05-AgentCore-tools/02-Agent-Core-browser-tool/13-browser-chrome-policies/browser-chrome-policies.ipynb
+++ b/01-tutorials/05-AgentCore-tools/02-Agent-Core-browser-tool/13-browser-chrome-policies/browser-chrome-policies.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "**Part 1** creates a Chrome policy that locks the browser to AWS documentation, uses Playwright to demonstrate the restrictions (allowed URL succeeds, blocked URL is rejected by Chrome), and uses session recording to review the enforcement.\n",
     "\n",
-    "**Part 2** demonstrates custom root CA certificates using [badssl.com](https://badssl.com) \u2014 a public site with an intentionally untrusted certificate \u2014 to show how Code Interpreter sessions can trust non-public CAs."
+    "**Part 2** demonstrates custom root CA certificates using [badssl.com](https://badssl.com) — a public site with an intentionally untrusted certificate — to show how Code Interpreter sessions can trust non-public CAs."
    ]
   },
   {
@@ -88,7 +88,7 @@
     "ACCOUNT_ID = boto3.client('sts').get_caller_identity()['Account']\n",
     "REGION = session.region_name\n",
     "\n",
-    "# Derived names \u2014 no manual replacement needed\n",
+    "# Derived names — no manual replacement needed\n",
     "BUCKET_NAME = f\"ac-browser-policy-demo-{ACCOUNT_ID}-{REGION}\"\n",
     "AC_ROLE_NAME = \"ac-browser-policy-execution-role\"\n",
     "BROWSER_NAME = \"docs_research_browser\"\n",
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Trust policy \u2014 bedrock-agentcore.amazonaws.com is the service principal\n",
+    "# Trust policy — bedrock-agentcore.amazonaws.com is the service principal\n",
     "trust_policy = {\n",
     "    \"Version\": \"2012-10-17\",\n",
     "    \"Statement\": [{\n",
@@ -263,7 +263,7 @@
    "id": "ba7a07117329",
    "metadata": {},
    "source": [
-    "> **Important \u2014 CDP compatibility:** Do not set `DeveloperToolsAvailability` to `2` (disabled). All AgentCore Browser automation uses the Chrome DevTools Protocol (CDP) via Playwright's `connect_over_cdp`. Setting this policy to `2` disables CDP at the Chrome level, which silently breaks all automation \u2014 the WebSocket connection succeeds at the proxy layer but Chrome refuses CDP commands, causing timeouts. Use `0` (allowed) or `1` (allowed only for extensions) instead.\n"
+    "> **Important — CDP compatibility:** Do not set `DeveloperToolsAvailability` to `2` (disabled). All AgentCore Browser automation uses the Chrome DevTools Protocol (CDP) via Playwright's `connect_over_cdp`. Setting this policy to `2` disables CDP at the Chrome level, which silently breaks all automation — the WebSocket connection succeeds at the proxy layer but Chrome refuses CDP commands, causing timeouts. Use `0` (allowed) or `1` (allowed only for extensions) instead.\n"
    ]
   },
   {
@@ -309,8 +309,8 @@
     "\n",
     "Create a custom browser that enforces the Chrome policy on every session. The `enterprise_policies` parameter takes a list of policy objects, each with a `location` (S3 path to the JSON file) and a `type`:\n",
     "\n",
-    "- **`MANAGED`** \u2014 enforced at the browser level, cannot be overridden (maps to Chrome's `/etc/chromium/policies/managed/`)\n",
-    "- **`RECOMMENDED`** \u2014 applied at the session level as preferences (maps to Chrome's `/etc/chromium/policies/recommended/`)\n",
+    "- **`MANAGED`** — enforced at the browser level, cannot be overridden (maps to Chrome's `/etc/chromium/policies/managed/`)\n",
+    "- **`RECOMMENDED`** — applied at the session level as preferences (maps to Chrome's `/etc/chromium/policies/recommended/`)\n",
     "\n",
     "Session recording is enabled so you can replay the session afterward in the AgentCore console."
    ]
@@ -403,7 +403,7 @@
     "        reason = info.get(\"failureReason\", \"Unknown\")\n",
     "        print(f\"Browser creation failed: {reason}\")\n",
     "        raise SystemExit(1)\n",
-    "    print(f\"  Status: {status} \u2014 waiting...\")\n",
+    "    print(f\"  Status: {status} — waiting...\")\n",
     "    time.sleep(5)"
    ]
   },
@@ -416,12 +416,12 @@
     "\n",
     "Start a browser session and use [Playwright](https://playwright.dev/docs/intro) to navigate to two URLs:\n",
     "\n",
-    "1. **`docs.aws.amazon.com`** \u2014 allowed by the policy \u2192 page loads successfully\n",
-    "2. **`www.wikipedia.org`** \u2014 blocked by the policy \u2192 Chrome displays an error page\n",
+    "1. **`docs.aws.amazon.com`** — allowed by the policy → page loads successfully\n",
+    "2. **`www.wikipedia.org`** — blocked by the policy → Chrome displays an error page\n",
     "\n",
     "This demonstrates that the restriction happens at the browser level, independent of any agent prompt or reasoning logic.\n",
     "\n",
-    "> **Tip:** While this cell runs, you can watch the browser live in the AgentCore console. Navigate to **Built-in tools** \u2192 **docs_research_browser** \u2192 **View live session**."
+    "> **Tip:** While this cell runs, you can watch the browser live in the AgentCore console. Navigate to **Built-in tools** → **docs_research_browser** → **View live session**."
    ]
   },
   {
@@ -457,7 +457,7 @@
     "        context = browser.contexts[0]\n",
     "        page = context.pages[0] if context.pages else await context.new_page()\n",
     "\n",
-    "        # \u2500\u2500 Test 1: Navigate to ALLOWED URL \u2500\u2500\n",
+    "        # ── Test 1: Navigate to ALLOWED URL ──\n",
     "        print(\"\\n\" + \"=\" * 60)\n",
     "        print(\"TEST 1: Navigate to docs.aws.amazon.com (ALLOWED)\")\n",
     "        print(\"=\" * 60)\n",
@@ -480,7 +480,7 @@
     "        print(f\"Extracted {len(text)} chars\")\n",
     "        print(f\"First 500 chars:\\n{text[:500]}\")\n",
     "\n",
-    "        # \u2500\u2500 Test 2: Navigate to BLOCKED URL \u2500\u2500\n",
+    "        # ── Test 2: Navigate to BLOCKED URL ──\n",
     "        print(\"\\n\" + \"=\" * 60)\n",
     "        print(\"TEST 2: Navigate to www.wikipedia.org (BLOCKED)\")\n",
     "        print(\"=\" * 60)\n",
@@ -490,11 +490,11 @@
     "            blocked_title = await page.title()\n",
     "            content = await page.evaluate(\"() => document.documentElement.outerHTML\", None)\n",
     "            if \"blocked\" in content.lower() or \"ERR_BLOCKED\" in content:\n",
-    "                print(\"Result: CHROME POLICY BLOCKED THIS URL \u2705\")\n",
+    "                print(\"Result: CHROME POLICY BLOCKED THIS URL ✅\")\n",
     "            else:\n",
-    "                print(f\"Result: Page loaded (unexpected) \u2014 title: {blocked_title}\")\n",
+    "                print(f\"Result: Page loaded (unexpected) — title: {blocked_title}\")\n",
     "        except Exception as e:\n",
-    "            print(\"Result: CHROME POLICY BLOCKED THIS URL \u2705\")\n",
+    "            print(\"Result: CHROME POLICY BLOCKED THIS URL ✅\")\n",
     "\n",
     "        await browser.close()\n",
     "        return text\n",
@@ -522,9 +522,9 @@
     "5. Choose **View Recording**\n",
     "\n",
     "The replay interface shows:\n",
-    "- **Video player** \u2014 interactive playback with timeline scrubber\n",
-    "- **User actions** \u2014 timestamped navigation events, including the blocked URL attempt\n",
-    "- **Network events** \u2014 confirming only `docs.aws.amazon.com` traffic succeeded"
+    "- **Video player** — interactive playback with timeline scrubber\n",
+    "- **User actions** — timestamped navigation events, including the blocked URL attempt\n",
+    "- **Network events** — confirming only `docs.aws.amazon.com` traffic succeeded"
    ]
   },
   {
@@ -536,7 +536,7 @@
     "\n",
     "You can also use the policy-restricted browser with an AI agent framework. The cell below creates a [Strands](https://strandsagents.com/) agent that researches AgentCore documentation. The agent will succeed on `docs.aws.amazon.com` and observe that `wikipedia.org` is blocked.\n",
     "\n",
-    "This sample uses Anthropic Claude through Amazon Bedrock. AgentCore is model-agnostic \u2014 you can substitute any model provider. For model configuration, refer to [Model Providers](https://strandsagents.com/latest/user-guide/concepts/model-providers/).\n",
+    "This sample uses Anthropic Claude through Amazon Bedrock. AgentCore is model-agnostic — you can substitute any model provider. For model configuration, refer to [Model Providers](https://strandsagents.com/latest/user-guide/concepts/model-providers/).\n",
     "\n",
     "> **Note:** The `AgentCoreBrowser` tool in `strands-agents-tools` creates browser sessions on demand. If you experience connection timeouts on the first attempt, the tool will retry. The first session creation for a newly created browser may take longer."
    ]
@@ -596,7 +596,7 @@
     "\n",
     "Organizations that run internal services with private certificate authorities, or route traffic through SSL-intercepting corporate proxies, need their agents to trust those non-public certificates.\n",
     "\n",
-    "To demonstrate this capability without requiring internal infrastructure, this section uses [https://untrusted-root.badssl.com](https://untrusted-root.badssl.com) \u2014 a public website that intentionally uses a certificate signed by an untrusted root CA. Normally, HTTPS connections to this site fail with SSL certificate errors, just like connections to your internal services would fail without the correct root CA."
+    "To demonstrate this capability without requiring internal infrastructure, this section uses [https://untrusted-root.badssl.com](https://untrusted-root.badssl.com) — a public website that intentionally uses a certificate signed by an untrusted root CA. Normally, HTTPS connections to this site fail with SSL certificate errors, just like connections to your internal services would fail without the correct root CA."
    ]
   },
   {
@@ -677,7 +677,7 @@
    "id": "04d58e025d2e",
    "metadata": {},
    "source": [
-    "### Step 6: Code Interpreter WITHOUT root CA \u2014 expect SSL error\n",
+    "### Step 6: Code Interpreter WITHOUT root CA — expect SSL error\n",
     "\n",
     "Create a default Code Interpreter session and attempt to connect to `https://untrusted-root.badssl.com`. The connection will fail because the root CA is not trusted."
    ]
@@ -727,11 +727,9 @@
    "id": "43c58bb1e8f7",
    "metadata": {},
    "source": [
-    "### Step 7: Code Interpreter WITH root CA \u2014 expect HTTP 200\n",
+    "### Step 7: Code Interpreter WITH root CA — expect HTTP 200\n",
     "\n",
-    "Create a custom Code Interpreter that trusts the BadSSL root CA certificate using the `certificates` parameter.\n",
-    "\n",
-    "> **Note:** The `CodeInterpreter` SDK wrapper does not yet support the `certificates` parameter in `create_code_interpreter()`. The cell below uses the boto3 control plane client directly for creation, then switches back to the SDK for session operations. Once the SDK is updated, you can use `Certificate.from_secret_arn(secret_arn)` directly \u2014 the same pattern shown in the Browser\u2019s `create_browser()` call.\n"
+    "Create a custom Code Interpreter that trusts the BadSSL root CA certificate using the `certificates` parameter. This uses the same `Certificate.from_secret_arn(...)` pattern shown in the Browser's `create_browser()` call.\n"
    ]
   },
   {
@@ -741,32 +739,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bedrock_agentcore._utils.endpoints import get_control_plane_endpoint\n",
+    "from bedrock_agentcore.tools import Certificate\n",
     "\n",
-    "# The CodeInterpreter SDK wrapper does not yet support the certificates parameter.\n",
-    "# Use the boto3 control plane client directly for creation, then use the SDK for\n",
-    "# session operations (start, invoke, stop).\n",
-    "cp_client = boto3.client(\n",
-    "    \"bedrock-agentcore-control\",\n",
-    "    region_name=REGION,\n",
-    "    endpoint_url=get_control_plane_endpoint(REGION),\n",
-    ")\n",
+    "ci_client_with_ca = CodeInterpreter(REGION)\n",
     "\n",
-    "response = cp_client.create_code_interpreter(\n",
+    "response = ci_client_with_ca.create_code_interpreter(\n",
     "    name=\"demo_rootca_interpreter\",\n",
-    "    executionRoleArn=EXECUTION_ROLE_ARN,\n",
-    "    networkConfiguration={\"networkMode\": \"PUBLIC\"},\n",
-    "    certificates=[\n",
-    "        {\"location\": {\"secretsManager\": {\"secretArn\": secret_arn}}}\n",
-    "    ],\n",
+    "    execution_role_arn=EXECUTION_ROLE_ARN,\n",
+    "    network_configuration={\"networkMode\": \"PUBLIC\"},\n",
+    "    certificates=[Certificate.from_secret_arn(secret_arn)],\n",
     "    description=\"Code interpreter trusting BadSSL untrusted root CA\",\n",
     ")\n",
     "\n",
     "interpreter_id = response[\"codeInterpreterId\"]\n",
     "print(f\"Created interpreter: {interpreter_id}\")\n",
-    "\n",
-    "# Use the SDK client for subsequent operations\n",
-    "ci_client_with_ca = CodeInterpreter(REGION)\n",
     "\n",
     "# Wait for ready\n",
     "print(\"Waiting for interpreter to become ready...\")\n",
@@ -815,7 +801,7 @@
     "        exit_code = structured.get(\"exitCode\", -1)\n",
     "\n",
     "        if exit_code == 0 and \"200\" in stdout:\n",
-    "            print(\"Result: SUCCESS \u2014 HTTP 200\")\n",
+    "            print(\"Result: SUCCESS — HTTP 200\")\n",
     "            print(\"  The connection succeeded because the root CA is now trusted.\")\n",
     "            print(f\"  Output: {stdout[:200]}\")\n",
     "        else:\n",
@@ -839,7 +825,7 @@
     "| Internal corporate services | Your organization's root CA certificate (HR portal, Jira, Artifactory) | Reference the secret ARN in `certificates` when creating a browser or code interpreter |\n",
     "| SSL-intercepting corporate proxies | Your proxy's root CA certificate (Zscaler, Palo Alto Networks) | Reference the secret ARN in `certificates` and configure proxy settings |\n",
     "\n",
-    "You can combine root CA certificates with Chrome policies in a single `create_browser` call \u2014 see the accompanying blog post for a combined example."
+    "You can combine root CA certificates with Chrome policies in a single `create_browser` call — see the accompanying blog post for a combined example."
    ]
   },
   {


### PR DESCRIPTION
The CodeInterpreter SDK wrapper supports the certificates parameter on create_code_interpreter(). Replace the boto3 control plane workaround with Certificate.from_secret_arn(), matching the pattern used for BrowserClient.create_browser().

Updates Step 7 of the custom root CA notebook to use the SDK-native
`certificates` parameter on `CodeInterpreter.create_code_interpreter()`
instead of falling back to the boto3 control plane client.

Changes:
- Remove boto3 `bedrock-agentcore-control` client and `get_control_plane_endpoint` import
- Use `Certificate.from_secret_arn(secret_arn)` via the SDK wrapper
- Update preceding markdown note (SDK wrapper already supports `certificates`)

This makes the Code Interpreter example symmetric with the existing
Browser `create_browser(..., certificates=[...])` usage.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [ x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [x ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x ] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x ] I have performed a self-review of this change
* [x ] Changes have been tested
* [ x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
