### PR TITLE
fix: swap UV base images to public.ecr.aws Python (trixie) for patched OpenSSL

### DIFF
--- a/01-tutorials/01-AgentCore-runtime/10-managed-session-storage/Dockerfile
+++ b/01-tutorials/01-AgentCore-runtime/10-managed-session-storage/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.14-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/01-tutorials/06-AgentCore-observability/03-advanced-concepts/03-agentops/02-langfuse/Dockerfile
+++ b/01-tutorials/06-AgentCore-observability/03-advanced-concepts/03-agentops/02-langfuse/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-multi-agent-incident-response/host_adk_agent/Dockerfile
+++ b/02-use-cases/A2A-multi-agent-incident-response/host_adk_agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-multi-agent-incident-response/monitoring_strands_agent/Dockerfile
+++ b/02-use-cases/A2A-multi-agent-incident-response/monitoring_strands_agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-multi-agent-incident-response/web_search_openai_agents/Dockerfile
+++ b/02-use-cases/A2A-multi-agent-incident-response/web_search_openai_agents/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-realestate-agentcore-multiagents/propertybookingagent_strands/Dockerfile
+++ b/02-use-cases/A2A-realestate-agentcore-multiagents/propertybookingagent_strands/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-realestate-agentcore-multiagents/propertysearchagent_strands/Dockerfile
+++ b/02-use-cases/A2A-realestate-agentcore-multiagents/propertysearchagent_strands/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/A2A-realestate-agentcore-multiagents/realestate_coordinator/Dockerfile
+++ b/02-use-cases/A2A-realestate-agentcore-multiagents/realestate_coordinator/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/02-use-cases/SRE-agent/Dockerfile
+++ b/02-use-cases/SRE-agent/Dockerfile
@@ -1,5 +1,5 @@
-# Use uv's ARM64 Python base image
-FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/02-use-cases/SRE-agent/Dockerfile.x86_64
+++ b/02-use-cases/SRE-agent/Dockerfile.x86_64
@@ -1,5 +1,5 @@
-# Use uv's x86_64 Python base image
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/02-use-cases/customer-support-assistant-vpc/agent/Dockerfile
+++ b/02-use-cases/customer-support-assistant-vpc/agent/Dockerfile
@@ -1,5 +1,5 @@
-# Base image
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Environment variables
 ENV UV_SYSTEM_PYTHON=1 \

--- a/02-use-cases/customer-support-assistant-vpc/mcp_dynamodb/Dockerfile
+++ b/02-use-cases/customer-support-assistant-vpc/mcp_dynamodb/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # Configure UV for container environment

--- a/02-use-cases/video-games-sales-assistant/cdk-data-analyst-assistant-agentcore-strands/data-analyst-assistant-agentcore-strands/Dockerfile
+++ b/02-use-cases/video-games-sales-assistant/cdk-data-analyst-assistant-agentcore-strands/data-analyst-assistant-agentcore-strands/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/03-integrations/AgentOps-Langfuse/Dockerfile
+++ b/03-integrations/AgentOps-Langfuse/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/03-integrations/agentic-frameworks/claude-agent/claude-hooks/Dockerfile
+++ b/03-integrations/agentic-frameworks/claude-agent/claude-hooks/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/03-integrations/agentic-frameworks/claude-agent/claude-sdk/Dockerfile
+++ b/03-integrations/agentic-frameworks/claude-agent/claude-sdk/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/03-integrations/agentic-frameworks/claude-agent/claude-sub-agents/Dockerfile
+++ b/03-integrations/agentic-frameworks/claude-agent/claude-sub-agents/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/03-integrations/agentic-frameworks/claude-agent/claude-with-code-interpreter/Dockerfile
+++ b/03-integrations/agentic-frameworks/claude-agent/claude-with-code-interpreter/Dockerfile
@@ -1,5 +1,5 @@
-# Use uv's ARM64 Python base image
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 ENV UV_SYSTEM_PYTHON=1 \
     UV_PROJECT_ENVIRONMENT="/usr/local/" \

--- a/05-blueprints/customer-support-agent-with-agentcore/Dockerfile
+++ b/05-blueprints/customer-support-agent-with-agentcore/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/05-blueprints/end-to-end-customer-service-agent/cx-agent-backend/Dockerfile
+++ b/05-blueprints/end-to-end-customer-service-agent/cx-agent-backend/Dockerfile
@@ -1,5 +1,5 @@
-# Use ARM64 Python 3.11 base image with uv pre-installed
-FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/python:3.11-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Set working directory
 WORKDIR /app

--- a/05-blueprints/shopping-concierge-agent/concierge_agent/supervisor_agent/Dockerfile
+++ b/05-blueprints/shopping-concierge-agent/concierge_agent/supervisor_agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # Configure UV for container environment

--- a/05-blueprints/travel-concierge-agent/concierge_agent/supervisor_agent/Dockerfile
+++ b/05-blueprints/travel-concierge-agent/concierge_agent/supervisor_agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # Configure UV for container environment


### PR DESCRIPTION
## Summary

Replaces `ghcr.io/astral-sh/uv:python<ver>-bookworm-slim` with `public.ecr.aws/docker/library/python:<ver>-slim-trixie` across 22 Dockerfiles, and copies the `uv`/`uvx` binaries in via `COPY --from=ghcr.io/astral-sh/uv:latest`.

### Why
The bookworm base ships an OpenSSL build affected by a CVE. Debian 13 (trixie) ships the patched OpenSSL (verified `3.5.5, 27 Jan 2026` inside the built image).

### What's preserved
- Per-Dockerfile Python minor versions are kept as-is (3.11 / 3.12 / 3.13 / 3.14) so dependency resolution doesn't drift.
- `--platform=linux/arm64` prefixes are preserved where present (`SRE-agent/Dockerfile`, `end-to-end-customer-service-agent/cx-agent-backend/Dockerfile`) — `public.ecr.aws/docker/library/python` is multi-arch.
- `uv pip install` / `uv sync` flows continue to work because `uv` is still on `PATH` via the multi-stage `COPY`.

### Files changed
22 Dockerfiles under `01-tutorials/`, `02-use-cases/`, `03-integrations/`, and `05-blueprints/`.

## Test plan

Verified end-to-end on the riskiest Dockerfile — `03-integrations/agentic-frameworks/claude-agent/claude-sdk/Dockerfile` — because it exercises the most surface (trixie base + NodeSource apt install for nodejs + `uv pip install` + Python 3.11 — the largest OS jump from bookworm).

- [x] `docker build` succeeds
- [x] Base image is Debian 13 trixie (`PRETTY_NAME="Debian GNU/Linux 13 (trixie)"`)
- [x] OpenSSL is patched: `OpenSSL 3.5.5 27 Jan 2026`
- [x] Python version preserved: `Python 3.11.15`
- [x] `uv` / `uvx` resolve on `PATH` (`uv 0.11.11`)
- [x] `uv pip install -r requirements.txt` succeeds
- [x] NodeSource `setup_lts.x` + `apt-get install nodejs` works on trixie (node 24.15)
- [x] `npm install -g @anthropic-ai/claude-code` succeeds
- [x] Container starts and reports healthy
- [x] `GET /ping` → `{"status":"Healthy", ...}`

Remaining Dockerfiles use the same (or a strict subset of the) pattern — same `uv` env vars, same `uv pip install` flow, most without any `apt-get` layer — so they should inherit the same result.

## Notes / tradeoffs
- `ghcr.io/astral-sh/uv:latest` is unpinned. If reviewers prefer a pinned uv version (e.g. `uv:0.11.11` or another tag), happy to pin.
- `SRE-agent/Dockerfile` uses `uv sync --frozen` against `uv.lock`. The lockfile is tied to Python 3.12, which is preserved — no lockfile regeneration required.