### PR TITLE
fix: Migrate remaining Dockerfiles from bookworm to trixie (CVE-2026-42010)

### DIFF
--- a/01-features/04-manage-context-of-your-agent/memory/03-integrations/01-runtime-integration/Dockerfile
+++ b/01-features/04-manage-context-of-your-agent/memory/03-integrations/01-runtime-integration/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/04-manage-context-of-your-agent/memory/03-integrations/02-identity-integration/Dockerfile
+++ b/01-features/04-manage-context-of-your-agent/memory/03-integrations/02-identity-integration/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/04-manage-context-of-your-agent/memory/05-security/01-iam-scoped-access/Dockerfile
+++ b/01-features/04-manage-context-of-your-agent/memory/05-security/01-iam-scoped-access/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/04-manage-context-of-your-agent/memory/05-security/02-cognito-federated-identity/Dockerfile
+++ b/01-features/04-manage-context-of-your-agent/memory/05-security/02-cognito-federated-identity/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/03-registry/03-advanced/discovery-and-invocation-at-runtime/Dockerfile
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/03-registry/03-advanced/discovery-and-invocation-at-runtime/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/03-registry/03-advanced/publish-agentcore-tools-in-registry/Dockerfile
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/03-registry/03-advanced/publish-agentcore-tools-in-registry/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/01-features/08-agents-that-transact/02-use-cases/pay-for-content-browser-use/agent/Dockerfile
+++ b/01-features/08-agents-that-transact/02-use-cases/pay-for-content-browser-use/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.13-slim-bookworm
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
 
 WORKDIR /app
 

--- a/01-features/08-agents-that-transact/02-use-cases/pay-for-data/agent/Dockerfile
+++ b/01-features/08-agents-that-transact/02-use-cases/pay-for-data/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.13-slim-bookworm
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
 
 WORKDIR /app
 

--- a/06-workshops/07-AgentCore-evaluations/05-groundtruth-based-evalautions/Dockerfile
+++ b/06-workshops/07-AgentCore-evaluations/05-groundtruth-based-evalautions/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 # All environment variables in one layer

--- a/06-workshops/13-AgentCore-payments/02-use-cases/pay-for-content-browser-use/agent/Dockerfile
+++ b/06-workshops/13-AgentCore-payments/02-use-cases/pay-for-content-browser-use/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.13-slim-bookworm
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
 
 WORKDIR /app
 

--- a/06-workshops/13-AgentCore-payments/02-use-cases/pay-for-data/agent/Dockerfile
+++ b/06-workshops/13-AgentCore-payments/02-use-cases/pay-for-data/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.13-slim-bookworm
+FROM public.ecr.aws/docker/library/python:3.13-slim-trixie
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Migrates all 11 remaining Dockerfiles from Debian Bookworm to Debian Trixie (stable) to address CVE-2026-42010 (GnuTLS RSA-PSK authentication bypass, CVSS 9.8).

## Changes

**4 files** — simple base image swap:
- `python:3.13-slim-bookworm` → `python:3.13-slim-trixie`

**7 files** — replaced third-party base with AWS ECR image + uv binary copy:
- `ghcr.io/astral-sh/uv:python3.13-bookworm-slim` → `python:3.13-slim-trixie` + `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/`

This follows the same pattern already used by 14+ other Dockerfiles in this repo.

## Why Trixie

- Debian Trixie (13) became stable on May 16, 2026
- Includes the GnuTLS security fix (DLA-4595-1, May 22, 2026)
- Bookworm full support ends June 2026
- Aligns all samples on the same base image family

## Related

- Ticket: D448133494
- Previous fix: https://github.com/awslabs/agentcore-samples/pull/1461
- CLI fix: https://github.com/aws/agentcore-cli/pull/1397