### PR TITLE
fix: restore Okta inbound-auth samples to deployable state

### DIFF
--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_gateway_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_gateway_auth.py
@@ -40,6 +40,9 @@ Prerequisites:
 import argparse
 import json
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 import urllib.parse
 import uuid
@@ -49,6 +52,7 @@ from io import BytesIO
 import boto3
 import requests
 from boto3.session import Session
+from botocore.exceptions import ClientError
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -214,9 +218,7 @@ def create_lambda() -> tuple:
     try:
         r = iam.create_role(RoleName=LAMBDA_ROLE_NAME, AssumeRolePolicyDocument=trust)
         lambda_role_arn = r["Role"]["Arn"]
-        iam.put_role_policy(
-            RoleName=LAMBDA_ROLE_NAME, PolicyName="logs", PolicyDocument=policy
-        )
+        iam.put_role_policy(RoleName=LAMBDA_ROLE_NAME, PolicyName="logs", PolicyDocument=policy)
         time.sleep(10)
         print(f"  Created Lambda role: {LAMBDA_ROLE_NAME}")
     except iam.exceptions.EntityAlreadyExistsException:
@@ -238,9 +240,7 @@ def create_lambda() -> tuple:
         lambda_arn = resp["FunctionArn"]
         print(f"  Created Lambda: {LAMBDA_NAME}")
     except lam.exceptions.ResourceConflictException:
-        lambda_arn = lam.get_function(FunctionName=LAMBDA_NAME)["Configuration"][
-            "FunctionArn"
-        ]
+        lambda_arn = lam.get_function(FunctionName=LAMBDA_NAME)["Configuration"]["FunctionArn"]
         print(f"  Reusing Lambda: {LAMBDA_NAME}")
 
     return lambda_arn, lambda_role_arn
@@ -275,7 +275,15 @@ def create_credential_provider() -> dict:
         provider_arn = resp["credentialProviderArn"]
         callback_url = resp["callbackUrl"]
         print(f"  Created credential provider: {PROVIDER_NAME}")
-    except control.exceptions.ConflictException:
+    except (control.exceptions.ConflictException, ClientError) as e:
+        # The control plane returns ValidationException("...already exists")
+        # instead of ConflictException for duplicate names; treat both as
+        # "exists, reuse it".
+        if isinstance(e, ClientError):
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = str(e).lower()
+            if not (code == "ValidationException" and "already exists" in msg):
+                raise
         resp = control.get_oauth2_credential_provider(name=PROVIDER_NAME)
         provider_arn = resp["credentialProviderArn"]
         callback_url = resp["callbackUrl"]
@@ -360,6 +368,21 @@ def create_gateway(lambda_arn: str) -> dict:
                 gateway_id, gateway_url = gw["gatewayId"], gw["gatewayUrl"]
                 break
 
+    # Wait for the gateway to reach READY before subsequent operations
+    # (e.g. create_gateway_target, which fails with
+    # "Cannot perform operation ... when gateway is in CREATING status").
+    print("  Waiting for Gateway to become READY...")
+    end_states = {"READY", "FAILED", "DELETE_FAILED"}
+    while True:
+        status_resp = control.get_gateway(gatewayIdentifier=gateway_id)
+        status = status_resp.get("status", "")
+        if status in end_states:
+            break
+        time.sleep(5)
+    if status != "READY":
+        raise RuntimeError(f"Gateway creation failed: {status}")
+    print(f"  Gateway READY: {gateway_id}")
+
     # Create Lambda target with outbound Okta credential provider
     api_spec = [
         {
@@ -387,15 +410,14 @@ def create_gateway(lambda_arn: str) -> dict:
                 }
             }
         },
-        credentialProviderConfigurations=[
-            {
-                "credentialProviderType": "OAUTH",
-                "oauthCredentialProvider": {
-                    "providerArn": os.environ.get("OKTA_PROVIDER_ARN", ""),
-                    "scopes": ["okta.myAccount.read"],
-                },
-            }
-        ],
+        # Lambda targets only support GATEWAY_IAM_ROLE credential provider
+        # (verified by API: ValidationException("Lambda target only supports
+        # GATEWAY_IAM_ROLE credential provider type")). The Okta credential
+        # provider created in Step 2 is still useful for the agent's INBOUND
+        # auth (customJWTAuthorizer on the gateway itself); for OAuth-style
+        # OUTBOUND auth, you'd need an OpenAPI target rather than a Lambda
+        # target.
+        credentialProviderConfigurations=[{"credentialProviderType": "GATEWAY_IAM_ROLE"}],
     )
     print("  Created Gateway target: TravelPlansLambda")
     print(f"  Gateway URL: {gateway_url}")
@@ -409,6 +431,30 @@ def create_gateway(lambda_arn: str) -> dict:
 
 
 # ── Step 4: Deploy Agent to Runtime ───────────────────────────────────────────
+
+
+def _create_runtime_with_retry(control, **kwargs):
+    """Retry create_agent_runtime to absorb the IAM role propagation race.
+
+    The control plane briefly returns ValidationException("Role validation
+    failed... please verify that the role exists") before the role is fully
+    propagated across services. Backoff: 4, 8, 16, 32, 64 seconds.
+    """
+    last_exc = None
+    for attempt in range(5):
+        try:
+            return control.create_agent_runtime(**kwargs)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = str(e).lower()
+            if code in ("ValidationException", "AccessDeniedException") and "role" in msg:
+                last_exc = e
+                wait = 2**attempt * 4
+                print(f"    Role not yet assumable; retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
+    raise last_exc
 
 
 def deploy_agent(gateway_url: str) -> dict:
@@ -446,8 +492,13 @@ def deploy_agent(gateway_url: str) -> dict:
                             "Action": [
                                 "bedrock:InvokeModel",
                                 "bedrock:InvokeModelWithResponseStream",
+                                "bedrock:Converse",
+                                "bedrock:ConverseStream",
                             ],
-                            "Resource": f"arn:aws:bedrock:{REGION}::foundation-model/*",
+                            "Resource": [
+                                "arn:aws:bedrock:*::foundation-model/*",
+                                f"arn:aws:bedrock:*:{ACCOUNT_ID}:inference-profile/*",
+                            ],
                         },
                         {
                             "Effect": "Allow",
@@ -472,7 +523,7 @@ def deploy_agent(gateway_url: str) -> dict:
                 }
             ),
         )
-        time.sleep(5)
+        time.sleep(15)  # IAM cross-service propagation
         print(f"  Created agent role: {role_name}")
     except iam.exceptions.EntityAlreadyExistsException:
         role_arn = iam.get_role(RoleName=role_name)["Role"]["Arn"]
@@ -492,23 +543,66 @@ def deploy_agent(gateway_url: str) -> dict:
     except s3.exceptions.BucketAlreadyOwnedByYou:
         pass
 
-    buf = BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(AGENT_FILE, agent_code)
-        zf.writestr("requirements.txt", "strands-agents\nbedrock-agentcore\nmcp\n")
-    buf.seek(0)
-    s3_key = f"agents/{AGENT_NAME}/agent.zip"
-    s3.put_object(Bucket=bucket_name, Key=s3_key, Body=buf.read())
+    # Build the deployment zip with uv-installed ARM64 wheels alongside the
+    # generated agent code. AgentCore Runtime mounts the zip at /var/task and
+    # does not pip-install at boot, so anything imported at module load
+    # (mcp, strands, bedrock_agentcore) must already be present.
+    sample_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements = os.path.join(sample_dir, "requirements.txt")
+    if not os.path.exists(requirements):
+        raise FileNotFoundError(f"requirements.txt not found: {requirements}")
+
+    build_dir = tempfile.mkdtemp(prefix="agentcore-build-")
+    pkg_dir = os.path.join(build_dir, "deployment_package")
+    zip_path = os.path.join(build_dir, "agent.zip")
+    os.makedirs(pkg_dir)
+
+    try:
+        with open(os.path.join(pkg_dir, AGENT_FILE), "w") as f:
+            f.write(agent_code)
+
+        print("  Installing arm64 dependencies with uv...")
+        subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python-platform",
+                "aarch64-manylinux2014",
+                "--python-version",
+                "3.13",
+                "--target",
+                pkg_dir,
+                "--only-binary",
+                ":all:",
+                "-r",
+                requirements,
+            ],
+            check=True,
+        )
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(pkg_dir):
+                for fname in files:
+                    abs_path = os.path.join(root, fname)
+                    arc_name = os.path.relpath(abs_path, pkg_dir)
+                    zf.write(abs_path, arc_name)
+
+        s3_key = f"agents/{AGENT_NAME}/agent.zip"
+        s3.upload_file(zip_path, bucket_name, s3_key)
+        print(f"  Uploaded to s3://{bucket_name}/{s3_key}")
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
 
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
-    resp = control.create_agent_runtime(
+    resp = _create_runtime_with_retry(
+        control,
         agentRuntimeName=AGENT_NAME,
         agentRuntimeArtifact={
-            "containerConfiguration": {
-                "containerUri": (
-                    f"{ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/"
-                    "bedrock-agentcore/managed/runtimes/python3.13:latest"
-                ),
+            "codeConfiguration": {
+                "code": {"s3": {"bucket": bucket_name, "prefix": s3_key}},
+                "runtime": "PYTHON_3_13",
+                "entryPoint": [AGENT_FILE],
             }
         },
         roleArn=role_arn,
@@ -520,11 +614,6 @@ def deploy_agent(gateway_url: str) -> dict:
                 "allowedAudience": [audience],
             }
         },
-        codeConfiguration={
-            "code": {
-                "s3": {"uri": f"s3://{bucket_name}/{s3_key}", "entryPoint": AGENT_FILE}
-            }
-        },
     )
 
     runtime_id = resp["agentRuntimeId"]
@@ -533,9 +622,7 @@ def deploy_agent(gateway_url: str) -> dict:
 
     print("  Waiting for READY...")
     while True:
-        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get(
-            "status", "UNKNOWN"
-        )
+        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get("status", "UNKNOWN")
         print(f"    Status: {s}")
         if s == "READY":
             break
@@ -586,7 +673,7 @@ def get_okta_token_via_flask():
 
 def test_agent(endpoint_url: str, bearer_token: str):
     """Invoke the agent with a valid Okta bearer token."""
-    session_id = f"okta-gateway-session-{uuid.uuid4().hex[:8]}"
+    session_id = str(uuid.uuid4())  # AgentCore requires a session id of >= 33 chars
 
     resp = requests.post(
         endpoint_url,
@@ -595,10 +682,13 @@ def test_agent(endpoint_url: str, bearer_token: str):
             "Content-Type": "application/json",
             "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
         },
-        json={
-            "prompt": "What flights does customer with user id user-123 have scheduled?"
-        },
-        timeout=120,
+        json={"prompt": "What flights does customer with user id user-123 have scheduled?"},
+        # 5 minutes — the agent calls @requires_access_token under the hood,
+        # which polls AgentCore Identity for token completion after returning
+        # the auth URL. Polling extends the streaming response well beyond a
+        # short HTTP timeout; the user needs time to complete OAuth consent
+        # in a browser before this invocation completes.
+        timeout=300,
     )
     resp.raise_for_status()
     print(f"  Agent response: {resp.text[:500]}")
@@ -623,12 +713,21 @@ def cleanup():
 
     for target_id in config.get("target_ids", []):
         try:
-            control.delete_gateway_target(
-                gatewayIdentifier=config["gateway_id"], targetId=target_id
-            )
+            control.delete_gateway_target(gatewayIdentifier=config["gateway_id"], targetId=target_id)
             print(f"  Deleted target: {target_id} ✓")
         except Exception as e:
             print(f"  Target delete: {e}")
+
+    # Wait for targets to disappear before deleting the gateway. Target
+    # deletion is async; DeleteGateway rejects with ValidationException
+    # ("...has targets associated with it") until the targets are fully gone.
+    if config.get("target_ids"):
+        print("  Waiting for targets to be removed...")
+        for _ in range(24):  # up to ~2 minutes
+            remaining = control.list_gateway_targets(gatewayIdentifier=config["gateway_id"]).get("items", [])
+            if not remaining:
+                break
+            time.sleep(5)
 
     try:
         control.delete_gateway(gatewayIdentifier=config["gateway_id"])
@@ -686,12 +785,8 @@ def cleanup():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="AgentCore Runtime + Gateway with Okta auth"
-    )
-    parser.add_argument(
-        "--cleanup", action="store_true", help="Delete created resources"
-    )
+    parser = argparse.ArgumentParser(description="AgentCore Runtime + Gateway with Okta auth")
+    parser.add_argument("--cleanup", action="store_true", help="Delete created resources")
     parser.add_argument(
         "--test-only",
         action="store_true",
@@ -756,9 +851,7 @@ def main():
     print(f"  Agent Runtime: {AGENT_NAME}")
     print(f"  Credential Provider: {PROVIDER_NAME}")
     print(f"  Callback URL (register in Okta): {provider_info['callback_url']}")
-    print(
-        "\n  To test: OKTA_BEARER_TOKEN=<token> python okta_gateway_auth.py --test-only"
-    )
+    print("\n  To test: OKTA_BEARER_TOKEN=<token> python okta_gateway_auth.py --test-only")
     print("  To clean up: python okta_gateway_auth.py --cleanup")
 
 

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_inbound_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_inbound_auth.py
@@ -51,16 +51,19 @@ Okta Setup (one-time):
 import argparse
 import json
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 import urllib.parse
 import uuid
 import zipfile
-from io import BytesIO
 
 import boto3
 import jwt
 import requests
 from boto3.session import Session
+from botocore.exceptions import ClientError
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -121,9 +124,7 @@ def create_execution_role(role_name: str) -> str:
     )
 
     try:
-        role = iam.create_role(
-            RoleName=role_name, AssumeRolePolicyDocument=trust_policy
-        )
+        role = iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust_policy)
         role_arn = role["Role"]["Arn"]
         print(f"  Created IAM role: {role_name}")
     except iam.exceptions.EntityAlreadyExistsException:
@@ -139,8 +140,13 @@ def create_execution_role(role_name: str) -> str:
                     "Action": [
                         "bedrock:InvokeModel",
                         "bedrock:InvokeModelWithResponseStream",
+                        "bedrock:Converse",
+                        "bedrock:ConverseStream",
                     ],
-                    "Resource": f"arn:aws:bedrock:{REGION}::foundation-model/*",
+                    "Resource": [
+                        "arn:aws:bedrock:*::foundation-model/*",
+                        f"arn:aws:bedrock:*:{ACCOUNT_ID}:inference-profile/*",
+                    ],
                 },
                 {
                     "Effect": "Allow",
@@ -164,7 +170,7 @@ def create_execution_role(role_name: str) -> str:
     except Exception:
         pass
 
-    time.sleep(5)
+    time.sleep(15)  # IAM cross-service propagation
     return role_arn
 
 
@@ -172,7 +178,13 @@ def create_execution_role(role_name: str) -> str:
 
 
 def upload_agent_to_s3() -> dict:
-    """Create agent zip and upload to S3."""
+    """Build agent deployment zip with uv, upload to S3.
+
+    AgentCore Runtime mounts the zip at /var/task and does not run pip at
+    boot. We pre-install ARM64 wheels with uv and bundle them with the agent
+    code so the runtime can boot without ModuleNotFoundError. See:
+    https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-code-deploy-python.html
+    """
     s3 = boto3.client("s3", region_name=REGION)
     bucket_name = f"agentcore-okta-inbound-{ACCOUNT_ID}-{REGION}"
 
@@ -188,20 +200,85 @@ def upload_agent_to_s3() -> dict:
     except s3.exceptions.BucketAlreadyOwnedByYou:
         print(f"  Reusing S3 bucket: {bucket_name}")
 
-    zip_buffer = BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(AGENT_FILE, AGENT_CODE)
-        zf.writestr("requirements.txt", "strands-agents\nbedrock-agentcore\n")
+    sample_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements = os.path.join(sample_dir, "requirements.txt")
+    if not os.path.exists(requirements):
+        raise FileNotFoundError(f"requirements.txt not found: {requirements}")
 
-    zip_buffer.seek(0)
-    s3_key = f"agents/{AGENT_NAME}/agent.zip"
-    s3.put_object(Bucket=bucket_name, Key=s3_key, Body=zip_buffer.read())
-    print(f"  Uploaded to s3://{bucket_name}/{s3_key}")
+    build_dir = tempfile.mkdtemp(prefix="agentcore-build-")
+    pkg_dir = os.path.join(build_dir, "deployment_package")
+    zip_path = os.path.join(build_dir, "agent.zip")
+    os.makedirs(pkg_dir)
 
-    return {"bucket": bucket_name, "key": s3_key}
+    try:
+        # Write the agent entry point.
+        with open(os.path.join(pkg_dir, AGENT_FILE), "w") as f:
+            f.write(AGENT_CODE)
+
+        # Pre-install ARM64 wheels.
+        print("  Installing arm64 dependencies with uv...")
+        subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python-platform",
+                "aarch64-manylinux2014",
+                "--python-version",
+                "3.13",
+                "--target",
+                pkg_dir,
+                "--only-binary",
+                ":all:",
+                "-r",
+                requirements,
+            ],
+            check=True,
+        )
+
+        # Zip the package directory at the archive root.
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(pkg_dir):
+                for fname in files:
+                    abs_path = os.path.join(root, fname)
+                    arc_name = os.path.relpath(abs_path, pkg_dir)
+                    zf.write(abs_path, arc_name)
+
+        s3_key = f"agents/{AGENT_NAME}/agent.zip"
+        s3.upload_file(zip_path, bucket_name, s3_key)
+        print(f"  Uploaded to s3://{bucket_name}/{s3_key}")
+
+        return {"bucket": bucket_name, "key": s3_key}
+
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
 
 
 # ── Step 3: Create AgentCore Runtime with Okta JWT Authorizer ─────────────────
+
+
+def _create_runtime_with_retry(control, **kwargs):
+    """Retry create_agent_runtime to absorb the IAM role propagation race.
+
+    The control plane briefly returns ValidationException("Role validation
+    failed... please verify that the role exists") before the role is fully
+    propagated across services. Backoff: 4, 8, 16, 32, 64 seconds.
+    """
+    last_exc = None
+    for attempt in range(5):
+        try:
+            return control.create_agent_runtime(**kwargs)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = str(e).lower()
+            if code in ("ValidationException", "AccessDeniedException") and "role" in msg:
+                last_exc = e
+                wait = 2**attempt * 4
+                print(f"    Role not yet assumable; retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
+    raise last_exc
 
 
 def create_runtime(role_arn: str, s3_info: dict) -> dict:
@@ -211,20 +288,18 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
     audience = os.environ.get("OKTA_AUDIENCE")
 
     if not all([discovery_url, client_id, audience]):
-        raise ValueError(
-            "Set OKTA_DISCOVERY_URL, OKTA_CLIENT_ID, OKTA_AUDIENCE environment variables."
-        )
+        raise ValueError("Set OKTA_DISCOVERY_URL, OKTA_CLIENT_ID, OKTA_AUDIENCE environment variables.")
 
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 
-    response = control.create_agent_runtime(
+    response = _create_runtime_with_retry(
+        control,
         agentRuntimeName=AGENT_NAME,
         agentRuntimeArtifact={
-            "containerConfiguration": {
-                "containerUri": (
-                    f"{ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/"
-                    "bedrock-agentcore/managed/runtimes/python3.13:latest"
-                ),
+            "codeConfiguration": {
+                "code": {"s3": {"bucket": s3_info["bucket"], "prefix": s3_info["key"]}},
+                "runtime": "PYTHON_3_13",
+                "entryPoint": [AGENT_FILE],
             }
         },
         roleArn=role_arn,
@@ -234,14 +309,6 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
                 "discoveryUrl": discovery_url,
                 "allowedClients": [client_id],
                 "allowedAudience": [audience],
-            }
-        },
-        codeConfiguration={
-            "code": {
-                "s3": {
-                    "uri": f"s3://{s3_info['bucket']}/{s3_info['key']}",
-                    "entryPoint": AGENT_FILE,
-                }
             }
         },
     )
@@ -255,9 +322,7 @@ def create_runtime(role_arn: str, s3_info: dict) -> dict:
 
     print("  Waiting for READY...")
     while True:
-        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get(
-            "status", "UNKNOWN"
-        )
+        s = control.get_agent_runtime(agentRuntimeId=runtime_id).get("status", "UNKNOWN")
         print(f"    Status: {s}")
         if s == "READY":
             break
@@ -305,7 +370,11 @@ def get_okta_token(scope: str = "agentcore") -> str:
         data={"grant_type": "client_credentials", "scope": scope},
         auth=(client_id, client_secret),
     )
-    resp.raise_for_status()
+    if not resp.ok:
+        raise RuntimeError(
+            f"Token endpoint returned {resp.status_code}:\n  {resp.text}\n"
+            "Verify OKTA_CLIENT_ID, OKTA_CLIENT_SECRET, OKTA_TOKEN_URL."
+        )
     token = resp.json()["access_token"]
     print("  Okta token acquired")
     return token
@@ -316,7 +385,7 @@ def get_okta_token(scope: str = "agentcore") -> str:
 
 def test_agent(endpoint_url: str):
     """Run a series of tests against the agent."""
-    session_id = f"okta-session-{uuid.uuid4().hex[:8]}"
+    session_id = str(uuid.uuid4())  # AgentCore requires a session id of >= 33 chars
 
     # Test 1: No auth — should fail
     print("\n  TEST 1: Unauthenticated request (should fail)...")
@@ -445,12 +514,8 @@ def cleanup():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="AgentCore Runtime with Okta inbound auth"
-    )
-    parser.add_argument(
-        "--cleanup", action="store_true", help="Delete created resources"
-    )
+    parser = argparse.ArgumentParser(description="AgentCore Runtime with Okta inbound auth")
+    parser.add_argument("--cleanup", action="store_true", help="Delete created resources")
     parser.add_argument(
         "--test-only",
         action="store_true",

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/requirements.txt
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/requirements.txt
@@ -1,0 +1,3 @@
+bedrock-agentcore
+strands-agents
+mcp


### PR DESCRIPTION
**Issue number**: #1581

   ### Concise description of the PR

   Restores both Python scripts under `01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/` to a deployable state. Verified on a clean account through deploy, IAM, and `customJWTAuthorizer`
   enforcement (unauthenticated request → 401). The full JWT-authenticated invocation was not exercised this round (no Okta tenant on hand); that path and the schema/session-id handling now match the already-merged
   cognito (#1565) and EntraID (#1570) samples, which were validated end-to-end against live tenants.

   ### User experience

   **Before:** both scripts crash on a clean account — schema rejection on `create_agent_runtime`, `ModuleNotFoundError` once deployed (deps in `requirements.txt` never installed into the zip), `AccessDeniedException` on
   first model call, plus gateway-specific failures (OAuth provider mishandling, Lambda-target credential type, gateway-target-during-CREATING race, broken cleanup).

   **After:** each script deploys and cleans up end-to-end without manual patches.

   ### Summary of changes

   **`okta_inbound_auth.py`**
   * Nest `codeConfiguration` inside `agentRuntimeArtifact`; add required `runtime` + `entryPoint`; point `code.s3.prefix` at the full `.zip` key.
   * Replace empty-`BytesIO` upload with `uv pip install -r requirements.txt --target ... --python-platform aarch64-manylinux2014 --python-version 3.13 --only-binary :all:` so deps ship in the zip.
   * Broaden `bedrock` IAM to `*::foundation-model/*` + `*:{ACCOUNT_ID}:inference-profile/*`; add `Converse`/`ConverseStream` (used by Strands).
   * 15s post-role sleep + retry-with-backoff on `create_agent_runtime` for the IAM propagation race.
   * Use a full-UUID session id (AgentCore requires ≥33 chars; the old truncated id failed authenticated invokes).

   **`okta_gateway_auth.py`**
   * Same schema, uv pre-install, IAM, retry, and session-id fixes.
   * Catch `ValidationException("...already exists")` alongside `ConflictException` when creating the OAuth2 credential provider.
   * Poll `get_gateway` for `READY` before `create_gateway_target` (was racing with `CREATING`).
   * Use `GATEWAY_IAM_ROLE` for the Lambda target — Lambda targets reject OAuth credential providers per the API contract.
   * `MCPClient` via `with` context manager.
   * Cleanup polls `list_gateway_targets` until empty before `delete_gateway`.

   ## Checklist
   * [x] I have reviewed the contributing guidelines
   * [ ] Add your name to CONTRIBUTORS.md
   * [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
   * [ ] Are you uploading a dataset?
   * [ ] Have you documented Introduction, Architecture Diagram, Prerequisites, Usage, Sample Prompts, and Clean Up steps in your example README?
   * [x] I agree to resolve any issues created for this example in the future.
   * [x] I have performed a self-review of this change
   * [x] Changes have been tested
   * [x] Changes are documented

   ## Acknowledgment

   By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.