### PR TITLE
fix: replace account ID with placeholder in PingFederate sample's aws-targets.json

### DIFF
--- a/01-tutorials/03-AgentCore-identity/08-IDP-examples/PingFederate/agent/private-idp-ping-agent/agentcore/aws-targets.json
+++ b/01-tutorials/03-AgentCore-identity/08-IDP-examples/PingFederate/agent/private-idp-ping-agent/agentcore/aws-targets.json
@@ -1,1 +1,1 @@
-[{"name": "default", "account": "837460776723", "region": "us-east-1"}]
+[{"name": "default", "account": "123456789012", "region": "us-east-1"}]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -116,3 +116,4 @@
 - Cristiano Scandura (scandura)
 - palbiren
 - Gui Ruggiero (guiruggiero)
+- Chris Lamont-Smith (clamonts)


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

### Concise description of the PR

```
Changes to PingFederate sample's aws-targets.json, to replace account ID with placeholder.

```

### User experience

Before: aws-targets.json exposed account ID
After: Uses the placeholder 123456789012. The existing deploy script (deploy_sample.sh) overwrites this file at deploy time with the caller's actual account ID, so there is no functional impact.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [X] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [N/A] Are you uploading a dataset?
* [N/A] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [X] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
