### PR TITLE
fix: restore EntraID inbound-auth samples to deployable state

### DIFF
--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_auth_code.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_auth_code.py
@@ -33,16 +33,19 @@ Prerequisites:
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 import uuid
 import zipfile
-from io import BytesIO
 
 import boto3
 from boto3.session import Session
+from botocore.config import Config
+from botocore.exceptions import ClientError
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -74,9 +77,7 @@ def create_credential_provider() -> dict:
     tenant_id = os.environ.get("ENTRA_TENANT_ID")
 
     if not all([client_id, client_secret, tenant_id]):
-        raise ValueError(
-            "Set ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET, ENTRA_TENANT_ID environment variables."
-        )
+        raise ValueError("Set ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET, ENTRA_TENANT_ID environment variables.")
 
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 
@@ -95,7 +96,15 @@ def create_credential_provider() -> dict:
         provider_arn = resp["credentialProviderArn"]
         callback_url = resp["callbackUrl"]
         print(f"  Created credential provider: {PROVIDER_NAME}")
-    except control.exceptions.ConflictException:
+    except (control.exceptions.ConflictException, ClientError) as e:
+        # The control plane returns ValidationException("...already exists")
+        # instead of ConflictException for duplicate names; treat both as
+        # "exists, reuse it".
+        if isinstance(e, ClientError):
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = str(e).lower()
+            if not (code == "ValidationException" and "already exists" in msg):
+                raise
         resp = control.get_oauth2_credential_provider(name=PROVIDER_NAME)
         provider_arn = resp["credentialProviderArn"]
         callback_url = resp["callbackUrl"]
@@ -152,8 +161,13 @@ def create_execution_role(role_name: str) -> str:
                     "Action": [
                         "bedrock:InvokeModel",
                         "bedrock:InvokeModelWithResponseStream",
+                        "bedrock:Converse",
+                        "bedrock:ConverseStream",
                     ],
-                    "Resource": f"arn:aws:bedrock:{REGION}::foundation-model/*",
+                    "Resource": [
+                        "arn:aws:bedrock:*::foundation-model/*",
+                        f"arn:aws:bedrock:*:{ACCOUNT_ID}:inference-profile/*",
+                    ],
                 },
                 {
                     "Effect": "Allow",
@@ -195,7 +209,14 @@ def create_execution_role(role_name: str) -> str:
 
 
 def upload_agent_to_s3() -> dict:
-    """Upload strands_entraid_onenote.py to S3."""
+    """Build agent deployment zip with uv, upload to S3.
+
+    AgentCore Runtime executes containers on ARM64 (Graviton) and enforces a
+    30s container init budget. We pre-install dependencies as ARM64 wheels with
+    uv and bundle them with the agent code so the runtime can boot without
+    running pip at start. See:
+    https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-code-deploy-python.html
+    """
     s3 = boto3.client("s3", region_name=REGION)
     bucket_name = f"agentcore-entra-3lo-{ACCOUNT_ID}-{REGION}"
 
@@ -211,28 +232,62 @@ def upload_agent_to_s3() -> dict:
     except s3.exceptions.BucketAlreadyOwnedByYou:
         print(f"  Reusing S3 bucket: {bucket_name}")
 
-    # Read local agent file
-    agent_path = os.path.join(os.path.dirname(__file__), AGENT_FILE)
-    if not os.path.exists(agent_path):
-        raise FileNotFoundError(
-            f"Agent file not found: {agent_path}\n"
-            "Ensure strands_entraid_onenote.py exists in the same directory."
+    sample_dir = os.path.dirname(os.path.abspath(__file__))
+    agent_path = os.path.join(sample_dir, AGENT_FILE)
+    callback_path = os.path.join(sample_dir, "oauth2_callback_server.py")
+    requirements = os.path.join(sample_dir, "requirements.txt")
+
+    for p in (agent_path, callback_path, requirements):
+        if not os.path.exists(p):
+            raise FileNotFoundError(f"Required file not found: {p}")
+
+    build_dir = tempfile.mkdtemp(prefix="agentcore-build-")
+    pkg_dir = os.path.join(build_dir, "deployment_package")
+    zip_path = os.path.join(build_dir, "agent.zip")
+    os.makedirs(pkg_dir)
+
+    try:
+        # Bundle source files (agent + callback helper imported by agent).
+        shutil.copy(agent_path, os.path.join(pkg_dir, AGENT_FILE))
+        shutil.copy(callback_path, os.path.join(pkg_dir, "oauth2_callback_server.py"))
+
+        # Pre-install ARM64 wheels.
+        print("  Installing arm64 dependencies with uv...")
+        subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python-platform",
+                "aarch64-manylinux2014",
+                "--python-version",
+                "3.13",
+                "--target",
+                pkg_dir,
+                "--only-binary",
+                ":all:",
+                "-r",
+                requirements,
+            ],
+            check=True,
         )
 
-    with open(agent_path, "rb") as f:
-        agent_content = f.read()
+        # Zip the package directory at the archive root.
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(pkg_dir):
+                for fname in files:
+                    abs_path = os.path.join(root, fname)
+                    arc_name = os.path.relpath(abs_path, pkg_dir)
+                    zf.write(abs_path, arc_name)
 
-    zip_buffer = BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(AGENT_FILE, agent_content)
-        zf.writestr("requirements.txt", "strands-agents\nbedrock-agentcore\nrequests\n")
+        s3_key = f"agents/{AGENT_NAME}/agent.zip"
+        s3.upload_file(zip_path, bucket_name, s3_key)
+        print(f"  Uploaded to s3://{bucket_name}/{s3_key}")
 
-    zip_buffer.seek(0)
-    s3_key = f"agents/{AGENT_NAME}/agent.zip"
-    s3.put_object(Bucket=bucket_name, Key=s3_key, Body=zip_buffer.read())
-    print(f"  Uploaded to s3://{bucket_name}/{s3_key}")
+        return {"bucket": bucket_name, "key": s3_key}
 
-    return {"bucket": bucket_name, "key": s3_key}
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
 
 
 # ── Step 4: Create AgentCore Runtime ──────────────────────────────────────────
@@ -245,25 +300,16 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
     response = control.create_agent_runtime(
         agentRuntimeName=AGENT_NAME,
         agentRuntimeArtifact={
-            "containerConfiguration": {
-                "containerUri": (
-                    f"{ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/"
-                    "bedrock-agentcore/managed/runtimes/python3.13:latest"
-                ),
+            "codeConfiguration": {
+                "code": {"s3": {"bucket": s3_info["bucket"], "prefix": s3_info["key"]}},
+                "runtime": "PYTHON_3_13",
+                "entryPoint": [AGENT_FILE],
             }
         },
         roleArn=role_arn,
         networkConfiguration={"networkMode": "PUBLIC"},
         environmentVariables={
             "scopes": SCOPES,
-        },
-        codeConfiguration={
-            "code": {
-                "s3": {
-                    "uri": f"s3://{s3_info['bucket']}/{s3_info['key']}",
-                    "entryPoint": AGENT_FILE,
-                }
-            }
         },
     )
 
@@ -273,9 +319,7 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
 
     print("  Waiting for READY...")
     while True:
-        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get(
-            "status", "UNKNOWN"
-        )
+        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get("status", "UNKNOWN")
         print(f"    Status: {s}")
         if s == "READY":
             break
@@ -307,11 +351,15 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
 # ── Step 5: Invoke Agent with OAuth Callback Server ───────────────────────────
 
 
-def invoke_agent_with_oauth(endpoint_url: str):
+def invoke_agent_with_oauth(runtime_arn: str):
     """
     Start the OAuth callback server, invoke the agent.
     On first call the agent returns an authorization URL for user consent.
     After consent, re-invoke to get the OneNote access token and create the notebook.
+
+    The runtime is created without `authorizerConfiguration`, so the data plane
+    expects SigV4-signed requests. boto3's `invoke_agent_runtime` signs
+    automatically; matches the pattern in 03-m2m-3lo/invoke.py.
     """
     from oauth2_callback_server import wait_for_oauth2_server_to_be_ready
 
@@ -325,9 +373,7 @@ def invoke_agent_with_oauth(endpoint_url: str):
     )
 
     # Start oauth2 callback server
-    oauth_proc = subprocess.Popen(
-        [sys.executable, "oauth2_callback_server.py", "--region", REGION]
-    )
+    oauth_proc = subprocess.Popen([sys.executable, "oauth2_callback_server.py", "--region", REGION])
 
     try:
         ok = wait_for_oauth2_server_to_be_ready()
@@ -335,22 +381,49 @@ def invoke_agent_with_oauth(endpoint_url: str):
             print("  Failed to start OAuth2 callback server.")
             return
 
-        import requests as req
-
-        headers = {
-            "Content-Type": "application/json",
-            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
-        }
-
+        # The agent calls @requires_access_token under the hood, which polls
+        # AgentCore Identity for token completion after returning the auth
+        # URL. The polling extends the streaming response well beyond the
+        # 60s boto3 read default; bump it so the user has time to complete
+        # OAuth in a browser.
+        client = boto3.client(
+            "bedrock-agentcore",
+            region_name=REGION,
+            config=Config(read_timeout=300, connect_timeout=10),
+        )
         print("  Invoking agent (first call — will return authorization URL)...")
-        resp = req.post(
-            endpoint_url,
-            headers=headers,
-            json={"prompt": prompt, "user_id": user_id},
-            timeout=120,
+        resp = client.invoke_agent_runtime(
+            agentRuntimeArn=runtime_arn,
+            qualifier="DEFAULT",
+            runtimeSessionId=session_id,
+            runtimeUserId=user_id,
+            payload=json.dumps({"prompt": prompt, "user_id": user_id}),
         )
 
-        print(f"  Response: {resp.text[:500]}")
+        # Stream chunks to stdout as they arrive. The agent's first useful
+        # message is "Authorization URL: ...", emitted ~4s into the request.
+        # We iterate the raw stream (not the buffered .read()) and flush each
+        # decoded chunk immediately so the user can copy the URL into a
+        # browser while the agent's polling loop continues server-side.
+        print("  Streaming response (Ctrl+C to abort):", flush=True)
+        print("  ── stream begin ──", flush=True)
+        body = resp.get("response")
+        if hasattr(body, "iter_lines"):
+            iterator = body.iter_lines(chunk_size=1)
+        else:
+            iterator = body
+        for event in iterator:
+            if isinstance(event, (bytes, bytearray)):
+                text = event.decode("utf-8", errors="replace")
+            elif isinstance(event, str):
+                text = event
+            elif isinstance(event, dict) and "chunk" in event:
+                text = event["chunk"].get("bytes", b"").decode("utf-8", errors="replace")
+            else:
+                continue
+            if text.strip():
+                print(f"  {text}", flush=True)
+        print("  ── stream end ──", flush=True)
         print(
             "\n  If an authorization URL was returned, copy it into your browser, "
             "grant consent, then re-run with --test-only to continue."
@@ -410,12 +483,8 @@ def cleanup():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="AgentCore Runtime: Entra ID 3LO with OneNote"
-    )
-    parser.add_argument(
-        "--cleanup", action="store_true", help="Delete created resources"
-    )
+    parser = argparse.ArgumentParser(description="AgentCore Runtime: Entra ID 3LO with OneNote")
+    parser.add_argument("--cleanup", action="store_true", help="Delete created resources")
     parser.add_argument(
         "--test-only",
         action="store_true",
@@ -431,7 +500,7 @@ def main():
     if args.test_only:
         with open(CONFIG_FILE) as f:
             config = json.load(f)
-        invoke_agent_with_oauth(config["endpoint_url"])
+        invoke_agent_with_oauth(config["runtime_arn"])
         return
 
     print("=== AgentCore Runtime: Entra ID 3LO Auth Code Flow (OneNote) ===\n")
@@ -450,7 +519,7 @@ def main():
     config = create_runtime(role_arn, s3_info)
 
     print("\n=== Step 5: Invoking Agent (with OAuth callback server) ===")
-    invoke_agent_with_oauth(config["endpoint_url"])
+    invoke_agent_with_oauth(config["runtime_arn"])
 
     print("\n=== Summary ===")
     print(f"  Credential provider: {PROVIDER_NAME}")

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_m2m.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_m2m.py
@@ -125,9 +125,7 @@ def create_lambda(iam: object) -> str:
             AssumeRolePolicyDocument=trust,
         )
         lambda_role_arn = role_resp["Role"]["Arn"]
-        iam.put_role_policy(
-            RoleName=LAMBDA_ROLE_NAME, PolicyName="logs", PolicyDocument=policy
-        )
+        iam.put_role_policy(RoleName=LAMBDA_ROLE_NAME, PolicyName="logs", PolicyDocument=policy)
         time.sleep(10)
         print(f"  Created Lambda role: {LAMBDA_ROLE_NAME}")
     except iam.exceptions.EntityAlreadyExistsException:
@@ -151,9 +149,7 @@ def create_lambda(iam: object) -> str:
         lambda_arn = resp["FunctionArn"]
         print(f"  Created Lambda: {LAMBDA_NAME}")
     except lam.exceptions.ResourceConflictException:
-        lambda_arn = lam.get_function(FunctionName=LAMBDA_NAME)["Configuration"][
-            "FunctionArn"
-        ]
+        lambda_arn = lam.get_function(FunctionName=LAMBDA_NAME)["Configuration"]["FunctionArn"]
         print(f"  Reusing Lambda: {LAMBDA_NAME}")
 
     return lambda_arn, lambda_role_arn
@@ -190,9 +186,7 @@ def create_gateway_role(iam: object, lambda_arn: str) -> str:
     )
 
     try:
-        resp = iam.create_role(
-            RoleName=GATEWAY_ROLE_NAME, AssumeRolePolicyDocument=trust
-        )
+        resp = iam.create_role(RoleName=GATEWAY_ROLE_NAME, AssumeRolePolicyDocument=trust)
         gateway_role_arn = resp["Role"]["Arn"]
         iam.put_role_policy(
             RoleName=GATEWAY_ROLE_NAME,
@@ -217,9 +211,7 @@ def create_gateway(gateway_role_arn: str) -> dict:
     app_id_uri = os.environ.get("ENTRA_APP_ID_URI")
 
     if not tenant_id or not app_id_uri:
-        raise ValueError(
-            "Set ENTRA_TENANT_ID and ENTRA_APP_ID_URI environment variables."
-        )
+        raise ValueError("Set ENTRA_TENANT_ID and ENTRA_APP_ID_URI environment variables.")
 
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 
@@ -232,10 +224,7 @@ def create_gateway(gateway_role_arn: str) -> dict:
             authorizerConfiguration={
                 "customJWTAuthorizer": {
                     "allowedAudience": [app_id_uri],
-                    "discoveryUrl": (
-                        f"https://login.microsoftonline.com/{tenant_id}"
-                        "/.well-known/openid-configuration"
-                    ),
+                    "discoveryUrl": (f"https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration"),
                 }
             },
         )
@@ -251,6 +240,21 @@ def create_gateway(gateway_role_arn: str) -> dict:
                 gateway_url = gw["gatewayUrl"]
                 break
         print(f"  Reusing Gateway: {GATEWAY_NAME}")
+
+    # Wait for the gateway to reach READY before subsequent operations
+    # (e.g. create_gateway_target, which fails with
+    # "Cannot perform operation ... when gateway is in CREATING status").
+    print("  Waiting for Gateway to become READY...")
+    end_states = {"READY", "FAILED", "DELETE_FAILED"}
+    while True:
+        status_resp = control.get_gateway(gatewayIdentifier=gateway_id)
+        status = status_resp.get("status", "")
+        if status in end_states:
+            break
+        time.sleep(5)
+    if status != "READY":
+        raise RuntimeError(f"Gateway creation failed: {status}")
+    print(f"  Gateway READY: {gateway_id}")
 
     return {"gateway_id": gateway_id, "gateway_url": gateway_url}
 
@@ -295,9 +299,7 @@ def create_lambda_target(gateway_id: str, lambda_arn: str) -> str:
                 }
             }
         },
-        credentialProviderConfigurations=[
-            {"credentialProviderType": "GATEWAY_IAM_ROLE"}
-        ],
+        credentialProviderConfigurations=[{"credentialProviderType": "GATEWAY_IAM_ROLE"}],
     )
     target_id = resp["targetId"]
     print(f"  Created Lambda target: LambdaUsingSDK (ID: {target_id})")
@@ -315,9 +317,7 @@ def get_entra_m2m_token() -> str:
     app_id_uri = os.environ.get("ENTRA_APP_ID_URI")
 
     if not all([tenant_id, client_id, client_secret, app_id_uri]):
-        raise ValueError(
-            "Set ENTRA_TENANT_ID, ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET, ENTRA_APP_ID_URI."
-        )
+        raise ValueError("Set ENTRA_TENANT_ID, ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET, ENTRA_APP_ID_URI.")
 
     token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     data = {
@@ -331,7 +331,11 @@ def get_entra_m2m_token() -> str:
         data=data,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
-    resp.raise_for_status()
+    if not resp.ok:
+        raise RuntimeError(
+            f"Token endpoint returned {resp.status_code}:\n  {resp.text}\n"
+            "Verify ENTRA_TENANT_ID, ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET, ENTRA_APP_ID_URI."
+        )
     token = resp.json()["access_token"]
     print("  Access token acquired from Entra ID")
     return token
@@ -353,8 +357,7 @@ def invoke_with_agent(gateway_url: str, access_token: str):
         )
     )
 
-    mcp_client.start()
-    try:
+    with mcp_client:
         tools = mcp_client.list_tools_sync()
         print(f"  Available tools: {[t.tool_name for t in tools]}")
 
@@ -364,8 +367,6 @@ def invoke_with_agent(gateway_url: str, access_token: str):
 
         result2 = agent("Give me directions to Seattle.")
         print(f"\n  Agent response: {result2.message}")
-    finally:
-        mcp_client.stop()
 
 
 # ── Step 7: Cleanup ────────────────────────────────────────────────────────────
@@ -386,12 +387,22 @@ def cleanup():
 
     for target_id in config.get("target_ids", []):
         try:
-            control.delete_gateway_target(
-                gatewayIdentifier=config["gateway_id"], targetId=target_id
-            )
+            control.delete_gateway_target(gatewayIdentifier=config["gateway_id"], targetId=target_id)
             print(f"  Deleted target: {target_id} ✓")
         except Exception as e:
             print(f"  Target delete error: {e}")
+
+    # Wait for targets to disappear before deleting the gateway. Target
+    # deletion is async; the gateway DeleteGateway call rejects with
+    # ValidationException("...has targets associated with it") until the
+    # targets are fully gone.
+    if config.get("target_ids"):
+        print("  Waiting for targets to be removed...")
+        for _ in range(24):  # up to ~2 minutes
+            remaining = control.list_gateway_targets(gatewayIdentifier=config["gateway_id"]).get("items", [])
+            if not remaining:
+                break
+            time.sleep(5)
 
     try:
         control.delete_gateway(gatewayIdentifier=config["gateway_id"])
@@ -421,12 +432,8 @@ def cleanup():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="AgentCore Gateway with Entra ID M2M auth"
-    )
-    parser.add_argument(
-        "--cleanup", action="store_true", help="Delete created resources"
-    )
+    parser = argparse.ArgumentParser(description="AgentCore Gateway with Entra ID M2M auth")
+    parser.add_argument("--cleanup", action="store_true", help="Delete created resources")
     parser.add_argument(
         "--test-only",
         action="store_true",

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_id_inbound_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_id_inbound_auth.py
@@ -38,16 +38,19 @@ Entra ID Setup (one-time):
 import argparse
 import json
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 import urllib.parse
 import uuid
 import zipfile
-from io import BytesIO
 
 import boto3
 import msal
 import requests
 from boto3.session import Session
+from botocore.exceptions import ClientError
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -163,8 +166,13 @@ def create_execution_role(role_name: str) -> str:
                     "Action": [
                         "bedrock:InvokeModel",
                         "bedrock:InvokeModelWithResponseStream",
+                        "bedrock:Converse",
+                        "bedrock:ConverseStream",
                     ],
-                    "Resource": f"arn:aws:bedrock:{REGION}::foundation-model/*",
+                    "Resource": [
+                        "arn:aws:bedrock:*::foundation-model/*",
+                        f"arn:aws:bedrock:*:{ACCOUNT_ID}:inference-profile/*",
+                    ],
                 },
                 {
                     "Effect": "Allow",
@@ -197,7 +205,7 @@ def create_execution_role(role_name: str) -> str:
     except Exception:
         pass  # Policy may already exist
 
-    time.sleep(5)  # Allow role propagation
+    time.sleep(15)  # IAM cross-service propagation
     return role_arn
 
 
@@ -205,7 +213,13 @@ def create_execution_role(role_name: str) -> str:
 
 
 def upload_agent_to_s3() -> dict:
-    """Create agent zip and upload to S3."""
+    """Build agent deployment zip with uv, upload to S3.
+
+    AgentCore Runtime mounts the zip at /var/task and does NOT run pip at
+    boot. We pre-install ARM64 wheels with uv and bundle them with the agent
+    code so the runtime can boot without ModuleNotFoundError. See:
+    https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-code-deploy-python.html
+    """
     s3 = boto3.client("s3", region_name=REGION)
     bucket_name = f"agentcore-entra-inbound-{ACCOUNT_ID}-{REGION}"
 
@@ -221,21 +235,85 @@ def upload_agent_to_s3() -> dict:
     except s3.exceptions.BucketAlreadyOwnedByYou:
         print(f"  Reusing S3 bucket: {bucket_name}")
 
-    # Create zip with agent code
-    zip_buffer = BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(AGENT_FILE, AGENT_CODE)
-        zf.writestr("requirements.txt", "strands-agents\nbedrock-agentcore\n")
+    sample_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements = os.path.join(sample_dir, "requirements.txt")
+    if not os.path.exists(requirements):
+        raise FileNotFoundError(f"requirements.txt not found: {requirements}")
 
-    zip_buffer.seek(0)
-    s3_key = f"agents/{AGENT_NAME}/agent.zip"
-    s3.put_object(Bucket=bucket_name, Key=s3_key, Body=zip_buffer.read())
-    print(f"  Uploaded agent code to s3://{bucket_name}/{s3_key}")
+    build_dir = tempfile.mkdtemp(prefix="agentcore-build-")
+    pkg_dir = os.path.join(build_dir, "deployment_package")
+    zip_path = os.path.join(build_dir, "agent.zip")
+    os.makedirs(pkg_dir)
 
-    return {"bucket": bucket_name, "key": s3_key}
+    try:
+        # Write the agent entry point.
+        with open(os.path.join(pkg_dir, AGENT_FILE), "w") as f:
+            f.write(AGENT_CODE)
+
+        # Pre-install ARM64 wheels.
+        print("  Installing arm64 dependencies with uv...")
+        subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python-platform",
+                "aarch64-manylinux2014",
+                "--python-version",
+                "3.13",
+                "--target",
+                pkg_dir,
+                "--only-binary",
+                ":all:",
+                "-r",
+                requirements,
+            ],
+            check=True,
+        )
+
+        # Zip the package directory at the archive root.
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(pkg_dir):
+                for fname in files:
+                    abs_path = os.path.join(root, fname)
+                    arc_name = os.path.relpath(abs_path, pkg_dir)
+                    zf.write(abs_path, arc_name)
+
+        s3_key = f"agents/{AGENT_NAME}/agent.zip"
+        s3.upload_file(zip_path, bucket_name, s3_key)
+        print(f"  Uploaded agent code to s3://{bucket_name}/{s3_key}")
+
+        return {"bucket": bucket_name, "key": s3_key}
+
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
 
 
 # ── Step 3: Create AgentCore Runtime with Entra JWT Authorizer ────────────────
+
+
+def _create_runtime_with_retry(control, **kwargs):
+    """Retry create_agent_runtime to absorb the IAM role propagation race.
+
+    The control plane briefly returns ValidationException("Role validation
+    failed... please verify that the role exists") before the role is fully
+    propagated across services. Backoff: 4, 8, 16, 32, 64 seconds.
+    """
+    last_exc = None
+    for attempt in range(5):
+        try:
+            return control.create_agent_runtime(**kwargs)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = str(e).lower()
+            if code in ("ValidationException", "AccessDeniedException") and "role" in msg:
+                last_exc = e
+                wait = 2**attempt * 4
+                print(f"    Role not yet assumable; retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
+    raise last_exc
 
 
 def create_runtime(role_arn: str, s3_info: dict) -> dict:
@@ -250,21 +328,18 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
             "Audience:  App Registration > Expose an API > Application ID URI"
         )
 
-    discovery_url = (
-        f"https://login.microsoftonline.com/{tenant_id}"
-        "/.well-known/openid-configuration"
-    )
+    discovery_url = f"https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration"
 
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 
-    response = control.create_agent_runtime(
+    response = _create_runtime_with_retry(
+        control,
         agentRuntimeName=AGENT_NAME,
         agentRuntimeArtifact={
-            "containerConfiguration": {
-                "containerUri": (
-                    f"{ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/"
-                    f"bedrock-agentcore/managed/runtimes/python3.13:latest"
-                ),
+            "codeConfiguration": {
+                "code": {"s3": {"bucket": s3_info["bucket"], "prefix": s3_info["key"]}},
+                "runtime": "PYTHON_3_13",
+                "entryPoint": [AGENT_FILE],
             }
         },
         roleArn=role_arn,
@@ -273,14 +348,6 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
             "customJWTAuthorizer": {
                 "discoveryUrl": discovery_url,
                 "allowedAudience": [audience],
-            }
-        },
-        codeConfiguration={
-            "code": {
-                "s3": {
-                    "uri": f"s3://{s3_info['bucket']}/{s3_info['key']}",
-                    "entryPoint": AGENT_FILE,
-                }
             }
         },
     )
@@ -355,9 +422,7 @@ def get_entra_token() -> str:
     result = app.acquire_token_for_client(scopes=scopes)
 
     if "access_token" not in result:
-        raise RuntimeError(
-            f"Failed to acquire token: {result.get('error_description')}"
-        )
+        raise RuntimeError(f"Failed to acquire token: {result.get('error_description')}")
 
     print("  Entra ID token acquired successfully")
     return result["access_token"]
@@ -465,12 +530,8 @@ def cleanup():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="AgentCore Runtime with Entra ID inbound auth"
-    )
-    parser.add_argument(
-        "--cleanup", action="store_true", help="Delete created resources"
-    )
+    parser = argparse.ArgumentParser(description="AgentCore Runtime with Entra ID inbound auth")
+    parser.add_argument("--cleanup", action="store_true", help="Delete created resources")
     parser.add_argument(
         "--test-only",
         action="store_true",


### PR DESCRIPTION
**Issue number**: #1566

   ### Concise description of the PR

   Restores all three Python scripts under `01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/` to a deployable state. Verified end-to-end on 2026-05-22 against a real Entra tenant.

   ### User experience

   **Before:** all three scripts crash on a clean account — schema rejection on `create_agent_runtime`, `ModuleNotFoundError` once deployed (deps listed in `requirements.txt` but never installed in the zip), `ConflictException` mishandling, missing SigV4 on invocation, gateway-target-during-CREATING race, and
   broken cleanup.

   **After:** each script runs end-to-end without manual patches.

   ### Summary of changes

   **`entra_id_inbound_auth.py`**
   - Nest `codeConfiguration` inside `agentRuntimeArtifact`; switch to canonical `code.s3.{bucket, prefix}` shape; add required `runtime` and `entryPoint`.
   - Replace in-memory `BytesIO` build with `uv pip install -r requirements.txt --target ... --python-platform aarch64-manylinux2014 --python-version 3.13 --only-binary :all:` so deps are actually installed in the zip.
   - 15s post-role sleep + retry-with-backoff on `create_agent_runtime` for the IAM propagation race.
   - Broaden `bedrock:InvokeModel` resource to `*::foundation-model/*` (wildcard region) + `*:{ACCOUNT_ID}:inference-profile/*`. Add `bedrock:Converse` and `bedrock:ConverseStream` actions.

   **`entra_gateway_auth_code.py`**
   - Same schema fix and same uv pre-install pattern (also bundles `oauth2_callback_server.py` since the agent imports from it).
   - Catch `ValidationException("...already exists")` in addition to `ConflictException` for OAuth2 credential provider creation.
   - Replace raw `requests.post()` with boto3 `invoke_agent_runtime` (auto-signs SigV4); set `read_timeout=300` for the OAuth polling window.
   - Stream response chunks to stdout as they arrive (`flush=True`, `iter_lines`) so the agent's `Authorization URL: ...` line reaches the user's terminal — previously the script accumulated chunks into a list and printed only after the loop ended, but the loop is held open by the agent's polling, so the URL never
   appeared.
   - Same IAM broadening.

   **`entra_gateway_m2m.py`**
   - Wait for gateway `READY` (poll `get_gateway`) before `create_gateway_target` — previously raced with `Cannot perform CreateGatewayTarget when gateway is in CREATING status`.
   - Switch `MCPClient` from `start()`/`stop()` to `with mcp_client:` (the documented context-manager form; `stop()` is `__exit__` and requires exception args).
   - Print Microsoft's response body on token-fetch failure for better diagnosis.
   - Cleanup: poll `list_gateway_targets` until empty before `delete_gateway`.

   ## Checklist

   * [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
   * [ ] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
   * [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
   * [ ] Are you uploading a dataset?
   * [ ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
   * [x] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
   * [x] I have performed a self-review of this change
   * [x] Changes have been tested
   * [x] Changes are documented

   ## Acknowledgment

   By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).