### PR TITLE
fix: update Discord invite link to strands community

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     <a href="https://docs.aws.amazon.com/bedrock-agentcore/">Documentation</a>
     ◆ <a href="https://github.com/aws/bedrock-agentcore-sdk-python">Python SDK</a>
     ◆ <a href="https://github.com/aws/agentcore-cli">AgentCore CLI</a>
-    ◆ <a href="https://discord.gg/bedrockagentcore-preview">Discord</a>
+    ◆ <a href="https://discord.gg/strands">Discord</a>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- Replaces abandoned `discord.gg/bedrockagentcore-preview` vanity URL with `discord.gg/strands`
- The old URL was claimed by an external party (reported via V2208165288 / AWS Vulnerability Reporting Program)
- Anyone clicking the old link from this README was redirected to a server not controlled by AWS

## Test plan
- [ ] Verify the new Discord link resolves to the correct Strands community server