### PR TITLE
feat(memory): add Claude SDK, LangGraph & LlamaIndex memory tutorials

### DIFF
--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/README.md
@@ -1,0 +1,13 @@
+# Short-term memory — framework examples
+
+End-to-end agent examples that wire AgentCore **short-term memory** (raw events, `get_last_k_turns`) into real agent frameworks. The [section README](../README.md) covers the underlying primitives — events, sessions, actor/session isolation, branching; these folders show them inside working agents.
+
+| Folder | What's inside |
+|---|---|
+| [`single-agent/`](./single-agent/) | One agent per example — Claude SDK, Strands, LangGraph, LlamaIndex — using built-in/custom hooks and branching |
+| [`multi-agent/`](./multi-agent/) | Multiple agents sharing one memory resource, including branch-per-subagent parallel execution |
+
+## Where to go next
+
+- Short-term memory primitives: [`../README.md`](../README.md)
+- Long-term memory examples: [`../../02-long-term-memory/examples/`](../../02-long-term-memory/examples/)

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/README.md
@@ -1,0 +1,12 @@
+# Short-term memory — multi-agent examples
+
+Multiple specialized agents collaborating through a shared AgentCore short-term memory resource. Branching keeps each agent's conversation context isolated within one session.
+
+| Folder | What it demonstrates |
+|---|---|
+| [`with-strands-agent/`](./with-strands-agent/) | A travel-planning coordinator delegating to flight/hotel agents over a shared memory store; `multi-agent-parallel-branches/` gives each subagent its own branch for safe parallel execution |
+
+## Where to go next
+
+- Single-agent short-term examples: [`../single-agent/`](../single-agent/)
+- Short-term memory primitives (incl. branching): [`../../README.md`](../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/with-strands-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/with-strands-agent/README.md
@@ -1,0 +1,33 @@
+# Short-term memory — Strands multi-agent
+
+A travel-planning system where a coordinator agent delegates to specialized **flight** and **hotel** booking assistants, all sharing one AgentCore short-term memory resource. Each specialist has its own `actor_id` but shares the `session_id`, so conversation context is preserved across agent transitions.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Short-term conversational (multi-agent) |
+| Agent type | Travel Planning Assistant (coordinator + specialists) |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Memory components | Shared short-term memory, lifecycle hooks, `get_last_k_turns` |
+| Complexity | Beginner |
+
+## What it does
+
+- [`travel-planning-agent.py`](./travel-planning-agent.py) — specialized agents exposed as tools; a coordinator delegates flight/hotel queries while all agents read and write the shared memory store (via `MemoryClient`).
+- [`travel-planning-agent-memory-manager.py`](./travel-planning-agent-memory-manager.py) — the same system using the newer **`MemoryManager`** / **`MemorySessionManager`** APIs.
+- [`multi-agent-parallel-branches/`](./multi-agent-parallel-branches/) — branch-per-subagent for safe parallel execution.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS account with AgentCore Memory permissions (and an IAM role for memory)
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python travel-planning-agent.py
+```
+
+See the [multi-agent index](../README.md) and the [short-term memory section README](../../../README.md) for context.

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/with-strands-agent/multi-agent-parallel-branches/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/multi-agent/with-strands-agent/multi-agent-parallel-branches/README.md
@@ -1,0 +1,37 @@
+# Short-term memory — multi-agent parallel branches
+
+A travel-planning system built on a **Strands Agent Graph** where each agent runs in its own AgentCore Memory **branch**. Branching gives every agent an isolated conversation context within a single shared session — like Git branches for conversation — so agents can execute in parallel without memory conflicts.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Multi-agent with memory branching |
+| Agent type | Travel Planning Assistant (coordinator + specialists) |
+| Framework | Strands Agent Graph (parallel execution) |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Memory components | Memory branching, branch-isolated contexts, parallel execution |
+| Complexity | Intermediate |
+
+## What it does
+
+[`multi-agent-parallel-execution-with-memory-branching.py`](./multi-agent-parallel-execution-with-memory-branching.py) builds three agents, each on its own branch:
+
+1. **Travel Coordinator** (`main` branch) — orchestrates planning.
+2. **Flight Booking Assistant** (`flight_agent_memory` branch) — air travel.
+3. **Hotel Booking Assistant** (`hotel_agent_memory` branch) — accommodations.
+
+The coordinator delegates to the specialists, which execute in parallel while each keeps its own branch-scoped history. The script also shows inspecting branch-specific conversations.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS account with AgentCore Memory permissions
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python multi-agent-parallel-execution-with-memory-branching.py
+```
+
+See the [Strands multi-agent README](../README.md) for the non-branching baseline.

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/README.md
@@ -1,0 +1,15 @@
+# Short-term memory — single-agent examples
+
+One agent per example, each wiring AgentCore short-term memory into a different framework. The same pattern recurs: retrieve recent turns on startup, store each turn as it happens.
+
+| Framework | Folder | What it demonstrates |
+|---|---|---|
+| Anthropic Claude SDK (no framework) | [`with-claude-sdk/`](./with-claude-sdk/) | Explicit `messages[]` management — the clearest view of what short-term memory does |
+| Strands Agents | [`with-strands-agent/`](./with-strands-agent/) | Personal agent via lifecycle hooks; `travel-planning-branching/` forks the conversation |
+| LangGraph | [`with-langgraph-agent/`](./with-langgraph-agent/) | Built-in checkpointing, custom hooks, and human-in-the-loop |
+| LlamaIndex | [`with-llamaindex-agent/`](./with-llamaindex-agent/) | `AgentCoreMemory` context in a `FunctionAgent` across four domains |
+
+## Where to go next
+
+- Multi-agent short-term examples: [`../multi-agent/`](../multi-agent/)
+- Short-term memory primitives: [`../../README.md`](../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/README.md
@@ -1,0 +1,85 @@
+# Short-term memory — Claude SDK single-agent
+
+A conversation loop built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), wired to AgentCore **short-term memory**.
+
+Unlike the Strands, LangGraph, and LlamaIndex examples in the sibling folders, there is **no agent framework here**. The Anthropic SDK is a stateless API client — it has no built-in conversation management, hooks, or session handling. You own the `messages[]` array, and you decide exactly when to read from and write to memory. That makes this the most explicit illustration of what AgentCore short-term memory does: **persist raw conversation turns so a new process can resume the conversation.**
+
+| Information | Details |
+|---|---|
+| Tutorial type | Short-term conversational |
+| Agent type | Personal assistant |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Memory components | `create_event`, `get_last_k_turns`, `list_memories`, `delete_memory_and_wait` |
+| Complexity | Beginner |
+
+## What it does
+
+[`claude-sdk-stm-conversation.py`](./claude-sdk-stm-conversation.py):
+
+1. Creates (or reuses) a strategy-less AgentCore memory resource — short-term, raw events only.
+2. Runs a multi-turn conversation with Claude through Amazon Bedrock, maintaining the `messages[]` array by hand.
+3. Stores each completed user/assistant exchange as an event with `create_event`.
+4. **Discards the in-memory conversation and rebuilds it from AgentCore** with `get_last_k_turns`, simulating the user returning in a new process — and shows the agent still remembers the user's name and interests.
+5. Prints the stored turns, then deletes the memory resource in a `finally` block.
+
+## Architecture
+
+```
+  ┌──────────────┐   1. rehydrate history    ┌────────────────────────┐
+  │  Your code   │ ◀──── get_last_k_turns ────│  AgentCore Memory      │
+  │ (messages[]) │                            │  (short-term / events) │
+  │              │ ───── create_event ──────▶ │                        │
+  └──────┬───────┘   4. store each turn       └────────────────────────┘
+         │
+         │ 2. messages.create(messages=[...])
+         ▼
+  ┌──────────────┐
+  │ Claude via   │  3. assistant reply
+  │ Amazon       │ ─────────────────────────┐
+  │ Bedrock      │                           │
+  └──────────────┘                           ▼
+                                      (appended to messages[]
+                                       and stored back to Memory)
+```
+
+The two integration points are just functions, because the SDK gives you nowhere else to hang them:
+
+| Step | Where | How |
+|---|---|---|
+| **Retrieve** | At startup / on resume | `get_last_k_turns(...)` → translate stored turns into Anthropic `messages[]` |
+| **Converse** | Each turn | `client.messages.create(model=..., system=..., messages=messages)` |
+| **Store** | After each turn | `create_event(memory_id, actor_id, session_id, messages=[(text, "USER"), (text, "ASSISTANT")])` |
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions. The `AnthropicBedrock` client and `MemoryClient` both resolve credentials from the standard AWS chain (environment variables, `~/.aws/credentials`, or an instance/role profile).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region. Request it in the Bedrock console under *Model access*. (Model availability varies by region; `us-west-2` is a safe default.)
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-stm-conversation.py
+```
+
+Expected output: a first conversation where the user introduces themselves, then a "user returns" section — running with a fresh `messages[]` array rebuilt only from memory — where the agent correctly recalls the earlier details. The script then prints the stored turns and deletes the memory resource.
+
+## Key implementation notes
+
+- **The SDK is stateless.** Every `messages.create()` call must include the full conversation history. There is no `session_id` on the Anthropic side — continuity comes entirely from AgentCore Memory plus the `messages[]` array you maintain.
+- **Roles differ between the two APIs.** AgentCore stores roles as `USER` / `ASSISTANT` / `TOOL`; the Anthropic Messages API expects lowercase `user` / `assistant`. `load_history()` translates and skips any non-conversational roles.
+- **`global.` model prefix** selects Bedrock's global (cross-region) inference endpoint — the default for Sonnet 4.6, with no regional pricing premium. Swap to `us.anthropic.claude-sonnet-4-6` to pin traffic to US regions (10% premium, for data-residency needs).
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a turn raises. Comment out the delete block to keep the memory between runs — `get_or_create_memory` will reuse it by name.
+- **No long-term strategies here.** Short-term memory stores raw turns only. For automatic fact/summary/preference extraction across sessions, see the long-term examples.
+
+## Where to go next
+
+- Long-term memory with strategies + `retrieve_memories`: [`../../../../02-long-term-memory/`](../../../../02-long-term-memory/)
+- The short-term memory primitives (events, sessions, branching): [`../../../`](../../../)
+- Other framework integrations: [`with-strands-agent/`](../with-strands-agent/), [`with-langgraph-agent/`](../with-langgraph-agent/), [`with-llamaindex-agent/`](../with-llamaindex-agent/)

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/claude-sdk-stm-conversation.py
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/claude-sdk-stm-conversation.py
@@ -81,9 +81,8 @@ from datetime import datetime
 # Messages API against Bedrock — no Anthropic API key required.
 from anthropic import AnthropicBedrock
 
-# AgentCore Memory client and the AWS error type we handle during memory creation.
+# AgentCore Memory client.
 from bedrock_agentcore.memory import MemoryClient
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -128,38 +127,22 @@ logger.info(f"✅ Clients initialized for region: {REGION}")
 # Long-term strategies (semantic/summary/user-preference extraction) are covered in
 # the 02-long-term-memory examples.
 #
-# `create_memory_and_wait` blocks until the resource is ACTIVE (typically a few
-# seconds for a strategy-less memory). If a memory with this name already exists
-# (e.g. from a previous run), we look up and reuse its ID instead of failing.
+# `create_or_get_memory` blocks until the resource is ACTIVE (typically a few seconds
+# for a strategy-less memory) and, if a memory with this name already exists (e.g. from
+# a previous run), looks it up and reuses it instead of failing.
 
 
 def get_or_create_memory(name: str) -> str:
     """Create a strategy-less (short-term) memory, or reuse it if it already exists."""
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=[],  # No strategies => short-term (raw events) only
-            description="Short-term memory for the Claude SDK conversation tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=[],  # No strategies => short-term (raw events) only
+        description="Short-term memory for the Claude SDK conversation tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory ready: {memory_id}")
+    return memory_id
 
 
 # ## Step 4: Memory integration helpers

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/claude-sdk-stm-conversation.py
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/claude-sdk-stm-conversation.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Short-Term Memory)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to build a **conversational agent** using the
+# **Anthropic Claude SDK** (via Amazon Bedrock) with AgentCore **short-term memory**
+# (raw events). Unlike higher-level frameworks (Strands, LangGraph, LlamaIndex),
+# the Anthropic SDK is a **stateless API client** — it has NO built-in conversation
+# management. We are responsible for maintaining the `messages[]` array and for
+# wiring memory in and out of it ourselves.
+#
+# That makes this the clearest example of *what AgentCore Memory actually does for
+# you*: we manually store each turn with `create_event` and rehydrate the
+# conversation with `get_last_k_turns` so a brand-new process can resume exactly
+# where the previous one left off.
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Short Term Conversational                                                        |
+# | Agent type          | Personal Assistant                                                               |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | AgentCore Short-term Memory, manual messages[] + agentic loop                    |
+# | Example complexity  | Beginner                                                                         |
+#
+# You'll learn to:
+# - Call Claude through Amazon Bedrock using the `AnthropicBedrock` client
+# - Use short-term memory for conversation continuity
+# - Store each user/assistant turn as an event with `create_event`
+# - Rehydrate conversation history with `get_last_k_turns` to resume across processes
+# - Manage the `messages[]` array yourself (the SDK does not)
+#
+# ## Architecture
+#
+# ```
+#   ┌──────────────┐   1. rehydrate history    ┌────────────────────────┐
+#   │  Your code   │ ◀──── get_last_k_turns ────│  AgentCore Memory      │
+#   │ (messages[]) │                            │  (short-term / events) │
+#   │              │ ───── create_event ──────▶ │                        │
+#   └──────┬───────┘   4. store each turn       └────────────────────────┘
+#          │
+#          │ 2. messages.create(messages=[...])
+#          ▼
+#   ┌──────────────┐
+#   │ Claude via   │  3. assistant reply
+#   │ Amazon       │ ─────────────────────────┐
+#   │ Bedrock      │                           │
+#   └──────────────┘                           ▼
+#                                       (appended to messages[]
+#                                        and stored back to Memory)
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the
+#   Bedrock console under Model access, in your chosen region)
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+from datetime import datetime
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# AgentCore Memory client and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-stm")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+ACTOR_ID = "user_123"  # Any unique identifier for the end-user / agent
+SESSION_ID = "personal_session_001"  # Unique identifier for this conversation
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# How many turns of history to rehydrate when resuming a conversation.
+HISTORY_TURNS = 5
+
+SYSTEM_PROMPT = (
+    "You are a helpful personal assistant. Be friendly, concise, and professional. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the Memory Resource (short-term only)
+#
+# For short-term memory we create a memory resource with NO strategies. This stores
+# raw conversation turns ("events") that we read back with `get_last_k_turns`.
+# Long-term strategies (semantic/summary/user-preference extraction) are covered in
+# the 02-long-term-memory examples.
+#
+# `create_memory_and_wait` blocks until the resource is ACTIVE (typically a few
+# seconds for a strategy-less memory). If a memory with this name already exists
+# (e.g. from a previous run), we look up and reuse its ID instead of failing.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a strategy-less (short-term) memory, or reuse it if it already exists."""
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=[],  # No strategies => short-term (raw events) only
+            description="Short-term memory for the Claude SDK conversation tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 4: Memory integration helpers
+#
+# Because the Anthropic SDK is stateless, memory integration is just two functions:
+#
+# 1. `load_history()` — rehydrate the Anthropic `messages[]` array from AgentCore
+#    short-term memory at startup (the RETRIEVE step).
+# 2. `store_turn()` — persist a completed user/assistant exchange back to memory
+#    after each turn (the STORE step).
+
+
+def load_history(memory_id: str) -> list:
+    """Rehydrate the Anthropic messages[] array from AgentCore short-term memory.
+
+    `get_last_k_turns` returns the most recent k turns, oldest-first, as a
+    list-of-turns where each turn is a list of message dicts shaped like:
+        {"role": "USER" | "ASSISTANT" | "TOOL", "content": {"text": "..."}}
+    We translate those into the {"role": ..., "content": ...} dicts the
+    Anthropic Messages API expects.
+    """
+    messages: list = []
+    try:
+        recent_turns = memory_client.get_last_k_turns(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            k=HISTORY_TURNS,
+        )
+    except Exception as e:
+        # A missing/empty session is normal on the very first run — start fresh.
+        logger.warning(f"Could not load history (starting fresh): {e}")
+        return messages
+
+    for turn in recent_turns:
+        for message in turn:
+            role = message["role"].lower()  # AgentCore stores USER/ASSISTANT; API wants lowercase
+            text = message["content"]["text"]
+            # The Anthropic Messages API only accepts the "user" and "assistant"
+            # roles in messages[]; skip TOOL or any other stored role here.
+            if role in ("user", "assistant"):
+                messages.append({"role": role, "content": text})
+
+    if messages:
+        logger.info(f"✅ Rehydrated {len(messages)} message(s) from {len(recent_turns)} turn(s)")
+    else:
+        logger.info("No prior history found — starting a new conversation")
+    return messages
+
+
+def store_turn(memory_id: str, user_text: str, assistant_text: str) -> None:
+    """Persist one completed user/assistant exchange to AgentCore short-term memory.
+
+    `create_event` takes the messages as a list of (text, role) tuples. Roles must be
+    one of USER, ASSISTANT, or TOOL. We store the pair as a single event so the turn
+    is retrieved together by `get_last_k_turns`.
+    """
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            messages=[
+                (user_text, "USER"),
+                (assistant_text, "ASSISTANT"),
+            ],
+        )
+        logger.info("✅ Stored turn to short-term memory")
+    except Exception as e:
+        # Don't crash the conversation if a single write fails; log and continue.
+        logger.error(f"Memory save error: {e}")
+
+
+# ## Step 5: The conversation turn
+#
+# This is the core integration point. For each user message we:
+#   1. Append the user message to the local messages[] array.
+#   2. Call Claude via Bedrock with the full history + system prompt.
+#   3. Extract the assistant's text reply and append it to messages[].
+#   4. Persist the completed turn back to AgentCore short-term memory.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; we only want the
+    text blocks (this simple assistant defines no tools, so there are no tool_use
+    blocks to handle here).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def chat_turn(memory_id: str, messages: list, user_text: str) -> str:
+    """Run a single conversation turn end-to-end and return the assistant's reply."""
+    # 1. Append the user's message to the local conversation state.
+    messages.append({"role": "user", "content": user_text})
+
+    # 2. Call Claude with the full conversation history.
+    response = claude.messages.create(
+        model=MODEL_ID,
+        max_tokens=1024,
+        system=SYSTEM_PROMPT,
+        messages=messages,
+    )
+
+    # 3. Extract the reply and append it so the next turn has full context.
+    assistant_text = extract_text(response)
+    messages.append({"role": "assistant", "content": assistant_text})
+
+    # 4. Persist this exchange so a future process can resume the conversation.
+    store_turn(memory_id, user_text, assistant_text)
+
+    return assistant_text
+
+
+# ## Step 6: Run the demo
+#
+# We run two separate "sessions" against the SAME AgentCore session_id to prove
+# continuity: the second agent is a fresh object with an empty messages[] array, yet
+# it answers correctly because it rehydrated the first conversation from memory.
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("ClaudeSDKShortTermMemory")
+
+        # ---- First conversation -------------------------------------------------
+        # A fresh conversation: load_history() finds nothing, so messages[] starts empty.
+        print("\n=== First Conversation ===")
+        messages = load_history(memory_id)
+
+        for user_text in [
+            "My name is Alex and I'm planning a trip to Japan.",
+            "I'm especially interested in food experiences.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = chat_turn(memory_id, messages, user_text)
+            print(f"Agent: {reply}\n")
+
+        # ---- User returns: brand-new agent state --------------------------------
+        # Simulate the user coming back later in a NEW process. We deliberately throw
+        # away the in-memory `messages` list and rebuild it ONLY from AgentCore
+        # short-term memory. If continuity works, the agent still knows the user's
+        # name and interests.
+        print("=== User Returns (new process, history rehydrated from memory) ===")
+        resumed_messages = load_history(memory_id)
+
+        for user_text in [
+            "What was my name again, and where am I going?",
+            "Suggest one thing to do based on what I told you.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = chat_turn(memory_id, resumed_messages, user_text)
+            print(f"Agent: {reply}\n")
+
+        # ---- Inspect what's stored ---------------------------------------------
+        print("=== Stored Short-Term Memory (last 3 turns) ===")
+        for i, turn in enumerate(
+            memory_client.get_last_k_turns(
+                memory_id=memory_id,
+                actor_id=ACTOR_ID,
+                session_id=SESSION_ID,
+                k=3,
+            ),
+            start=1,
+        ):
+            print(f"Turn {i}:")
+            for message in turn:
+                role = message["role"]
+                text = message["content"]["text"]
+                preview = text[:100] + "..." if len(text) > 100 else text
+                print(f"  {role}: {preview}")
+            print()
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-claude-sdk/requirements.txt
@@ -1,0 +1,7 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient used for short-term memory
+# (create_event / get_last_k_turns / list_events).
+bedrock-agentcore

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-langgraph-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-langgraph-agent/README.md
@@ -1,0 +1,101 @@
+# Short-term memory — LangGraph single-agent
+
+Three LangGraph examples that use Amazon Bedrock AgentCore Memory for **short-term**
+memory — running context within a conversation, persisted and resumed across turns. The
+common thread is the **`AgentCoreMemorySaver` checkpointer** from
+[`langgraph-checkpoint-aws`](https://pypi.org/project/langgraph-checkpoint-aws/): pass it
+to the agent and LangGraph automatically saves and restores graph state per
+`(thread_id, actor_id)`, where `thread_id` maps to the AgentCore **session_id** and
+`actor_id` to the AgentCore **actor_id**.
+
+| Example | File | Pattern | Complexity |
+|---|---|---|---|
+| **Math agent with checkpointing** | [`math-agent-with-checkpointing.py`](./math-agent-with-checkpointing.py) | `AgentCoreMemorySaver` as the checkpointer for automatic state persistence; multi-turn calculations that build on prior context; session isolation across `thread_id`s. | Beginner |
+| **Personal fitness coach** | [`personal-fitness-coach.py`](./personal-fitness-coach.py) | Memory exposed as a **tool** (`list_events`) the agent calls to retrieve recent conversation history; a hand-built `StateGraph` with a chatbot node + `ToolNode`. | Beginner |
+| **Support agent (human-in-the-loop)** | [`support-agent-human-in-the-loop.py`](./support-agent-human-in-the-loop.py) | LangGraph's `interrupt` / `Command` to pause for human input and resume; state preserved across the interruption by the checkpointer. | Beginner |
+
+All three use Claude Haiku 4.5 on Amazon Bedrock and require no IAM execution role
+(short-term memory uses no long-term extraction strategy).
+
+## Architecture
+
+<div style="text-align:left">
+    <img src="images/architecture.png" width="65%" />
+</div>
+
+```
+  graph.stream/invoke ──▶ LangGraph agent ──▶ model (Bedrock, Claude Haiku 4.5)
+          │                     │
+          │ config:             │ checkpoint state per (thread_id, actor_id)
+          │  thread_id=session  ▼
+          │  actor_id=user   ┌─────────────────────────────────────────────┐
+          └─────────────────▶│  AgentCore Memory (AgentCoreMemorySaver)     │
+                             │   thread_id → session_id, actor_id → actor_id │
+                             └─────────────────────────────────────────────┘
+```
+
+## Configuration: thread_id and actor_id
+
+For the `AgentCoreMemorySaver` checkpointer, every invocation must set both identifiers in
+the runtime config — this is how state is scoped and resumed:
+
+```python
+config = {
+    "configurable": {
+        "thread_id": "session-1",     # maps to AgentCore session_id (the conversation thread)
+        "actor_id": "react-agent-1",  # maps to AgentCore actor_id (the user/agent)
+    }
+}
+```
+
+Using a new `thread_id` starts a fresh, isolated conversation; reusing one resumes exactly
+where it left off.
+
+> ### LangGraph API note
+> These examples use `create_react_agent` from `langgraph.prebuilt` (and, in the fitness
+> coach, a hand-built `StateGraph`). In **LangGraph v1.0**, `create_react_agent` is
+> **deprecated** in favor of `from langchain.agents import create_agent` with the
+> middleware system — it still runs but emits a deprecation warning. The
+> `AgentCoreMemorySaver` checkpointer, `thread_id`/`actor_id` config, and `StateGraph` APIs
+> shown here are unchanged across versions. For the current `create_agent` + middleware
+> style applied to long-term memory, see the
+> [LTM LangGraph examples](../../../../02-long-term-memory/examples/single-agent/with-langgraph-agent/).
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock
+  model-invocation permissions (resolved from the standard AWS chain).
+- **Amazon Bedrock model access for Claude Haiku 4.5** in your region (request it in the
+  Bedrock console under *Model access*; `us-west-2` is a safe default).
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python math-agent-with-checkpointing.py
+python personal-fitness-coach.py
+python support-agent-human-in-the-loop.py
+```
+
+> **Note:** `support-agent-human-in-the-loop.py` uses an `InMemorySaver` checkpointer in
+> the script body (it handles the full interrupt/resume protocol cleanly for the demo); the
+> file documents swapping in `AgentCoreMemorySaver(memory_id, region_name=region)` for
+> production. The other two use `AgentCoreMemorySaver` directly.
+
+## Cleanup
+
+Each script creates an AgentCore Memory resource (billable). The scripts end with a
+commented-out `client.delete_memory_and_wait(...)` call — uncomment it to delete the
+resource after a run, or delete it from the AgentCore console.
+
+## Where to go next
+
+- Long-term memory with LangGraph (built-in callback, custom callback, memory-as-tool):
+  [`../../../../02-long-term-memory/examples/single-agent/with-langgraph-agent/`](../../../../02-long-term-memory/examples/single-agent/with-langgraph-agent/)
+- The short-term memory concepts (events, sessions, actor isolation, branching):
+  [`../../../README.md`](../../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-strands-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-strands-agent/README.md
@@ -1,0 +1,33 @@
+# Short-term memory — Strands single-agent
+
+A personal assistant built with **Strands Agents**, wired to AgentCore short-term memory through lifecycle hooks. The agent loads recent turns on startup (`get_last_k_turns`) and stores each new message as it's added, so a conversation continues seamlessly when the user returns.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Short-term conversational |
+| Agent type | Personal Agent |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Memory components | Short-term memory, `AgentInitializedEvent` + `MessageAddedEvent` hooks, `get_last_k_turns` |
+| Complexity | Beginner |
+
+## What it does
+
+- [`personal-agent.py`](./personal-agent.py) — personal assistant with a web-search tool; an `AgentInitializedEvent` hook hydrates history and a `MessageAddedEvent` hook stores each turn via `MemoryClient`.
+- [`personal-agent-memory-manager.py`](./personal-agent-memory-manager.py) — the same agent using the newer **`MemoryManager`** / **`MemorySessionManager`** APIs instead of `MemoryClient` (useful as a migration reference).
+- [`travel-planning-branching/`](./travel-planning-branching/) — forks conversation history into branches to explore alternative paths.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python personal-agent.py
+```
+
+See the [single-agent index](../README.md) and the [short-term memory section README](../../../README.md) for context.

--- a/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-strands-agent/travel-planning-branching/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/01-short-term-memory/examples/single-agent/with-strands-agent/travel-planning-branching/README.md
@@ -1,0 +1,36 @@
+# Short-term memory — Strands branching
+
+A travel-planning assistant that uses AgentCore Memory **branching** to fork conversation history. Branches let the agent explore alternative "what-if" paths (e.g. separate flight and hotel threads) while preserving — and staying grounded in — the original main-branch conversation.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Short-term conversational with memory branching |
+| Agent type | Travel Planning Assistant |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Memory components | Short-term memory, conversation branching, branch-scoped `get_last_k_turns` |
+| Complexity | Beginner |
+
+## What it does
+
+[`travel-planning-agent-with-memory-branching.py`](./travel-planning-agent-with-memory-branching.py):
+
+1. Runs a main-branch conversation where all turns are stored.
+2. Forks a **flight** branch and a **hotel** branch from the main conversation.
+3. Each branch follows its own path while still reading the shared main-branch history.
+4. Shows switching between branches and inspecting branch-specific history.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python travel-planning-agent-with-memory-branching.py
+```
+
+See the [Strands single-agent README](../README.md) for the non-branching baseline.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/09-record-streaming/examples/cross-region-replication/scripts/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/09-record-streaming/examples/cross-region-replication/scripts/README.md
@@ -1,0 +1,19 @@
+# Cross-region replication — scripts
+
+Deployment and runtime scripts backing the [cross-region replication tutorial](../README.md). You don't run these directly — the [notebook](../06-memory-cross-region-replication.py) invokes them — but they're documented here for reference.
+
+| File | What it does |
+|---|---|
+| [`deploy.sh`](./deploy.sh) | First-time deployment: packages the Lambda, uploads to S3 in both regions, deploys the DynamoDB Global Table and per-region CloudFormation stacks, creates the primary (streaming ON) and secondary (OFF) memories, and seeds the active-region config. Usage: `bash deploy.sh <primary-region> <secondary-region>`. |
+| [`toggle-streaming.sh`](./toggle-streaming.sh) | The failover switch — enables or disables streaming on a region's memory via `update-memory`. Usage: `bash toggle-streaming.sh <enable\|disable> <region>`. |
+| [`handler.py`](./handler.py) | Lambda consumer. Reads memory-record stream events from Kinesis and replicates them to the remote region via `BatchCreateMemoryRecords`. Skips `replicated/`-prefixed namespaces (loop prevention) and non-replicable events. |
+| [`regional-stack.yaml`](./regional-stack.yaml) | Per-region CloudFormation: Kinesis stream, Lambda + event source mapping, SQS DLQ, IAM roles, CloudWatch alarms. |
+| [`global-stack.yaml`](./global-stack.yaml) | DynamoDB Global Table tracking which region is active. |
+
+## Prerequisites
+
+- AWS CLI v2 with permissions for CloudFormation, Kinesis, Lambda, IAM, SQS, DynamoDB, S3
+- Python 3.10+
+- AgentCore access in both target regions
+
+See the [cross-region replication README](../README.md) for the full architecture, RPO/RTO, and failover walkthrough.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/README.md
@@ -1,0 +1,21 @@
+# Long-term memory — framework examples
+
+End-to-end agent examples that wire AgentCore **long-term memory** (strategies + `retrieve_memories`) into real agent frameworks. The [section README](../README.md) covers the strategies, namespaces, and retrieval APIs; these folders show them inside working agents.
+
+| Folder | What's inside |
+|---|---|
+| [`single-agent/`](./single-agent/) | One agent per example — Claude SDK, Strands, LangGraph, LlamaIndex — across three integration patterns (built-in hook/callback, custom override, memory-as-tool) |
+| [`multi-agent/`](./multi-agent/) | Multiple agents sharing one long-term memory resource (travel booking, healthcare) with per-agent namespaces |
+
+## The three integration patterns
+
+Every framework folder shows the same three ways to wire long-term memory into an agent:
+
+1. **Built-in hook/callback** — the framework saves and recalls on its standard lifecycle.
+2. **Custom hook/override** — you control extraction/consolidation models or storage logic.
+3. **Memory as a tool** — the model decides when to store and recall via tool calls.
+
+## Where to go next
+
+- Long-term memory overview (strategies, namespaces, retrieval): [`../README.md`](../README.md)
+- Short-term memory examples: [`../../01-short-term-memory/examples/`](../../01-short-term-memory/examples/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/README.md
@@ -1,0 +1,15 @@
+# Long-term memory — multi-agent examples
+
+Multiple specialized agents collaborating through a single shared AgentCore long-term memory resource, each scoped to its own namespace so agents build persistent, non-colliding knowledge.
+
+| Framework | Folder | What it demonstrates |
+|---|---|---|
+| Anthropic Claude SDK (no framework) | [`with-claude-sdk/`](./with-claude-sdk/) | A research team sharing one memory resource, fully explicit |
+| Strands Agents | [`with-strands-agent/`](./with-strands-agent/) | Travel-booking (built-in hook) and healthcare (custom hook, episodic) |
+| LangGraph | [`with-langgraph-agent/`](./with-langgraph-agent/) | Shared-memory multi-agent via `create_agent` |
+| LlamaIndex | [`with-llamaindex-agent/`](./with-llamaindex-agent/) | Shared-memory multi-agent via `FunctionAgent` |
+
+## Where to go next
+
+- Single-agent long-term examples: [`../single-agent/`](../single-agent/)
+- Long-term memory overview: [`../../README.md`](../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/README.md
@@ -1,0 +1,132 @@
+# Long-term memory — Claude SDK multi-agent (shared memory)
+
+A **multi-agent research team** built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), with **no agent framework**, where several specialized agents collaborate through a **single shared AgentCore Memory resource**.
+
+The single-agent Claude SDK tutorials ([`../../single-agent/with-claude-sdk/`](../../single-agent/with-claude-sdk/)) wired memory into one agent. This one turns the same memory primitive into the **communication channel** for a team: one agent writes, the next reads what it wrote, and so on down a pipeline. Because the Anthropic SDK is a stateless API client — no shared session, no framework passing state between agents — the multi-agent mechanics are fully explicit: the only thing the agents have in common is a `memory_id`.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term, multi-agent |
+| Agent type | Research team — Researcher → Analyst → Report Writer |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategy | Semantic — **built-in** (`semanticMemoryStrategy`, no IAM execution role) |
+| Memory components | `create_memory_and_wait` (Semantic strategy), `create_event`, `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Complexity | Advanced |
+
+## What it does
+
+[`claude-sdk-multi-agent-shared-memory.py`](./claude-sdk-multi-agent-shared-memory.py):
+
+1. Creates (or reuses) **one** memory resource with a built-in **Semantic strategy** — no IAM execution role required.
+2. Runs three agents as **separate Claude conversations** (each with its own `messages[]` array and its own `actor_id`), sharing the one `memory_id`:
+   - **Research Agent** gathers findings on the topic and writes them to the **shared blackboard**.
+   - **Analyst Agent** retrieves the researcher's findings *from shared memory*, synthesizes them, and writes the synthesis back.
+   - **Report Agent** retrieves **both** the findings and the synthesis, then writes the final executive summary.
+3. Between stages, **waits for the asynchronous extraction pipeline** so the next agent can retrieve the previous agent's output (the producer/consumer handoff).
+4. Prints what lives in **shared** memory (the whole team's output) versus what lives in one agent's **private** slice.
+5. Deletes the memory resource in a `finally` block.
+
+## Architecture
+
+```
+           ┌───────────────────────────────────────────────────────────────┐
+           │           ONE shared AgentCore Memory  (single memory_id)       │
+           │                                                                 │
+           │   SHARED namespace  (actor_id = "team-shared")                  │
+           │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+           │                                                                 │
+           │   PRIVATE namespaces (actor_id = each agent)                    │
+           │     /research-team/research-agent/knowledge/                    │
+           │     /research-team/analyst-agent/knowledge/                     │
+           └───────────────────────────────────────────────────────────────┘
+                ▲ write          ▲ read+write          ▲ read
+                │ shared         │ shared              │ shared
+    ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+    │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+    │  actor: research │ │  actor: analyst  │ │  actor: report   │
+    │  own messages[]  │ │  own messages[]  │ │  own messages[]  │
+    │  Claude/Bedrock  │ │  Claude/Bedrock  │ │  Claude/Bedrock  │
+    └──────────────────┘ └──────────────────┘ └──────────────────┘
+         1. gather            2. synthesize         3. summarize
+         findings ──▶ memory  read findings ──▶     read findings +
+                              write synthesis       synthesis ──▶ report
+
+  Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+```
+
+## How memory is shared (the core idea)
+
+A memory resource is just a `memory_id` — nothing binds it to a single agent. Every agent in this script targets the **same** `memory_id`; that is what makes the memory *shared*. Three identifiers decide who-sees-what:
+
+| Identifier | Role in a multi-agent system |
+|---|---|
+| `memory_id` | The shared resource. **Same** for every agent — this is what makes memory shared. |
+| `actor_id` | **Who** is writing/reading. Each agent has its own, plus one team identity. |
+| `namespace` | **Where** records land. `{actorId}` is substituted from the event's `actor_id`. |
+
+The single namespace template `"/research-team/{actorId}/knowledge/"` produces a **shared pool** or a **private slice** depending only on which `actor_id` you write under — verified against this repo's [`../../../04-namespaces/`](../../../04-namespaces/) tutorial, where `{actorId}` is filled in from the `actorId` on `CreateEvent`:
+
+| Write with `actor_id` = | Resolves to | Meaning |
+|---|---|---|
+| `"team-shared"` | `/research-team/team-shared/knowledge/` | **Team blackboard** — every agent reads & writes it |
+| `"research-agent"` | `/research-team/research-agent/knowledge/` | Researcher's **private** slice |
+| `"analyst-agent"` | `/research-team/analyst-agent/knowledge/` | Analyst's **private** slice |
+
+**Agent B sees Agent A's work because B retrieves from the shared blackboard that A wrote to** — not because they share a conversation (they don't). That is the producer/consumer pattern with AgentCore Memory as the channel. One Semantic strategy with one namespace template covers both the shared pool and every private slice; you do **not** need a strategy per agent.
+
+### Why one strategy, one template
+
+`{actorId}` is the only lever you need. Because it is substituted at extraction time from whatever `actor_id` you pass to `create_event`, the same strategy fans every agent's writes into the right place: shared writes go to the `team-shared` actor's namespace, private writes go to each agent's own. Retrieval is by **exact resolved namespace** (the installed SDK's `retrieve_memories` does not accept wildcards), so reading "the shared blackboard" means resolving the template with `actorId="team-shared"`.
+
+## The multi-agent lifecycle
+
+| Step | Where | How |
+|---|---|---|
+| **Create** | Once, at startup | `create_memory_and_wait(name=..., strategies=[{semanticMemoryStrategy: {namespaces: ["/research-team/{actorId}/knowledge/"]}}])` |
+| **Produce** | Each agent, after it answers | `create_event(memory_id, actor_id="team-shared", session_id, messages=[(output, "USER")])` — publish to the blackboard |
+| **Wait** | Between stages | Poll `retrieve_memories` on the shared namespace until the producer's records surface (extraction is asynchronous) |
+| **Consume** | Next agent, before it answers | `retrieve_memories(memory_id, namespace="/research-team/team-shared/knowledge/", query=..., top_k=...)` and fold the results into the agent's user turn |
+| **Inspect** | End of run | Retrieve from the shared namespace vs an agent's private namespace to see shared-vs-isolated |
+
+Each agent is a **separate Claude conversation**: a fresh `messages[]` array, its own system prompt, its own `actor_id`. Nothing is carried between agents except what passes *through* memory.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions. The `AnthropicBedrock` client and `MemoryClient` both resolve credentials from the standard AWS chain (environment variables, `~/.aws/credentials`, or an instance/role profile).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region (request it in the Bedrock console under *Model access*; `us-west-2` is a safe default).
+- No IAM execution role is required — built-in strategies (Semantic included) use AgentCore-managed models for extraction and consolidation.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-multi-agent-shared-memory.py
+```
+
+Expected output: the Research Agent's findings, a wait while extraction runs, the Analyst Agent's synthesis (built from the researcher's findings it retrieved from shared memory), another wait, the Report Agent's executive summary (built from both), then a print of what lives in the shared blackboard versus one agent's private slice. The script then deletes the memory resource.
+
+> **Note on timing:** long-term extraction is asynchronous, so the script waits (up to ~2 minutes per stage) for each agent's output to surface before handing off. If records haven't surfaced in time it warns and continues with whatever is available; the downstream agent simply has less context. This is expected behavior, not an error. In production you would not block a pipeline between every stage — you would let producers run ahead and have consumers pick up work later.
+
+## Key implementation notes
+
+- **Shared `memory_id` is the whole trick.** Every agent constructs its work against the same memory resource. There is no special "multi-agent" API — collaboration is just multiple clients reading and writing one resource.
+- **`actor_id` selects shared vs private.** The same namespace template resolves to the team blackboard (`actor_id="team-shared"`) or an agent's private slice (`actor_id=<agent>`). This is the single lever for isolation vs sharing.
+- **Producer/consumer over memory, not over a conversation.** Agents never share a `messages[]` array. Agent B reads Agent A's output by retrieving it from the shared namespace — the only channel between them.
+- **Sequential handoff waits for extraction.** Because each stage consumes the previous stage's output, the script polls until the producer's records are extracted before the consumer retrieves. Single-agent tutorials only wait once; a pipeline waits between stages.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept wildcards — the template is resolved with the target `actor_id` before each call.
+- **Built-in strategy needs no IAM role.** AgentCore manages the extraction/consolidation models. To customize them, see the strategy-override examples under [`../../../02-strategy-overrides/`](../../../02-strategy-overrides/).
+- **The SDK is stateless, so context is injected via the prompt.** Retrieved records are folded into each agent's user turn — there is no server-side session on the Anthropic side.
+- **Cleanup runs in `finally`.** The shared memory resource is billable, so it's deleted even if a stage raises. Comment out the delete block to keep the memory between runs — `get_or_create_memory` will reuse it by name.
+
+## Where to go next
+
+- Namespaces, shared vs isolated record sets, and retrieval modes: [`../../../04-namespaces/`](../../../04-namespaces/)
+- The single-agent Claude SDK patterns this builds on: [`../../single-agent/with-claude-sdk/`](../../single-agent/with-claude-sdk/)
+- The same multi-agent idea in a framework: [`../with-strands-agent/`](../with-strands-agent/)
+- Short-term multi-agent (shared session, branching): [`../../../../01-short-term-memory/examples/multi-agent/`](../../../../01-short-term-memory/examples/multi-agent/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/claude-sdk-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/claude-sdk-multi-agent-shared-memory.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Multi-Agent — Shared Memory)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates a **multi-agent system** built directly on the
+# **Anthropic Claude SDK** (via Amazon Bedrock) where several specialized agents
+# collaborate through a **single shared AgentCore Memory resource**. The single-agent
+# tutorials (`../../single-agent/with-claude-sdk/`) wired memory into one agent. Here
+# the same memory primitive becomes the **communication substrate** for a team: one
+# agent writes, the next reads what it wrote, and so on down a pipeline.
+#
+# The use case is a **research team**:
+#   1. **Research Agent** gathers raw findings on a topic and writes them to memory.
+#   2. **Analyst Agent** retrieves the researcher's findings, synthesizes them into
+#      insights, and writes the synthesis back to memory.
+#   3. **Report Agent** retrieves BOTH the findings and the synthesis, then writes a
+#      final executive summary.
+#
+# Each agent is a **separate Claude conversation** (its own `messages[]` array) and has
+# its own **`actor_id`**. What ties them together is that they all use the **same
+# `memory_id`** — a memory resource is just a resource ID, and any number of clients can
+# read and write it concurrently. That is the whole multi-agent pattern: shared
+# `memory_id`, per-agent `actor_id`, and a deliberate namespace design that decides what
+# is *shared* across the team versus *private* to one agent.
+#
+# **NOTE:** We use a built-in **Semantic** strategy, so each agent's `create_event`
+# call feeds the same asynchronous extraction pipeline, and the next agent's
+# `retrieve_memories` reads the distilled records back. Built-in strategies require NO
+# IAM execution role. Extraction is asynchronous (~30-90s), so after each agent writes
+# we wait for its records to surface before the next agent retrieves them — exactly the
+# producer/consumer handoff a real sequential pipeline needs.
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term, Multi-agent                                                           |
+# | Agent type          | Research Team (Researcher → Analyst → Report Writer)                              |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | One shared memory_id, per-agent actor_id, shared vs agent-specific namespaces, create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Share ONE AgentCore Memory resource across multiple independent Claude agents
+# - Give each agent its own `actor_id` while all agents target the same `memory_id`
+# - Design namespaces so some knowledge is **team-shared** and some is **agent-private**
+# - Hand off work between agents: Agent B retrieves what Agent A stored (producer/consumer)
+# - Orchestrate a sequential pipeline where each agent builds on the previous one's output
+# - Keep each agent as a separate Claude conversation (separate `messages[]` arrays)
+#
+# ## How memory is shared (the core idea)
+#
+# A memory resource is identified by a plain `memory_id`. Nothing binds it to a single
+# agent — every agent in this script constructs its own `MemoryClient` against the SAME
+# `memory_id`. Three identifiers decide who-can-see-what:
+#
+# | Identifier    | Role in a multi-agent system                                                    |
+# |---------------|---------------------------------------------------------------------------------|
+# | `memory_id`   | The shared resource. SAME for every agent — this is what makes memory shared.   |
+# | `actor_id`    | WHO is writing/reading. We give each agent a distinct one, PLUS a team identity. |
+# | `namespace`   | WHERE records land. `{actorId}` is substituted from the event's `actor_id`.     |
+#
+# The namespace template `"/research-team/{actorId}/knowledge/"` has its `{actorId}`
+# placeholder filled in **from the `actor_id` passed to `create_event`** (verified
+# against this repo's `02-long-term-memory/04-namespaces/` tutorial). So the SAME
+# template produces a SHARED pool or a PRIVATE slice depending only on which actor_id
+# you write under:
+#
+#   • Write with actor_id="team-shared"     → "/research-team/team-shared/knowledge/"
+#       → the TEAM BLACKBOARD every agent reads from and writes to.
+#   • Write with actor_id="research-agent"  → "/research-team/research-agent/knowledge/"
+#       → that agent's PRIVATE scratchpad, isolated from the others.
+#
+# Agent B "sees" Agent A's work because B retrieves from the shared blackboard that A
+# wrote to — not because they share a conversation (they don't). This is the producer/
+# consumer pattern, with AgentCore Memory as the channel.
+#
+# ## Architecture
+#
+# ```
+#            ┌───────────────────────────────────────────────────────────────┐
+#            │           ONE shared AgentCore Memory  (single memory_id)       │
+#            │                                                                 │
+#            │   SHARED namespace  (actor_id = "team-shared")                  │
+#            │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+#            │                                                                 │
+#            │   PRIVATE namespaces (actor_id = each agent)                    │
+#            │     /research-team/research-agent/knowledge/                    │
+#            │     /research-team/analyst-agent/knowledge/                     │
+#            └───────────────────────────────────────────────────────────────┘
+#                 ▲ write          ▲ read+write          ▲ read
+#                 │ shared         │ shared              │ shared
+#     ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+#     │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+#     │  actor: research │ │  actor: analyst  │ │  actor: report   │
+#     │  own messages[]  │ │  own messages[]  │ │  own messages[]  │
+#     │  Claude/Bedrock  │ │  Claude/Bedrock  │ │  Claude/Bedrock  │
+#     └──────────────────┘ └──────────────────┘ └──────────────────┘
+#          1. gather            2. synthesize         3. summarize
+#          findings ──▶ memory  read findings ──▶     read findings +
+#                               write synthesis       synthesis ──▶ report
+#
+#   Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the
+#   Bedrock console under Model access, in your chosen region)
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
+# and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-multi-agent")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# ---- Actor identities ------------------------------------------------------------
+# Every agent shares the SAME memory_id (created in Step 5). They differ by actor_id.
+# We give each agent its own actor_id for PRIVATE scratch space, and define one extra
+# "team" actor_id whose namespace is the SHARED blackboard all agents read/write.
+RESEARCH_ACTOR_ID = "research-agent"
+ANALYST_ACTOR_ID = "analyst-agent"
+REPORT_ACTOR_ID = "report-agent"
+SHARED_ACTOR_ID = "team-shared"  # records written under this actor form the team blackboard
+
+# One session ties this pipeline run together. All three agents use the same session_id
+# so the run reads as one coherent collaboration in the event history.
+SESSION_ID = f"research-run-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+# Namespace template. `{actorId}` is substituted at extraction time from the actor_id
+# on the event (see this repo's 04-namespaces tutorial). The SAME template yields the
+# shared blackboard or a private slice depending only on which actor_id we write under.
+# Always end namespace templates with "/" so prefix matching can't collide siblings.
+NAMESPACE_TEMPLATE = "/research-team/{actorId}/knowledge/"
+
+# The shared blackboard namespace, fully resolved. This is the channel between agents.
+SHARED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=SHARED_ACTOR_ID)
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event.
+# Because this is a SEQUENTIAL handoff (each agent consumes the previous agent's
+# output), we must wait for extraction between stages. We poll but cap the wait.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# The research topic the whole team works on.
+RESEARCH_TOPIC = (
+    "The operational trade-offs of adopting vector databases for "
+    "retrieval-augmented generation (RAG) in production systems."
+)
+
+# Per-agent system prompts. Each agent is a distinct persona with a distinct job in the
+# pipeline. They never share a conversation — only the memory resource.
+RESEARCH_AGENT_PROMPT = (
+    "You are a Research Agent on a research team. Your job is to gather concrete, "
+    "factual findings on the assigned topic: specific capabilities, constraints, costs, "
+    "and trade-offs. Produce a tight set of discrete findings (bullet points), each a "
+    "self-contained, verifiable statement. Do not editorialize or conclude — just "
+    "surface the raw findings for your teammates to build on. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+ANALYST_AGENT_PROMPT = (
+    "You are an Analyst Agent on a research team. Your teammate the Research Agent has "
+    "gathered raw findings, which are provided to you from shared memory. Your job is to "
+    "SYNTHESIZE them: identify themes, tensions, and the decision factors that matter "
+    "most. Produce a short synthesis (3-5 insights), each grounded in the findings you "
+    "were given. Do not invent facts beyond the provided findings. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+REPORT_AGENT_PROMPT = (
+    "You are a Report Agent on a research team. Both the raw findings (from the Research "
+    "Agent) and the synthesis (from the Analyst Agent) are provided to you from shared "
+    "memory. Your job is to write a crisp EXECUTIVE SUMMARY for a busy decision-maker: "
+    "a one-paragraph overview followed by a short, prioritized recommendation list. "
+    "Ground every claim in the provided material. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call. A single Claude client and a single
+# MemoryClient are reused by all three agents — what differs per agent is the actor_id,
+# system prompt, and `messages[]` array, not the underlying clients.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the shared memory resource (one built-in Semantic strategy)
+#
+# This is the resource ALL agents share. We attach a single built-in **Semantic**
+# strategy whose namespace template is `/research-team/{actorId}/knowledge/`. Because
+# `{actorId}` is substituted from the event's actor_id, this ONE strategy serves both the
+# shared team blackboard (actor_id="team-shared") and each agent's private slice
+# (actor_id=<agent>) — no separate strategy per agent required.
+#
+# Built-in strategies require NO IAM execution role — AgentCore manages the extraction
+# and consolidation models. `create_memory_and_wait` blocks until the resource is
+# ACTIVE. If a memory with this name already exists, we reuse its ID instead of failing.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create the shared-memory resource with a built-in Semantic strategy, or reuse it."""
+    # A single-key dict keyed by the strategy type's wire value
+    # (StrategyType.SEMANTIC.value == "semanticMemoryStrategy"). The one namespace
+    # template covers every actor_id the team writes under (shared + per-agent).
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "ResearchTeamKnowledge",
+                "description": "Findings, syntheses, and reports shared across the research team",
+                "namespaces": [NAMESPACE_TEMPLATE],
+            }
+        }
+    ]
+
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # Strategies => long-term extraction is enabled
+            description="Shared long-term memory for the Claude SDK multi-agent research team tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created shared memory with built-in Semantic strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 4: Memory read/write helpers (the shared channel)
+#
+# These two helpers are how agents talk to each other. `store_to_memory` writes an
+# agent's output under a given actor_id (which selects shared vs private), and
+# `retrieve_from_memory` reads back from a resolved namespace. They are deliberately
+# thin wrappers over `create_event` / `retrieve_memories` so the multi-agent mechanics
+# stay visible.
+
+
+def store_to_memory(memory_id: str, actor_id: str, text: str, label: str) -> None:
+    """Write an agent's contribution to memory under `actor_id`.
+
+    The actor_id decides WHERE this lands: SHARED_ACTOR_ID writes to the team blackboard;
+    an agent's own actor_id writes to its private slice. Because the memory has a Semantic
+    strategy, this event is asynchronously extracted into long-term records that teammates
+    can later retrieve. We write the agent's output as a single USER message — the unit of
+    knowledge we want extracted.
+    """
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=actor_id,
+            session_id=SESSION_ID,
+            messages=[(text, "USER")],
+        )
+        logger.info(f"🧠 [{label}] stored to memory under actor '{actor_id}' (queued for extraction)")
+    except Exception as e:
+        # Don't crash the pipeline if a single write fails; log and continue.
+        logger.error(f"Memory save error for {label}: {e}")
+
+
+def retrieve_from_memory(memory_id: str, namespace: str, query: str, top_k: int = 10) -> list:
+    """Retrieve extracted records from one fully-resolved namespace.
+
+    `retrieve_memories` runs a semantic search over the namespace and returns the most
+    relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported
+    (verified in the SDK), so callers substitute `{actorId}` before calling. Each record
+    is a dict whose `content.text` holds the extracted memory.
+    """
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve from {namespace}: {e}")
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info(f"🔎 Retrieved {len(texts)} record(s) from {namespace}")
+    return texts
+
+
+def wait_for_records(memory_id: str, namespace: str, query: str) -> None:
+    """Poll a namespace until records surface, or until the max wait elapses.
+
+    This is the SEQUENTIAL handoff barrier: extraction is asynchronous, so before the
+    next agent retrieves the previous agent's output we wait for that output to be
+    extracted into the shared namespace. In production you would not block a pipeline
+    like this between every stage; you would let the producer run ahead and have the
+    consumer pick up work later. We block here only so the demo's handoff is deterministic.
+    """
+    logger.info(f"⏳ Waiting for extraction into {namespace} ...")
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        if retrieve_from_memory(memory_id, namespace, query, top_k=1):
+            logger.info("✅ Records are available — handing off to the next agent")
+            return
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Records did not surface within the wait window. Extraction may still complete "
+        "shortly; the next agent will simply see fewer (or no) records from this stage."
+    )
+
+
+# ## Step 5: Run one agent (a single, self-contained Claude conversation)
+#
+# Each agent is its OWN conversation: a fresh `messages[]` array, its own system prompt,
+# its own actor_id. The only thing carried between agents is what passes THROUGH memory.
+# `context` is the text we retrieved from memory for this agent (empty for the first
+# agent); we fold it into the user turn so the agent works from its teammates' output.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; we only want the
+    text blocks (these agents define no tools, so there are no tool_use blocks).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def run_agent(system_prompt: str, task: str, context: str = "") -> str:
+    """Run one agent turn as a standalone Claude conversation and return its reply.
+
+    Args:
+        system_prompt: The agent's persona/role.
+        task: The instruction for this agent.
+        context: Knowledge retrieved from shared memory (the previous agents' output).
+                 Empty for the first agent in the pipeline.
+    """
+    # Each agent starts with a FRESH messages[] — agents do not share conversation state.
+    user_content = task
+    if context:
+        user_content = (
+            f"{task}\n\n"
+            f"--- Knowledge from your teammates (retrieved from shared memory) ---\n"
+            f"{context}\n"
+            f"--- End of shared knowledge ---"
+        )
+
+    messages = [{"role": "user", "content": user_content}]
+    response = claude.messages.create(
+        model=MODEL_ID,
+        max_tokens=1500,
+        system=system_prompt,
+        messages=messages,
+    )
+    return extract_text(response)
+
+
+# ## Step 6: Orchestrate the pipeline
+#
+# Sequential producer/consumer handoff over the shared memory:
+#
+#   1. Research Agent gathers findings → writes them to the SHARED blackboard.
+#      (wait for extraction)
+#   2. Analyst Agent retrieves the findings from the shared blackboard → synthesizes →
+#      writes the synthesis back to the SHARED blackboard.
+#      (wait for extraction)
+#   3. Report Agent retrieves BOTH findings and synthesis from the shared blackboard →
+#      writes the final executive summary.
+#
+# Every retrieve hits the SAME shared namespace that the previous agent wrote to — that
+# is how Agent B sees Agent A's work despite never sharing a conversation.
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("ClaudeSDKMultiAgentSharedMemory")
+
+        # ---- Stage 1: Research Agent ------------------------------------------------
+        # First agent in the pipeline: no upstream context. It gathers findings and
+        # publishes them to the SHARED blackboard (actor_id = SHARED_ACTOR_ID) so the
+        # rest of the team can read them. It also keeps a copy in its PRIVATE slice to
+        # show agent-specific storage alongside the shared pool.
+        print("\n=== Stage 1: Research Agent (gather findings) ===")
+        findings = run_agent(
+            system_prompt=RESEARCH_AGENT_PROMPT,
+            task=f"Gather concrete findings on this topic:\n{RESEARCH_TOPIC}",
+        )
+        print(f"Research Agent:\n{findings}\n")
+        # Publish to the shared blackboard so teammates can consume it...
+        store_to_memory(memory_id, SHARED_ACTOR_ID, findings, label="research findings → shared")
+        # ...and keep a private copy in the researcher's own namespace (agent-specific).
+        store_to_memory(memory_id, RESEARCH_ACTOR_ID, findings, label="research findings → private")
+
+        # Wait for the researcher's findings to be extracted before the analyst reads them.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="research findings on the topic")
+
+        # ---- Stage 2: Analyst Agent -------------------------------------------------
+        # Consumes the researcher's findings FROM SHARED MEMORY (it was never in the
+        # researcher's conversation), synthesizes, and publishes the synthesis back.
+        print("=== Stage 2: Analyst Agent (synthesize findings) ===")
+        prior_findings = retrieve_from_memory(
+            memory_id, SHARED_NAMESPACE, query="key findings and trade-offs about vector databases for RAG"
+        )
+        context_for_analyst = "\n".join(f"- {f}" for f in prior_findings)
+        synthesis = run_agent(
+            system_prompt=ANALYST_AGENT_PROMPT,
+            task="Synthesize the research findings into the insights that matter most.",
+            context=context_for_analyst,
+        )
+        print(f"Analyst Agent:\n{synthesis}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, synthesis, label="analysis synthesis → shared")
+        store_to_memory(memory_id, ANALYST_ACTOR_ID, synthesis, label="analysis synthesis → private")
+
+        # Wait for the synthesis to be extracted before the report agent reads it.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="synthesis and key insights")
+
+        # ---- Stage 3: Report Agent --------------------------------------------------
+        # Consumes BOTH the findings and the synthesis from shared memory and writes the
+        # final executive summary. A single retrieve over the shared blackboard returns
+        # everything the team has published so far.
+        print("=== Stage 3: Report Agent (write executive summary) ===")
+        all_team_knowledge = retrieve_from_memory(
+            memory_id,
+            SHARED_NAMESPACE,
+            query="research findings and analytical synthesis about vector databases for RAG",
+        )
+        context_for_report = "\n".join(f"- {k}" for k in all_team_knowledge)
+        report = run_agent(
+            system_prompt=REPORT_AGENT_PROMPT,
+            task="Write the executive summary and prioritized recommendations.",
+            context=context_for_report,
+        )
+        print(f"Report Agent:\n{report}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, report, label="final report → shared")
+        store_to_memory(memory_id, REPORT_ACTOR_ID, report, label="final report → private")
+
+        # ---- Inspect what's in shared vs agent-specific memory ----------------------
+        # The shared blackboard now holds the whole team's output; each private slice
+        # holds only that one agent's contribution. This is the shared-vs-isolated view.
+        print("=== What lives in SHARED memory (the team blackboard) ===")
+        for item in retrieve_from_memory(memory_id, SHARED_NAMESPACE, query="everything the team produced"):
+            print(f"  • {item}")
+        print()
+
+        print("=== What lives in the Research Agent's PRIVATE memory ===")
+        research_private_ns = NAMESPACE_TEMPLATE.format(actorId=RESEARCH_ACTOR_ID)
+        for item in retrieve_from_memory(memory_id, research_private_ns, query="this agent's own findings"):
+            print(f"  • {item}")
+        print()
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/claude-sdk-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/claude-sdk-multi-agent-shared-memory.py
@@ -134,11 +134,9 @@ from datetime import datetime
 # Messages API against Bedrock — no Anthropic API key required.
 from anthropic import AnthropicBedrock
 
-# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
-# and the AWS error type we handle during memory creation.
+# AgentCore Memory client and the StrategyType enum (gives us the exact strategy keys).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -240,8 +238,8 @@ logger.info(f"✅ Clients initialized for region: {REGION}")
 # (actor_id=<agent>) — no separate strategy per agent required.
 #
 # Built-in strategies require NO IAM execution role — AgentCore manages the extraction
-# and consolidation models. `create_memory_and_wait` blocks until the resource is
-# ACTIVE. If a memory with this name already exists, we reuse its ID instead of failing.
+# and consolidation models. `create_or_get_memory` blocks until the resource is ACTIVE.
+# If a memory with this name already exists, it returns that one instead of failing.
 
 
 def get_or_create_memory(name: str) -> str:
@@ -259,32 +257,19 @@ def get_or_create_memory(name: str) -> str:
         }
     ]
 
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # Strategies => long-term extraction is enabled
-            description="Shared long-term memory for the Claude SDK multi-agent research team tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created shared memory with built-in Semantic strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the resource and blocks until it is ACTIVE. If a
+    # memory with this name already exists, it returns the existing one instead of
+    # failing — so a re-run reuses the same resource without us hand-rolling the lookup.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # Strategies => long-term extraction is enabled
+        description="Shared long-term memory for the Claude SDK multi-agent research team tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Shared memory ready with built-in Semantic strategy: {memory_id}")
+    return memory_id
 
 
 # ## Step 4: Memory read/write helpers (the shared channel)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-claude-sdk/requirements.txt
@@ -1,0 +1,7 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient shared across all agents
+# (create_memory_and_wait with a Semantic strategy, create_event, retrieve_memories).
+bedrock-agentcore

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/README.md
@@ -1,0 +1,155 @@
+# Long-term memory — LangGraph, multi-agent shared memory
+
+A **multi-agent** system built with **LangGraph** (`create_agent`) where several
+specialized agents collaborate through a **single shared AgentCore Memory resource**. One
+agent writes, the next reads what it wrote, and so on down a pipeline — AgentCore Memory is
+the communication substrate.
+
+The use case is a **research team**: a **Research Agent** gathers findings, an **Analyst
+Agent** synthesizes them, and a **Report Agent** writes the executive summary. Each is a
+separate LangGraph `create_agent` with its own `actor_id`; they share one `memory_id`.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term, multi-agent |
+| Agent usecase | Research team (Researcher → Analyst → Report Writer) |
+| Framework | LangGraph (v1.0 `create_agent`) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | One shared `memory_id`, per-agent `actor_id`, shared vs private namespaces, `create_event`, `retrieve_memories` |
+| Complexity | Advanced |
+
+> ### ⚠️ LangGraph v1.0 API note
+> Each agent is built with the current **`from langchain.agents import create_agent`** API
+> (the older `langgraph.prebuilt.create_react_agent` is deprecated in v1.0). The agents
+> have no tools — they reason over text — so the multi-agent coordination lives entirely in
+> how the orchestrator routes each agent's output and input through the shared
+> `MemoryClient`, keeping the shared-memory pattern explicit and framework-neutral.
+
+## What it does
+
+[`langgraph-multi-agent-shared-memory.py`](./langgraph-multi-agent-shared-memory.py):
+
+1. Creates (or reuses) **one** memory resource with a built-in **Semantic** strategy whose
+   namespace template is `/research-team/{actorId}/knowledge/`. No IAM execution role.
+2. **Stage 1 — Research Agent**: gathers findings on the topic, writes them to the SHARED
+   blackboard (`actor_id="team-shared"`) and a PRIVATE copy under its own actor_id.
+3. *(waits for extraction)*
+4. **Stage 2 — Analyst Agent**: retrieves the findings from the shared blackboard,
+   synthesizes them, writes the synthesis back to the shared blackboard.
+5. *(waits for extraction)*
+6. **Stage 3 — Report Agent**: retrieves BOTH findings and synthesis from the shared
+   blackboard and writes the final executive summary.
+7. Inspects what lives in shared vs. private memory, then deletes the resource in a
+   `finally` block.
+
+## How memory is shared (the core idea)
+
+A memory resource is identified by a plain `memory_id`. Three identifiers decide
+who-can-see-what:
+
+| Identifier | Role in a multi-agent system |
+|---|---|
+| `memory_id` | The shared resource. **SAME** for every agent — this is what makes memory shared. |
+| `actor_id` | **WHO** is writing/reading. Each agent has a distinct one, plus a `team-shared` identity. |
+| `namespace` | **WHERE** records land. `{actorId}` is substituted from the event's `actor_id`. |
+
+The template `"/research-team/{actorId}/knowledge/"` yields a **shared** pool or a
+**private** slice depending only on which `actor_id` you write under:
+
+- Write with `actor_id="team-shared"` → `/research-team/team-shared/knowledge/` — the
+  **team blackboard** every agent reads from and writes to.
+- Write with `actor_id="research-agent"` → `/research-team/research-agent/knowledge/` —
+  that agent's **private scratchpad**.
+
+Agent B "sees" Agent A's work because B retrieves from the shared blackboard that A wrote
+to — not because they share a conversation (they don't). This is the producer/consumer
+pattern, with AgentCore Memory as the channel.
+
+## Architecture
+
+```
+           ┌───────────────────────────────────────────────────────────────┐
+           │           ONE shared AgentCore Memory  (single memory_id)       │
+           │                                                                 │
+           │   SHARED namespace  (actor_id = "team-shared")                  │
+           │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+           │                                                                 │
+           │   PRIVATE namespaces (actor_id = each agent)                    │
+           │     /research-team/research-agent/knowledge/                    │
+           │     /research-team/analyst-agent/knowledge/                     │
+           └───────────────────────────────────────────────────────────────┘
+                ▲ write          ▲ read+write          ▲ read
+                │ shared         │ shared              │ shared
+    ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+    │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+    │  actor: research │ │  actor: analyst  │ │  actor: report   │
+    │  create_agent    │ │  create_agent    │ │  create_agent    │
+    │  (LangGraph)     │ │  (LangGraph)     │ │  (LangGraph)     │
+    └──────────────────┘ └──────────────────┘ └──────────────────┘
+         1. gather            2. synthesize         3. summarize
+         findings ──▶ memory  read findings ──▶     read findings +
+                              write synthesis       synthesis ──▶ report
+
+  Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+```
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock
+  model-invocation permissions (resolved from the standard AWS chain).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region (request it in the
+  Bedrock console under *Model access*; `us-west-2` is a safe default).
+- **No IAM execution role required** — built-in strategies use AgentCore-managed models.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python langgraph-multi-agent-shared-memory.py
+```
+
+Expected output: each stage prints its agent's output and a `🧠 stored to memory` line;
+between stages you'll see `⏳ Waiting for extraction` then `✅ Records are available`.
+Finally the script prints what lives in the shared blackboard vs. one agent's private slice,
+then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous, and this is a **sequential** pipeline —
+> each agent consumes the previous one's output — so the script waits for records to
+> surface between stages. Each wait is capped at ~2 minutes; if records haven't appeared it
+> warns and continues (the next agent simply sees fewer records). In production you would
+> not block between every stage.
+
+## Key implementation notes
+
+- **Shared `memory_id`, per-agent `actor_id`.** One resource, many actors. The `actor_id`
+  on each `create_event` decides whether the record lands in the shared blackboard or an
+  agent's private slice — there is no separate strategy per agent.
+- **Agents never share a conversation.** Each `create_agent` invocation is standalone;
+  everything that crosses between agents goes *through memory*. The orchestrator retrieves
+  the upstream output and folds it into the next agent's user turn.
+- **Sequential handoff needs a wait.** Because extraction is asynchronous and stage N+1
+  reads stage N's output, `wait_for_records` polls the shared namespace before handing off.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept
+  wildcards — helpers substitute `{actorId}` before calling.
+- **Thin wrappers keep the pattern visible.** `store_to_memory` / `retrieve_from_memory`
+  are deliberately minimal wrappers over `create_event` / `retrieve_memories` so the
+  multi-agent mechanics aren't hidden behind framework abstractions.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a
+  stage raises. Comment out the delete block to keep it between runs.
+
+## Where to go next
+
+- The single-agent LangGraph patterns:
+  [`../../single-agent/with-langgraph-agent/`](../../single-agent/with-langgraph-agent/)
+- The same multi-agent pattern with the Claude SDK:
+  [`../with-claude-sdk/`](../with-claude-sdk/)
+- The Strands multi-agent example: [`../with-strands-agent/`](../with-strands-agent/)
+- The long-term memory overview (all strategies, retrieval, namespaces):
+  [`../../../README.md`](../../../README.md)
+```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/langgraph-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/langgraph-multi-agent-shared-memory.py
@@ -128,11 +128,9 @@ from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage
 
-# AgentCore Memory client (shared by all agents) + the StrategyType enum + the error we
-# handle when reusing an existing memory.
+# AgentCore Memory client (shared by all agents) + the StrategyType enum.
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -240,30 +238,18 @@ def get_or_create_memory(name: str) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # strategies => long-term extraction is enabled
-            description="Shared LTM for the LangGraph multi-agent research team tutorial",
-            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created shared memory with built-in Semantic strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the resource and waits for it; on a name clash (the
+    # memory already exists) it returns the existing memory instead of raising. No
+    # memory_execution_role_arn — built-in strategies don't need one.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # strategies => long-term extraction is enabled
+        description="Shared LTM for the LangGraph multi-agent research team tutorial",
+        event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Shared memory with built-in Semantic strategy ready: {memory_id}")
+    return memory_id
 
 
 # ## Step 4: Memory read/write helpers (the shared channel)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/langgraph-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/langgraph-multi-agent-shared-memory.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python
+
+# # LangGraph with AgentCore Memory (Multi-Agent — Shared Memory)
+#
+# ## Introduction
+#
+# This tutorial demonstrates a **multi-agent system** built with **LangGraph**
+# (`create_agent`) where several specialized agents collaborate through a **single shared
+# AgentCore Memory resource**. The single-agent tutorials
+# (`../../single-agent/with-langgraph-agent/`) wired memory into one agent. Here the same
+# memory primitive becomes the **communication substrate** for a team: one agent writes,
+# the next reads what it wrote, and so on down a pipeline.
+#
+# The use case is a **research team**:
+#   1. **Research Agent** gathers raw findings on a topic and writes them to memory.
+#   2. **Analyst Agent** retrieves the researcher's findings, synthesizes them into
+#      insights, and writes the synthesis back to memory.
+#   3. **Report Agent** retrieves BOTH the findings and the synthesis, then writes a final
+#      executive summary.
+#
+# Each agent is a **separate LangGraph `create_agent`** with its own system prompt and its
+# own **`actor_id`**. What ties them together is that they all read/write the **same
+# `memory_id`** — a memory resource is just a resource ID, and any number of clients can
+# use it concurrently. That is the whole multi-agent pattern: shared `memory_id`, per-agent
+# `actor_id`, and a deliberate namespace design that decides what is *shared* across the
+# team versus *private* to one agent.
+#
+# > **LangGraph API note (v1.0):** Each agent is built with the current
+# > **`from langchain.agents import create_agent`** API (the older
+# > `langgraph.prebuilt.create_react_agent` is deprecated in v1.0). The agents themselves
+# > have no tools — they reason over text — so the multi-agent mechanics live entirely in
+# > how we route their I/O through the shared `MemoryClient` (`create_event` /
+# > `retrieve_memories`), keeping the shared-memory pattern explicit and framework-neutral.
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term, Multi-agent                                                           |
+# | Agent usecase       | Research Team (Researcher → Analyst → Report Writer)                              |
+# | Agentic Framework   | LangGraph (v1.0 `create_agent`)                                                  |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | One shared memory_id, per-agent actor_id, shared vs agent-specific namespaces, create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Share ONE AgentCore Memory resource across multiple independent LangGraph agents
+# - Give each agent its own `actor_id` while all agents target the same `memory_id`
+# - Design namespaces so some knowledge is **team-shared** and some is **agent-private**
+# - Hand off work between agents: Agent B retrieves what Agent A stored (producer/consumer)
+# - Orchestrate a sequential pipeline where each agent builds on the previous one's output
+#
+# ## How memory is shared (the core idea)
+#
+# A memory resource is identified by a plain `memory_id`. Nothing binds it to a single
+# agent. Three identifiers decide who-can-see-what:
+#
+# | Identifier    | Role in a multi-agent system                                                    |
+# |---------------|---------------------------------------------------------------------------------|
+# | `memory_id`   | The shared resource. SAME for every agent — this is what makes memory shared.   |
+# | `actor_id`    | WHO is writing/reading. Each agent has a distinct one, PLUS a team identity.    |
+# | `namespace`   | WHERE records land. `{actorId}` is substituted from the event's `actor_id`.     |
+#
+# The namespace template `"/research-team/{actorId}/knowledge/"` has its `{actorId}`
+# placeholder filled from the `actor_id` passed to `create_event`. So the SAME template
+# produces a SHARED pool or a PRIVATE slice depending only on which actor_id you write under:
+#
+#   • Write with actor_id="team-shared"     → "/research-team/team-shared/knowledge/"
+#       → the TEAM BLACKBOARD every agent reads from and writes to.
+#   • Write with actor_id="research-agent"  → "/research-team/research-agent/knowledge/"
+#       → that agent's PRIVATE scratchpad, isolated from the others.
+#
+# Agent B "sees" Agent A's work because B retrieves from the shared blackboard that A wrote
+# to — not because they share a conversation (they don't). This is the producer/consumer
+# pattern, with AgentCore Memory as the channel.
+#
+# ## Architecture
+#
+# ```
+#            ┌───────────────────────────────────────────────────────────────┐
+#            │           ONE shared AgentCore Memory  (single memory_id)       │
+#            │                                                                 │
+#            │   SHARED namespace  (actor_id = "team-shared")                  │
+#            │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+#            │                                                                 │
+#            │   PRIVATE namespaces (actor_id = each agent)                    │
+#            │     /research-team/research-agent/knowledge/                    │
+#            │     /research-team/analyst-agent/knowledge/                     │
+#            └───────────────────────────────────────────────────────────────┘
+#                 ▲ write          ▲ read+write          ▲ read
+#                 │ shared         │ shared              │ shared
+#     ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+#     │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+#     │  actor: research │ │  actor: analyst  │ │  actor: report   │
+#     │  create_agent    │ │  create_agent    │ │  create_agent    │
+#     │  (LangGraph)     │ │  (LangGraph)     │ │  (LangGraph)     │
+#     └──────────────────┘ └──────────────────┘ └──────────────────┘
+#          1. gather            2. synthesize         3. summarize
+#          findings ──▶ memory  read findings ──▶     read findings +
+#                               write synthesis       synthesis ──▶ report
+#
+#   Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+# ```
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the Bedrock
+#   console under *Model access*, in your chosen region)
+# - No IAM execution role required — we use a **built-in** Semantic strategy.
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+
+# LangGraph v1.0 agent factory (replaces the deprecated create_react_agent).
+from langchain.agents import create_agent
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import HumanMessage
+
+# AgentCore Memory client (shared by all agents) + the StrategyType enum + the error we
+# handle when reusing an existing memory.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("langgraph-multi-agent")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock. The `global.` prefix selects the
+# global (cross-region) inference endpoint. To pin to a region, swap the prefix.
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# ---- Actor identities ------------------------------------------------------------
+# Every agent shares the SAME memory_id (created in Step 3). They differ by actor_id. Each
+# agent has its own actor_id for PRIVATE scratch space, plus one "team" actor_id whose
+# namespace is the SHARED blackboard all agents read/write.
+RESEARCH_ACTOR_ID = "research-agent"
+ANALYST_ACTOR_ID = "analyst-agent"
+REPORT_ACTOR_ID = "report-agent"
+SHARED_ACTOR_ID = "team-shared"  # records written under this actor form the team blackboard
+
+# One session ties this pipeline run together. All three agents use the same session_id so
+# the run reads as one coherent collaboration in the event history.
+SESSION_ID = f"research-run-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+# Namespace template. `{actorId}` is substituted at extraction time from the actor_id on
+# the event. The SAME template yields the shared blackboard or a private slice depending
+# only on which actor_id we write under. Always end namespace templates with "/".
+NAMESPACE_TEMPLATE = "/research-team/{actorId}/knowledge/"
+
+# The shared blackboard namespace, fully resolved. This is the channel between agents.
+SHARED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=SHARED_ACTOR_ID)
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event. Because
+# this is a SEQUENTIAL handoff (each agent consumes the previous agent's output), we must
+# wait for extraction between stages. We poll but cap the wait.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# The research topic the whole team works on.
+RESEARCH_TOPIC = (
+    "The operational trade-offs of adopting vector databases for "
+    "retrieval-augmented generation (RAG) in production systems."
+)
+
+# Per-agent system prompts. Each agent is a distinct persona with a distinct job in the
+# pipeline. They never share a conversation — only the memory resource.
+RESEARCH_AGENT_PROMPT = (
+    "You are a Research Agent on a research team. Your job is to gather concrete, factual "
+    "findings on the assigned topic: specific capabilities, constraints, costs, and "
+    "trade-offs. Produce a tight set of discrete findings (bullet points), each a "
+    "self-contained, verifiable statement. Do not editorialize or conclude — just surface "
+    "the raw findings for your teammates to build on. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+ANALYST_AGENT_PROMPT = (
+    "You are an Analyst Agent on a research team. Your teammate the Research Agent has "
+    "gathered raw findings, which are provided to you from shared memory. Your job is to "
+    "SYNTHESIZE them: identify themes, tensions, and the decision factors that matter most. "
+    "Produce a short synthesis (3-5 insights), each grounded in the findings you were given. "
+    "Do not invent facts beyond the provided findings. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+REPORT_AGENT_PROMPT = (
+    "You are a Report Agent on a research team. Both the raw findings (from the Research "
+    "Agent) and the synthesis (from the Analyst Agent) are provided to you from shared "
+    "memory. Your job is to write a crisp EXECUTIVE SUMMARY for a busy decision-maker: a "
+    "one-paragraph overview followed by a short, prioritized recommendation list. Ground "
+    "every claim in the provided material. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the shared clients
+#
+# A single Bedrock-backed chat model and a single MemoryClient are reused by all three
+# agents — what differs per agent is the actor_id, system prompt, and `create_agent`
+# instance, not the underlying clients.
+
+
+llm = init_chat_model(MODEL_ID, model_provider="bedrock_converse", region_name=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the shared memory resource (one built-in Semantic strategy)
+#
+# This is the resource ALL agents share. We attach a single built-in **Semantic** strategy
+# whose namespace template is `/research-team/{actorId}/knowledge/`. Because `{actorId}` is
+# substituted from the event's actor_id, this ONE strategy serves both the shared team
+# blackboard (actor_id="team-shared") and each agent's private slice — no separate strategy
+# per agent. Built-in strategies require NO IAM execution role.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create the shared-memory resource with a built-in Semantic strategy, or reuse it."""
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "ResearchTeamKnowledge",
+                "description": "Findings, syntheses, and reports shared across the research team",
+                "namespaces": [NAMESPACE_TEMPLATE],
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # strategies => long-term extraction is enabled
+            description="Shared LTM for the LangGraph multi-agent research team tutorial",
+            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created shared memory with built-in Semantic strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 4: Memory read/write helpers (the shared channel)
+#
+# These two helpers are how agents talk to each other. `store_to_memory` writes an agent's
+# output under a given actor_id (which selects shared vs private), and `retrieve_from_memory`
+# reads back from a resolved namespace. They are deliberately thin wrappers over
+# `create_event` / `retrieve_memories` so the multi-agent mechanics stay visible.
+
+
+def store_to_memory(memory_id: str, actor_id: str, text: str, label: str) -> None:
+    """Write an agent's contribution to memory under `actor_id`.
+
+    The actor_id decides WHERE this lands: SHARED_ACTOR_ID writes to the team blackboard;
+    an agent's own actor_id writes to its private slice. Because the memory has a Semantic
+    strategy, this event is asynchronously extracted into long-term records that teammates
+    can later retrieve. We write the agent's output as a single USER message.
+    """
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=actor_id,
+            session_id=SESSION_ID,
+            messages=[(text, "USER")],
+        )
+        logger.info(f"🧠 [{label}] stored to memory under actor '{actor_id}' (queued for extraction)")
+    except Exception as e:
+        # Don't crash the pipeline if a single write fails; log and continue.
+        logger.error(f"Memory save error for {label}: {e}")
+
+
+def retrieve_from_memory(memory_id: str, namespace: str, query: str, top_k: int = 10) -> list:
+    """Retrieve extracted records from one fully-resolved namespace.
+
+    `retrieve_memories` runs a semantic search over the namespace and returns the most
+    relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported —
+    so callers substitute `{actorId}` before calling. Each record is a dict whose
+    `content.text` holds the extracted memory.
+    """
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve from {namespace}: {e}")
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info(f"🔎 Retrieved {len(texts)} record(s) from {namespace}")
+    return texts
+
+
+def wait_for_records(memory_id: str, namespace: str, query: str) -> None:
+    """Poll a namespace until records surface, or until the max wait elapses.
+
+    This is the SEQUENTIAL handoff barrier: extraction is asynchronous, so before the next
+    agent retrieves the previous agent's output we wait for that output to be extracted into
+    the shared namespace. In production you would not block a pipeline like this between
+    every stage. We block here only so the demo's handoff is deterministic.
+    """
+    logger.info(f"⏳ Waiting for extraction into {namespace} ...")
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        if retrieve_from_memory(memory_id, namespace, query, top_k=1):
+            logger.info("✅ Records are available — handing off to the next agent")
+            return
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Records did not surface within the wait window. Extraction may still complete "
+        "shortly; the next agent will simply see fewer (or no) records from this stage."
+    )
+
+
+# ## Step 5: Run one agent (a self-contained LangGraph create_agent)
+#
+# Each agent is its OWN LangGraph agent: its own system prompt, its own actor_id, a fresh
+# invocation. The only thing carried between agents is what passes THROUGH memory. `context`
+# is the text we retrieved from memory for this agent (empty for the first agent); we fold
+# it into the user turn so the agent works from its teammates' output.
+
+
+def run_agent(system_prompt: str, task: str, context: str = "") -> str:
+    """Build a LangGraph agent for this persona, run one turn, and return its reply.
+
+    Args:
+        system_prompt: The agent's persona/role.
+        task: The instruction for this agent.
+        context: Knowledge retrieved from shared memory (the previous agents' output).
+                 Empty for the first agent in the pipeline.
+    """
+    user_content = task
+    if context:
+        user_content = (
+            f"{task}\n\n"
+            f"--- Knowledge from your teammates (retrieved from shared memory) ---\n"
+            f"{context}\n"
+            f"--- End of shared knowledge ---"
+        )
+
+    # Each agent is a standalone LangGraph agent with no tools — it reasons over the
+    # prompt + context. The multi-agent coordination happens OUTSIDE the agent, in how we
+    # route its output and input through the shared memory (Step 6).
+    agent = create_agent(model=llm, tools=[], system_prompt=system_prompt)
+    result = agent.invoke({"messages": [HumanMessage(content=user_content)]})
+    return result["messages"][-1].text()
+
+
+# ## Step 6: Orchestrate the pipeline
+#
+# Sequential producer/consumer handoff over the shared memory:
+#
+#   1. Research Agent gathers findings → writes them to the SHARED blackboard.
+#      (wait for extraction)
+#   2. Analyst Agent retrieves the findings from the shared blackboard → synthesizes →
+#      writes the synthesis back to the SHARED blackboard.
+#      (wait for extraction)
+#   3. Report Agent retrieves BOTH findings and synthesis from the shared blackboard →
+#      writes the final executive summary.
+#
+# Every retrieve hits the SAME shared namespace the previous agent wrote to — that is how
+# Agent B sees Agent A's work despite never sharing a conversation.
+
+
+def main() -> None:
+    memory_id = None  # init so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("LangGraphMultiAgentSharedMemory")
+
+        # ---- Stage 1: Research Agent --------------------------------------------
+        # First agent in the pipeline: no upstream context. It gathers findings and
+        # publishes them to the SHARED blackboard so the rest of the team can read them. It
+        # also keeps a copy in its PRIVATE slice to show agent-specific storage.
+        print("\n=== Stage 1: Research Agent (gather findings) ===")
+        findings = run_agent(
+            system_prompt=RESEARCH_AGENT_PROMPT,
+            task=f"Gather concrete findings on this topic:\n{RESEARCH_TOPIC}",
+        )
+        print(f"Research Agent:\n{findings}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, findings, label="research findings → shared")
+        store_to_memory(memory_id, RESEARCH_ACTOR_ID, findings, label="research findings → private")
+
+        # Wait for the researcher's findings to be extracted before the analyst reads them.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="research findings on the topic")
+
+        # ---- Stage 2: Analyst Agent ---------------------------------------------
+        # Consumes the researcher's findings FROM SHARED MEMORY (it was never in the
+        # researcher's conversation), synthesizes, and publishes the synthesis back.
+        print("=== Stage 2: Analyst Agent (synthesize findings) ===")
+        prior_findings = retrieve_from_memory(
+            memory_id, SHARED_NAMESPACE, query="key findings and trade-offs about vector databases for RAG"
+        )
+        context_for_analyst = "\n".join(f"- {f}" for f in prior_findings)
+        synthesis = run_agent(
+            system_prompt=ANALYST_AGENT_PROMPT,
+            task="Synthesize the research findings into the insights that matter most.",
+            context=context_for_analyst,
+        )
+        print(f"Analyst Agent:\n{synthesis}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, synthesis, label="analysis synthesis → shared")
+        store_to_memory(memory_id, ANALYST_ACTOR_ID, synthesis, label="analysis synthesis → private")
+
+        # Wait for the synthesis to be extracted before the report agent reads it.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="synthesis and key insights")
+
+        # ---- Stage 3: Report Agent ----------------------------------------------
+        # Consumes BOTH the findings and the synthesis from shared memory and writes the
+        # final executive summary. A single retrieve over the shared blackboard returns
+        # everything the team has published so far.
+        print("=== Stage 3: Report Agent (write executive summary) ===")
+        all_team_knowledge = retrieve_from_memory(
+            memory_id,
+            SHARED_NAMESPACE,
+            query="research findings and analytical synthesis about vector databases for RAG",
+        )
+        context_for_report = "\n".join(f"- {k}" for k in all_team_knowledge)
+        report = run_agent(
+            system_prompt=REPORT_AGENT_PROMPT,
+            task="Write the executive summary and prioritized recommendations.",
+            context=context_for_report,
+        )
+        print(f"Report Agent:\n{report}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, report, label="final report → shared")
+        store_to_memory(memory_id, REPORT_ACTOR_ID, report, label="final report → private")
+
+        # ---- Inspect what's in shared vs agent-specific memory ------------------
+        # The shared blackboard now holds the whole team's output; each private slice holds
+        # only that one agent's contribution. This is the shared-vs-isolated view.
+        print("=== What lives in SHARED memory (the team blackboard) ===")
+        for item in retrieve_from_memory(memory_id, SHARED_NAMESPACE, query="everything the team produced"):
+            print(f"  • {item}")
+        print()
+
+        print("=== What lives in the Research Agent's PRIVATE memory ===")
+        research_private_ns = NAMESPACE_TEMPLATE.format(actorId=RESEARCH_ACTOR_ID)
+        for item in retrieve_from_memory(memory_id, research_private_ns, query="this agent's own findings"):
+            print(f"  • {item}")
+        print()
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the demo
+        # finishes. To keep the memory between runs (e.g. to inspect it in the console),
+        # comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-langgraph-agent/requirements.txt
@@ -1,0 +1,8 @@
+boto3
+bedrock_agentcore
+# LangGraph v1.0+: create_agent lives in the `langchain` package (>=1.0); `langgraph` is
+# the underlying runtime.
+langchain>=1.0
+langgraph>=1.0
+langchain_aws
+langchain_core

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/README.md
@@ -1,0 +1,164 @@
+# Long-term memory — LlamaIndex, multi-agent shared memory
+
+A **multi-agent** system built with **LlamaIndex** (`FunctionAgent`) where several
+specialized agents collaborate through a **single shared AgentCore Memory resource**. One
+agent writes, the next reads what it wrote, and so on down a pipeline — AgentCore Memory is
+the communication substrate.
+
+The use case is a **research team**: a **Research Agent** gathers findings, an **Analyst
+Agent** synthesizes them, and a **Report Agent** writes the executive summary. Each is a
+separate LlamaIndex `FunctionAgent` with its own `actor_id`; they share one `memory_id`.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term, multi-agent |
+| Agent usecase | Research team (Researcher → Analyst → Report Writer) |
+| Framework | LlamaIndex (`FunctionAgent`) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | One shared `memory_id`, per-agent `actor_id`, shared vs private namespaces, `create_event`, `retrieve_memories` |
+| Complexity | Advanced |
+
+> ### LlamaIndex API note
+> The agents have no tools — they reason over text — so the multi-agent coordination lives
+> entirely in how the orchestrator routes each agent's output and input through the shared
+> `MemoryClient`, keeping the shared-memory pattern explicit and framework-neutral. A
+> *single* agent would instead wire memory in via the `Memory` + `BaseMemoryBlock` API (see
+> the [single-agent tutorials](../../single-agent/with-llamaindex-agent/)); the deprecated
+> `ChatMemoryBuffer` is not used.
+
+## What it does
+
+[`llamaindex-multi-agent-shared-memory.py`](./llamaindex-multi-agent-shared-memory.py):
+
+1. Creates (or reuses) **one** memory resource with a built-in **Semantic** strategy whose
+   namespace template is `/research-team/{actorId}/knowledge/`. No IAM execution role.
+2. **Stage 1 — Research Agent**: gathers findings on the topic, writes them to the SHARED
+   blackboard (`actor_id="team-shared"`) and a PRIVATE copy under its own actor_id.
+3. *(waits for extraction)*
+4. **Stage 2 — Analyst Agent**: retrieves the findings from the shared blackboard,
+   synthesizes them, writes the synthesis back to the shared blackboard.
+5. *(waits for extraction)*
+6. **Stage 3 — Report Agent**: retrieves BOTH findings and synthesis from the shared
+   blackboard and writes the final executive summary.
+7. Inspects what lives in shared vs. private memory, then deletes the resource in a
+   `finally` block.
+
+## How memory is shared (the core idea)
+
+A memory resource is identified by a plain `memory_id`. Three identifiers decide
+who-can-see-what:
+
+| Identifier | Role in a multi-agent system |
+|---|---|
+| `memory_id` | The shared resource. **SAME** for every agent — this is what makes memory shared. |
+| `actor_id` | **WHO** is writing/reading. Each agent has a distinct one, plus a `team-shared` identity. |
+| `namespace` | **WHERE** records land. `{actorId}` is substituted from the event's `actor_id`. |
+
+The template `"/research-team/{actorId}/knowledge/"` yields a **shared** pool or a
+**private** slice depending only on which `actor_id` you write under:
+
+- Write with `actor_id="team-shared"` → `/research-team/team-shared/knowledge/` — the
+  **team blackboard** every agent reads from and writes to.
+- Write with `actor_id="research-agent"` → `/research-team/research-agent/knowledge/` —
+  that agent's **private scratchpad**.
+
+Agent B "sees" Agent A's work because B retrieves from the shared blackboard that A wrote
+to — not because they share a conversation (they don't). This is the producer/consumer
+pattern, with AgentCore Memory as the channel.
+
+## Architecture
+
+```
+           ┌───────────────────────────────────────────────────────────────┐
+           │           ONE shared AgentCore Memory  (single memory_id)       │
+           │                                                                 │
+           │   SHARED namespace  (actor_id = "team-shared")                  │
+           │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+           │                                                                 │
+           │   PRIVATE namespaces (actor_id = each agent)                    │
+           │     /research-team/research-agent/knowledge/                    │
+           │     /research-team/analyst-agent/knowledge/                     │
+           └───────────────────────────────────────────────────────────────┘
+                ▲ write          ▲ read+write          ▲ read
+                │ shared         │ shared              │ shared
+    ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+    │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+    │  actor: research │ │  actor: analyst  │ │  actor: report   │
+    │  FunctionAgent   │ │  FunctionAgent   │ │  FunctionAgent   │
+    │  (LlamaIndex)    │ │  (LlamaIndex)    │ │  (LlamaIndex)    │
+    └──────────────────┘ └──────────────────┘ └──────────────────┘
+         1. gather            2. synthesize         3. summarize
+         findings ──▶ memory  read findings ──▶     read findings +
+                              write synthesis       synthesis ──▶ report
+
+  Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+```
+
+## ✅ Namespace correctness
+
+Reads use the **same resolved namespace** the previous agent wrote to —
+`SHARED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=SHARED_ACTOR_ID)`. The single-agent
+memory-as-tool tutorials searched a hard-coded `/strategies/` prefix that didn't match the
+strategy's write target, so retrieval returned nothing. This tutorial resolves one template
+for both directions. `retrieve_memories` does **not** accept wildcards — the namespace must
+be fully resolved before calling.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock
+  model-invocation permissions (resolved from the standard AWS chain).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region (request it in the
+  Bedrock console under *Model access*; `us-west-2` is a safe default).
+- **No IAM execution role required** — built-in strategies use AgentCore-managed models.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python llamaindex-multi-agent-shared-memory.py
+```
+
+Expected output: each stage prints its agent's output and a `🧠 stored to memory` line;
+between stages you'll see `⏳ Waiting for extraction` then `✅ Records are available`.
+Finally the script prints what lives in the shared blackboard vs. one agent's private slice,
+then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous, and this is a **sequential** pipeline —
+> each agent consumes the previous one's output — so the script waits for records to surface
+> between stages. Each wait is capped at ~2 minutes; if records haven't appeared it warns
+> and continues (the next agent simply sees fewer records). In production you would not block
+> between every stage.
+
+## Key implementation notes
+
+- **Shared `memory_id`, per-agent `actor_id`.** One resource, many actors. The `actor_id` on
+  each `create_event` decides whether the record lands in the shared blackboard or an agent's
+  private slice — there is no separate strategy per agent.
+- **Agents never share a conversation.** Each `FunctionAgent` invocation is standalone;
+  everything that crosses between agents goes *through memory*. The orchestrator retrieves
+  the upstream output and folds it into the next agent's user turn.
+- **No per-agent `Memory` object.** Cross-agent state lives in the shared AgentCore resource,
+  not in any one agent's LlamaIndex `Memory`. Each agent runs statelessly.
+- **Sequential handoff needs a wait.** Because extraction is asynchronous and stage N+1 reads
+  stage N's output, `wait_for_records` polls the shared namespace before handing off.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept
+  wildcards — helpers substitute `{actorId}` before calling.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a
+  stage raises. Comment out the delete block to keep it between runs.
+
+## Where to go next
+
+- The single-agent LlamaIndex patterns:
+  [`../../single-agent/with-llamaindex-agent/`](../../single-agent/with-llamaindex-agent/)
+- The same multi-agent pattern with LangGraph:
+  [`../with-langgraph-agent/`](../with-langgraph-agent/)
+- The same pattern with the Claude SDK: [`../with-claude-sdk/`](../with-claude-sdk/)
+- The Strands multi-agent example: [`../with-strands-agent/`](../with-strands-agent/)
+- The long-term memory overview (all strategies, retrieval, namespaces):
+  [`../../../README.md`](../../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python
+
+# # LlamaIndex with AgentCore Memory (Multi-Agent — Shared Memory)
+#
+# ## Introduction
+#
+# This tutorial demonstrates a **multi-agent system** built with **LlamaIndex**
+# (`FunctionAgent`) where several specialized agents collaborate through a **single shared
+# AgentCore Memory resource**. The single-agent tutorials
+# (`../../single-agent/with-llamaindex-agent/`) wired memory into one agent via a
+# `BaseMemoryBlock`. Here the same memory primitive becomes the **communication substrate**
+# for a team: one agent writes, the next reads what it wrote, and so on down a pipeline.
+#
+# The use case is a **research team**:
+#   1. **Research Agent** gathers raw findings on a topic and writes them to memory.
+#   2. **Analyst Agent** retrieves the researcher's findings, synthesizes them into
+#      insights, and writes the synthesis back to memory.
+#   3. **Report Agent** retrieves BOTH the findings and the synthesis, then writes a final
+#      executive summary.
+#
+# Each agent is a **separate LlamaIndex `FunctionAgent`** with its own system prompt and its
+# own **`actor_id`**. What ties them together is that they all read/write the **same
+# `memory_id`** — a memory resource is just a resource ID, and any number of clients can use
+# it concurrently. That is the whole multi-agent pattern: shared `memory_id`, per-agent
+# `actor_id`, and a namespace design that decides what is *shared* across the team versus
+# *private* to one agent.
+#
+# > **LlamaIndex API note:** The agents have no tools — they reason over text — so the
+# > multi-agent mechanics live entirely in how we route their I/O through the shared
+# > AgentCore `MemoryClient` (`create_event` / `retrieve_memories`). This keeps the
+# > shared-memory pattern explicit and framework-neutral, mirroring the LangGraph and
+# > Claude SDK multi-agent tutorials. (Note: a single agent would instead use the
+# > `Memory` + `BaseMemoryBlock` API shown in the single-agent tutorials —
+# > `ChatMemoryBuffer` is deprecated.)
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term, Multi-agent                                                           |
+# | Agent usecase       | Research Team (Researcher → Analyst → Report Writer)                              |
+# | Agentic Framework   | LlamaIndex (`FunctionAgent`)                                                     |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Strategies          | Semantic (facts) — **built-in** (no IAM execution role)                          |
+# | Memory components    | One shared memory_id, per-agent actor_id, shared vs private namespaces, create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Share ONE AgentCore Memory resource across multiple independent LlamaIndex agents
+# - Give each agent its own `actor_id` while all agents target the same `memory_id`
+# - Design namespaces so some knowledge is **team-shared** and some is **agent-private**
+# - Hand off work between agents: Agent B retrieves what Agent A stored (producer/consumer)
+# - Orchestrate a sequential pipeline where each agent builds on the previous one's output
+#
+# ## How memory is shared (the core idea)
+#
+# A memory resource is identified by a plain `memory_id`. Three identifiers decide
+# who-can-see-what:
+#
+# | Identifier    | Role in a multi-agent system                                                  |
+# |---------------|-------------------------------------------------------------------------------|
+# | `memory_id`   | The shared resource. SAME for every agent — this is what makes memory shared. |
+# | `actor_id`    | WHO is writing/reading. Each agent has a distinct one, PLUS a team identity.  |
+# | `namespace`   | WHERE records land. `{actorId}` is substituted from the event's `actor_id`.   |
+#
+# The namespace template `"/research-team/{actorId}/knowledge/"` has its `{actorId}`
+# placeholder filled from the `actor_id` passed to `create_event`. So the SAME template
+# produces a SHARED pool or a PRIVATE slice depending only on which actor_id you write under:
+#
+#   • Write with actor_id="team-shared"     → "/research-team/team-shared/knowledge/"
+#       → the TEAM BLACKBOARD every agent reads from and writes to.
+#   • Write with actor_id="research-agent"  → "/research-team/research-agent/knowledge/"
+#       → that agent's PRIVATE scratchpad, isolated from the others.
+#
+# Agent B "sees" Agent A's work because B retrieves from the shared blackboard that A wrote
+# to — not because they share a conversation (they don't). This is the producer/consumer
+# pattern, with AgentCore Memory as the channel.
+#
+# ## Architecture
+#
+# ```
+#            ┌───────────────────────────────────────────────────────────────┐
+#            │           ONE shared AgentCore Memory  (single memory_id)       │
+#            │                                                                 │
+#            │   SHARED namespace  (actor_id = "team-shared")                  │
+#            │     /research-team/team-shared/knowledge/   ◀── team blackboard │
+#            │                                                                 │
+#            │   PRIVATE namespaces (actor_id = each agent)                    │
+#            │     /research-team/research-agent/knowledge/                    │
+#            │     /research-team/analyst-agent/knowledge/                     │
+#            └───────────────────────────────────────────────────────────────┘
+#                 ▲ write          ▲ read+write          ▲ read
+#                 │ shared         │ shared              │ shared
+#     ┌───────────┴──────┐ ┌───────┴──────────┐ ┌────────┴─────────┐
+#     │  Research Agent  │ │  Analyst Agent   │ │  Report Agent    │
+#     │  actor: research │ │  actor: analyst  │ │  actor: report   │
+#     │  FunctionAgent   │ │  FunctionAgent   │ │  FunctionAgent   │
+#     │  (LlamaIndex)    │ │  (LlamaIndex)    │ │  (LlamaIndex)    │
+#     └──────────────────┘ └──────────────────┘ └──────────────────┘
+#          1. gather            2. synthesize         3. summarize
+#          findings ──▶ memory  read findings ──▶     read findings +
+#                               write synthesis       synthesis ──▶ report
+#
+#   Sequential handoff:  Research ─(wait for extraction)─▶ Analyst ─(wait)─▶ Report
+# ```
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the Bedrock
+#   console under *Model access*, in your chosen region)
+# - No IAM execution role required — we use a **built-in** Semantic strategy.
+# - `pip install -r requirements.txt`
+
+# ## Step 1: Setup and Imports
+
+
+import asyncio as _asyncio
+import logging
+import os
+import time
+from datetime import datetime
+
+# AgentCore Memory client (shared by all agents) + the StrategyType enum + the error we
+# handle when reusing an existing memory.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# LlamaIndex agent + Bedrock LLM. FunctionAgent is the current agent class; the agents here
+# carry no tools, so they reason purely over the prompt + retrieved context.
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.bedrock_converse import BedrockConverse as _BedrockConverseBase
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("llamaindex-multi-agent")
+
+# ---- Configuration --------------------------------------------------------------
+REGION = os.getenv("AWS_REGION", "us-west-2")
+
+# Claude Sonnet 4.6 on Amazon Bedrock. `global.` selects the cross-region inference
+# endpoint; swap the prefix to pin to one region.
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# ---- Actor identities ------------------------------------------------------------
+# Every agent shares the SAME memory_id (created in Step 3). They differ by actor_id. Each
+# agent has its own actor_id for PRIVATE scratch space, plus one "team" actor_id whose
+# namespace is the SHARED blackboard all agents read/write.
+RESEARCH_ACTOR_ID = "research-agent"
+ANALYST_ACTOR_ID = "analyst-agent"
+REPORT_ACTOR_ID = "report-agent"
+SHARED_ACTOR_ID = "team-shared"  # records written under this actor form the team blackboard
+
+# One session ties this pipeline run together. All three agents use the same session_id so
+# the run reads as one coherent collaboration in the event history.
+SESSION_ID = f"research-run-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+# Namespace template. `{actorId}` is substituted at extraction time from the actor_id on the
+# event. The SAME template yields the shared blackboard or a private slice depending only on
+# which actor_id we write under. Always end namespace templates with "/".
+NAMESPACE_TEMPLATE = "/research-team/{actorId}/knowledge/"
+
+# The shared blackboard namespace, fully resolved. This is the channel between agents. We
+# read from the SAME resolved namespace the previous agent wrote to — no namespace drift.
+SHARED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=SHARED_ACTOR_ID)
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event. Because
+# this is a SEQUENTIAL handoff (each agent consumes the previous agent's output), we wait
+# for extraction between stages. We poll but cap the wait.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# The research topic the whole team works on.
+RESEARCH_TOPIC = (
+    "The operational trade-offs of adopting vector databases for "
+    "retrieval-augmented generation (RAG) in production systems."
+)
+
+# Per-agent system prompts. Each agent is a distinct persona with a distinct job in the
+# pipeline. They never share a conversation — only the memory resource.
+RESEARCH_AGENT_PROMPT = (
+    "You are a Research Agent on a research team. Your job is to gather concrete, factual "
+    "findings on the assigned topic: specific capabilities, constraints, costs, and "
+    "trade-offs. Produce a tight set of discrete findings (bullet points), each a "
+    "self-contained, verifiable statement. Do not editorialize or conclude — just surface "
+    "the raw findings for your teammates to build on. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+ANALYST_AGENT_PROMPT = (
+    "You are an Analyst Agent on a research team. Your teammate the Research Agent has "
+    "gathered raw findings, which are provided to you from shared memory. Your job is to "
+    "SYNTHESIZE them: identify themes, tensions, and the decision factors that matter most. "
+    "Produce a short synthesis (3-5 insights), each grounded in the findings you were given. "
+    "Do not invent facts beyond the provided findings. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+REPORT_AGENT_PROMPT = (
+    "You are a Report Agent on a research team. Both the raw findings (from the Research "
+    "Agent) and the synthesis (from the Analyst Agent) are provided to you from shared "
+    "memory. Your job is to write a crisp EXECUTIVE SUMMARY for a busy decision-maker: a "
+    "one-paragraph overview followed by a short, prioritized recommendation list. Ground "
+    "every claim in the provided material. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: A Bedrock LLM that is safe to call from async code
+#
+# `BedrockConverse.achat` uses aiobotocore, which has a credential-loading issue on some
+# Python 3.13 setups. We subclass it to run the synchronous `chat` on a worker thread for
+# every async entry point the agent uses — the same wrapper used by the single-agent
+# LlamaIndex tutorials.
+
+
+class BedrockConverse(_BedrockConverseBase):
+    """Sync-on-thread wrapper to avoid the aiobotocore Python 3.13 credential issue."""
+
+    async def achat(self, messages, **kwargs):
+        return await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+    async def astream_chat(self, messages, **kwargs):
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+        return _gen()
+
+    async def astream_chat_with_tools(
+        self,
+        tools,
+        user_msg=None,
+        chat_history=None,
+        verbose=False,
+        allow_parallel_tool_calls=False,
+        tool_required=False,
+        **kwargs,
+    ):
+        chat_kwargs = self._prepare_chat_with_tools_compat(
+            tools,
+            user_msg=user_msg,
+            chat_history=chat_history,
+            verbose=verbose,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+            tool_required=tool_required,
+            **kwargs,
+        )
+
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, **chat_kwargs)
+
+        return _gen()
+
+
+# ## Step 3: Initialize the shared clients
+#
+# A single Bedrock-backed LLM and a single MemoryClient are reused by all three agents —
+# what differs per agent is the actor_id, system prompt, and `FunctionAgent` instance, not
+# the underlying clients.
+
+
+llm = BedrockConverse(model=MODEL_ID, region_name=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info("✅ Clients initialized for region: %s", REGION)
+
+
+# ## Step 4: Create the shared memory resource (one built-in Semantic strategy)
+#
+# This is the resource ALL agents share. We attach a single built-in **Semantic** strategy
+# whose namespace template is `/research-team/{actorId}/knowledge/`. Because `{actorId}` is
+# substituted from the event's actor_id, this ONE strategy serves both the shared team
+# blackboard (actor_id="team-shared") and each agent's private slice — no separate strategy
+# per agent. Built-in strategies require NO IAM execution role.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create the shared-memory resource with a built-in Semantic strategy, or reuse it."""
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "ResearchTeamKnowledge",
+                "description": "Findings, syntheses, and reports shared across the research team",
+                "namespaces": [NAMESPACE_TEMPLATE],
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # strategies => long-term extraction is enabled
+            description="Shared LTM for the LlamaIndex multi-agent research team tutorial",
+            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info("✅ Created shared memory with built-in Semantic strategy: %s", memory_id)
+        return memory_id
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info("Memory '%s' already exists, retrieving its ID...", name)
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m.get("name") == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info("✅ Reusing existing memory: %s", existing)
+            return existing
+        logger.error("❌ Memory creation failed: %s", e)
+        raise
+
+
+# ## Step 5: Memory read/write helpers (the shared channel)
+#
+# These two helpers are how agents talk to each other. `store_to_memory` writes an agent's
+# output under a given actor_id (which selects shared vs private), and `retrieve_from_memory`
+# reads back from a resolved namespace. They are deliberately thin wrappers over
+# `create_event` / `retrieve_memories` so the multi-agent mechanics stay visible.
+
+
+def store_to_memory(memory_id: str, actor_id: str, text: str, label: str) -> None:
+    """Write an agent's contribution to memory under `actor_id`.
+
+    The actor_id decides WHERE this lands: SHARED_ACTOR_ID writes to the team blackboard; an
+    agent's own actor_id writes to its private slice. Because the memory has a Semantic
+    strategy, this event is asynchronously extracted into long-term records teammates can
+    later retrieve. We write the agent's output as a single USER message.
+    """
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=actor_id,
+            session_id=SESSION_ID,
+            messages=[(text, "USER")],
+        )
+        logger.info("🧠 [%s] stored to memory under actor '%s' (queued for extraction)", label, actor_id)
+    except Exception as e:  # noqa: BLE001 - a single write failure must not kill the pipeline
+        logger.error("Memory save error for %s: %s", label, e)
+
+
+def retrieve_from_memory(memory_id: str, namespace: str, query: str, top_k: int = 10) -> list:
+    """Retrieve extracted records from one fully-resolved namespace.
+
+    `retrieve_memories` runs a semantic search over the namespace and returns the most
+    relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported —
+    so callers substitute `{actorId}` before calling. Each record is a dict whose
+    `content.text` holds the extracted memory.
+    """
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to retrieve from %s: %s", namespace, e)
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info("🔎 Retrieved %d record(s) from %s", len(texts), namespace)
+    return texts
+
+
+def wait_for_records(memory_id: str, namespace: str, query: str) -> None:
+    """Poll a namespace until records surface, or until the max wait elapses.
+
+    This is the SEQUENTIAL handoff barrier: extraction is asynchronous, so before the next
+    agent retrieves the previous agent's output we wait for that output to be extracted into
+    the shared namespace. In production you would not block a pipeline like this between
+    every stage. We block here only so the demo's handoff is deterministic.
+    """
+    logger.info("⏳ Waiting for extraction into %s ...", namespace)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        if retrieve_from_memory(memory_id, namespace, query, top_k=1):
+            logger.info("✅ Records are available — handing off to the next agent")
+            return
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Records did not surface within the wait window. Extraction may still complete "
+        "shortly; the next agent will simply see fewer (or no) records from this stage."
+    )
+
+
+# ## Step 6: Run one agent (a self-contained LlamaIndex FunctionAgent)
+#
+# Each agent is its OWN LlamaIndex agent: its own system prompt, its own actor_id, a fresh
+# invocation. The only thing carried between agents is what passes THROUGH memory. `context`
+# is the text we retrieved from memory for this agent (empty for the first agent); we fold
+# it into the user turn so the agent works from its teammates' output.
+#
+# We deliberately do NOT pass a `memory=` object to `agent.run`: cross-agent state lives in
+# the SHARED AgentCore resource, not in any one agent's LlamaIndex Memory. Each agent runs
+# statelessly and the orchestrator moves knowledge between them through memory (Step 7).
+
+
+async def run_agent(system_prompt: str, task: str, context: str = "") -> str:
+    """Build a LlamaIndex FunctionAgent for this persona, run one turn, and return its reply.
+
+    Args:
+        system_prompt: The agent's persona/role.
+        task: The instruction for this agent.
+        context: Knowledge retrieved from shared memory (the previous agents' output).
+                 Empty for the first agent in the pipeline.
+    """
+    user_content = task
+    if context:
+        user_content = (
+            f"{task}\n\n"
+            f"--- Knowledge from your teammates (retrieved from shared memory) ---\n"
+            f"{context}\n"
+            f"--- End of shared knowledge ---"
+        )
+
+    # Each agent is a standalone FunctionAgent with no tools — it reasons over the prompt +
+    # context. The multi-agent coordination happens OUTSIDE the agent, in how we route its
+    # output and input through the shared memory (Step 7).
+    agent = FunctionAgent(tools=[], llm=llm, system_prompt=system_prompt)
+    response = await agent.run(user_content)
+    return str(response)
+
+
+# ## Step 7: Orchestrate the pipeline
+#
+# Sequential producer/consumer handoff over the shared memory:
+#
+#   1. Research Agent gathers findings → writes them to the SHARED blackboard.
+#      (wait for extraction)
+#   2. Analyst Agent retrieves the findings from the shared blackboard → synthesizes →
+#      writes the synthesis back to the SHARED blackboard.
+#      (wait for extraction)
+#   3. Report Agent retrieves BOTH findings and synthesis from the shared blackboard →
+#      writes the final executive summary.
+#
+# Every retrieve hits the SAME shared namespace the previous agent wrote to — that is how
+# Agent B sees Agent A's work despite never sharing a conversation.
+
+
+async def main() -> None:
+    memory_id = None  # init so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("LlamaIndexMultiAgentSharedMemory")
+        # Brief data-plane propagation pause after the resource goes ACTIVE.
+        time.sleep(10)
+
+        # ---- Stage 1: Research Agent --------------------------------------------
+        # First agent in the pipeline: no upstream context. It gathers findings and
+        # publishes them to the SHARED blackboard so the rest of the team can read them. It
+        # also keeps a copy in its PRIVATE slice to show agent-specific storage.
+        print("\n=== Stage 1: Research Agent (gather findings) ===")
+        findings = await run_agent(
+            system_prompt=RESEARCH_AGENT_PROMPT,
+            task=f"Gather concrete findings on this topic:\n{RESEARCH_TOPIC}",
+        )
+        print(f"Research Agent:\n{findings}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, findings, label="research findings → shared")
+        store_to_memory(memory_id, RESEARCH_ACTOR_ID, findings, label="research findings → private")
+
+        # Wait for the researcher's findings to be extracted before the analyst reads them.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="research findings on the topic")
+
+        # ---- Stage 2: Analyst Agent ---------------------------------------------
+        # Consumes the researcher's findings FROM SHARED MEMORY (it was never in the
+        # researcher's conversation), synthesizes, and publishes the synthesis back.
+        print("=== Stage 2: Analyst Agent (synthesize findings) ===")
+        prior_findings = retrieve_from_memory(
+            memory_id, SHARED_NAMESPACE, query="key findings and trade-offs about vector databases for RAG"
+        )
+        context_for_analyst = "\n".join(f"- {f}" for f in prior_findings)
+        synthesis = await run_agent(
+            system_prompt=ANALYST_AGENT_PROMPT,
+            task="Synthesize the research findings into the insights that matter most.",
+            context=context_for_analyst,
+        )
+        print(f"Analyst Agent:\n{synthesis}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, synthesis, label="analysis synthesis → shared")
+        store_to_memory(memory_id, ANALYST_ACTOR_ID, synthesis, label="analysis synthesis → private")
+
+        # Wait for the synthesis to be extracted before the report agent reads it.
+        wait_for_records(memory_id, SHARED_NAMESPACE, query="synthesis and key insights")
+
+        # ---- Stage 3: Report Agent ----------------------------------------------
+        # Consumes BOTH the findings and the synthesis from shared memory and writes the
+        # final executive summary. A single retrieve over the shared blackboard returns
+        # everything the team has published so far.
+        print("=== Stage 3: Report Agent (write executive summary) ===")
+        all_team_knowledge = retrieve_from_memory(
+            memory_id,
+            SHARED_NAMESPACE,
+            query="research findings and analytical synthesis about vector databases for RAG",
+        )
+        context_for_report = "\n".join(f"- {k}" for k in all_team_knowledge)
+        report = await run_agent(
+            system_prompt=REPORT_AGENT_PROMPT,
+            task="Write the executive summary and prioritized recommendations.",
+            context=context_for_report,
+        )
+        print(f"Report Agent:\n{report}\n")
+        store_to_memory(memory_id, SHARED_ACTOR_ID, report, label="final report → shared")
+        store_to_memory(memory_id, REPORT_ACTOR_ID, report, label="final report → private")
+
+        # ---- Inspect what's in shared vs agent-specific memory ------------------
+        # The shared blackboard now holds the whole team's output; each private slice holds
+        # only that one agent's contribution. This is the shared-vs-isolated view.
+        print("=== What lives in SHARED memory (the team blackboard) ===")
+        for item in retrieve_from_memory(memory_id, SHARED_NAMESPACE, query="everything the team produced"):
+            print(f"  • {item}")
+        print()
+
+        print("=== What lives in the Research Agent's PRIVATE memory ===")
+        research_private_ns = NAMESPACE_TEMPLATE.format(actorId=RESEARCH_ACTOR_ID)
+        for item in retrieve_from_memory(memory_id, research_private_ns, query="this agent's own findings"):
+            print(f"  • {item}")
+        print()
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the demo
+        # finishes. To keep the memory between runs (e.g. to inspect it in the console),
+        # comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info("✅ Deleted memory: %s", memory_id)
+            except Exception as e:  # noqa: BLE001
+                logger.error("Failed to delete memory %s: %s", memory_id, e)
+
+
+if __name__ == "__main__":
+    _asyncio.run(main())

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
@@ -122,11 +122,9 @@ import os
 import time
 from datetime import datetime
 
-# AgentCore Memory client (shared by all agents) + the StrategyType enum + the error we
-# handle when reusing an existing memory.
+# AgentCore Memory client (shared by all agents) + the StrategyType enum.
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # LlamaIndex agent + Bedrock LLM. FunctionAgent is the current agent class; the agents here
 # carry no tools, so they reason purely over the prompt + retrieved context.
@@ -285,30 +283,16 @@ def get_or_create_memory(name: str) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # strategies => long-term extraction is enabled
-            description="Shared LTM for the LlamaIndex multi-agent research team tutorial",
-            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info("✅ Created shared memory with built-in Semantic strategy: %s", memory_id)
-        return memory_id
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info("Memory '%s' already exists, retrieving its ID...", name)
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m.get("name") == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info("✅ Reusing existing memory: %s", existing)
-            return existing
-        logger.error("❌ Memory creation failed: %s", e)
-        raise
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # strategies => long-term extraction is enabled
+        description="Shared LTM for the LlamaIndex multi-agent research team tutorial",
+        event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info("✅ Shared memory with built-in Semantic strategy ready: %s", memory_id)
+    return memory_id
 
 
 # ## Step 5: Memory read/write helpers (the shared channel)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/llamaindex-multi-agent-shared-memory.py
@@ -163,10 +163,11 @@ NAMESPACE_TEMPLATE = "/research-team/{actorId}/knowledge/"
 # read from the SAME resolved namespace the previous agent wrote to — no namespace drift.
 SHARED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=SHARED_ACTOR_ID)
 
-# Long-term extraction is asynchronous — records appear ~30-90s after create_event. Because
-# this is a SEQUENTIAL handoff (each agent consumes the previous agent's output), we wait
-# for extraction between stages. We poll but cap the wait.
-EXTRACTION_MAX_WAIT_SECONDS = 120
+# Long-term extraction is asynchronous — records usually appear ~30-90s after create_event,
+# but the tail runs longer (observed past 2 min). Because this is a SEQUENTIAL handoff (each
+# agent consumes the previous agent's output), we poll for extraction between stages and cap
+# the wait generously so a slow extraction doesn't leave the next agent with an empty board.
+EXTRACTION_MAX_WAIT_SECONDS = 300
 EXTRACTION_POLL_INTERVAL_SECONDS = 15
 
 # The research topic the whole team works on.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-llamaindex-agent/requirements.txt
@@ -1,0 +1,7 @@
+# Multi-agent coordination routes I/O through the AgentCore MemoryClient directly, so only
+# the LlamaIndex agent + Bedrock LLM packages are needed (no Memory/BaseMemoryBlock here —
+# that's the single-agent pattern). ChatMemoryBuffer is deprecated and unused.
+llama-index-core>=0.12.0
+llama-index-llms-bedrock-converse>=0.3.0
+bedrock-agentcore>=0.1.6
+boto3>=1.34.0

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-strands-agent/01-built-in-hook/travel-booking-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-strands-agent/01-built-in-hook/travel-booking-agent/README.md
@@ -1,0 +1,37 @@
+# Long-term memory — Strands multi-agent travel booking
+
+A travel-planning system where a coordinator delegates to specialized **flight** and **hotel** booking agents, all sharing one AgentCore long-term memory resource. Each specialist reads and writes its **own namespace**, building persistent understanding of user preferences over time while sharing the same memory infrastructure.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational (multi-agent) |
+| Agent type | Travel Booking Assistant (coordinator + specialists) |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | User Preference (built-in — no IAM execution role) |
+| Memory components | Shared LTM resource, per-agent namespaces, built-in `AgentCoreMemoryHook` |
+| Complexity | Intermediate |
+
+## What it does
+
+[`travel-booking-assistant.py`](./travel-booking-assistant.py):
+
+1. Creates one shared memory resource with a long-term strategy.
+2. Defines flight and hotel specialists, each scoped to its own namespace.
+3. A coordinator delegates queries to the right specialist.
+4. Preferences extracted in one session are recalled in later ones, per namespace.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Amazon Bedrock AgentCore SDK
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python travel-booking-assistant.py
+```
+
+See the [Strands multi-agent README](../../README.md) for the custom-hook alternative.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/README.md
@@ -1,0 +1,15 @@
+# Long-term memory — single-agent examples
+
+One agent per example, each giving a single agent long-term memory backed by AgentCore. The folders differ by framework; within each, the same three integration patterns recur (built-in, custom, memory-as-tool).
+
+| Framework | Folder | What it demonstrates |
+|---|---|---|
+| Anthropic Claude SDK (no framework) | [`with-claude-sdk/`](./with-claude-sdk/) | Built-in strategies, custom override, memory-as-tool, and episodic memory — all explicit |
+| Strands Agents | [`with-strands-agent/`](./with-strands-agent/) | Built-in hook, custom hook (incl. self-managed strategy), and memory-tool patterns |
+| LangGraph | [`with-langgraph-agent/`](./with-langgraph-agent/) | Built-in callback, custom callbacks (user-preference, episodic), and memory-as-tool |
+| LlamaIndex | [`with-llamaindex-agent/`](./with-llamaindex-agent/) | Built-in memory block, custom memory block, and memory tool |
+
+## Where to go next
+
+- Multi-agent long-term examples: [`../multi-agent/`](../multi-agent/)
+- Long-term memory overview: [`../../README.md`](../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/README.md
@@ -1,0 +1,109 @@
+# Long-term memory — Claude SDK, built-in strategies
+
+A conversation loop built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), wired to AgentCore **long-term memory** using **built-in strategies**.
+
+Short-term memory (see the [`01-short-term-memory`](../../../../../01-short-term-memory/) examples) stores raw conversation turns verbatim. Long-term memory goes a step further: it runs an **asynchronous extraction pipeline** over those turns and distills them into reusable, searchable records — standalone **facts** (Semantic strategy) and stable **user preferences** (User Preference strategy). You don't call a separate "extract" API; attaching strategies to the memory resource makes every `create_event` feed the pipeline automatically.
+
+Because the Anthropic SDK is a stateless API client — no framework, no hooks, no session handling — the full memory lifecycle is explicit and easy to follow: create with strategies → store turns → wait for extraction → retrieve records → inject them into a future session's system prompt.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Personal assistant |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) + User Preference — both **built-in** (no IAM execution role) |
+| Memory components | `create_memory_and_wait` (with strategies), `create_event`, `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Complexity | Intermediate |
+
+## What it does
+
+[`claude-sdk-ltm-semantic.py`](./claude-sdk-ltm-semantic.py):
+
+1. Creates (or reuses) a memory resource with **two built-in strategies** — Semantic and User Preference. No IAM execution role is required.
+2. Runs a first conversation with Claude through Amazon Bedrock, maintaining the `messages[]` array by hand and storing each turn with `create_event` — which queues the turn for long-term extraction.
+3. Polls until the asynchronous extraction surfaces records (~30–90s).
+4. Retrieves the distilled facts and preferences with `retrieve_memories` and prints them.
+5. Starts a **second session with an empty `messages[]` array**, injecting the retrieved long-term records into the system prompt — and shows the agent still recalls the user's name, dietary needs, and interests.
+6. Deletes the memory resource in a `finally` block.
+
+## Architecture
+
+```
+  ┌──────────────┐                              ┌─────────────────────────────┐
+  │  Your code   │ ──── 1. create_event ──────▶ │  AgentCore Memory           │
+  │ (messages[]) │       (each turn)            │                             │
+  │              │                              │  short-term events ──┐      │
+  │              │                              │                      │      │
+  │              │                              │   2. async extraction│      │
+  │              │                              │      (built-in       ▼      │
+  │              │                              │       strategies) long-term │
+  │              │ ◀─── 3. retrieve_memories ── │   • Semantic facts   records│
+  │              │       (per namespace)        │   • User preferences        │
+  └──────┬───────┘                              └─────────────────────────────┘
+         │
+         │ 4. inject records into system prompt, then messages.create(...)
+         ▼
+  ┌──────────────┐
+  │ Claude via   │  5. assistant reply, now personalized from long-term memory
+  │ Amazon       │
+  │ Bedrock      │
+  └──────────────┘
+```
+
+The lifecycle is just a handful of calls, because the SDK gives you nowhere else to hang them:
+
+| Step | Where | How |
+|---|---|---|
+| **Create** | Once, at startup | `create_memory_and_wait(name=..., strategies=[{semanticMemoryStrategy: {...}}, {userPreferenceMemoryStrategy: {...}}])` |
+| **Store** | After each turn | `create_event(memory_id, actor_id, session_id, messages=[(text, "USER"), (text, "ASSISTANT")])` — extraction is triggered automatically |
+| **Wait** | Before first retrieval | Poll `retrieve_memories` until records appear (extraction is asynchronous) |
+| **Retrieve** | On resume / new session | `retrieve_memories(memory_id, namespace="/users/<actor>/facts/", query=..., top_k=...)` |
+| **Inject** | Building the next prompt | Fold retrieved `content.text` records into the `system` prompt |
+
+## The strategies used here
+
+| Strategy | `StrategyType` value | Extracts | Namespace in this tutorial |
+|---|---|---|---|
+| **Semantic** | `semanticMemoryStrategy` | Standalone facts about the user/world | `/users/{actorId}/facts/` |
+| **User Preference** | `userPreferenceMemoryStrategy` | Stable, durable user preferences | `/users/{actorId}/preferences/` |
+
+`{actorId}` is substituted at extraction time, keeping each user's records isolated. Two other built-in strategies exist — **Summary** (`summaryMemoryStrategy`, rolling per-session summaries) and **Episodic** (`episodicMemoryStrategy`, meaningful interaction sequences) — see the [long-term memory README](../../../../README.md).
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions. The `AnthropicBedrock` client and `MemoryClient` both resolve credentials from the standard AWS chain (environment variables, `~/.aws/credentials`, or an instance/role profile).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region. Request it in the Bedrock console under *Model access*. (Model availability varies by region; `us-west-2` is a safe default.)
+- No IAM execution role is required — built-in strategies use AgentCore-managed models for extraction and consolidation.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-ltm-semantic.py
+```
+
+Expected output: a first conversation where the user shares their name, travel plans, dietary preference, and interests; a wait while extraction runs; the extracted facts and preferences printed back; then a "second session" — starting with an empty `messages[]` array — where the agent personalizes its suggestion using only the long-term memory injected into the system prompt. The script then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous. The script polls for up to ~2 minutes; if records haven't surfaced by then it warns and continues (they typically appear shortly after). Re-running retrieval a little later will pick them up. This is expected behavior, not an error.
+
+## Key implementation notes
+
+- **Strategies are what make memory "long-term."** The `create_event` call is identical to the short-term tutorial — attaching strategies to the memory resource is the only difference, and it's what feeds the extraction pipeline.
+- **Built-in strategies need no IAM role.** AgentCore manages the extraction/consolidation models. To swap in your own models or prompts, use the strategy-override examples under `02-long-term-memory`.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept wildcards — substitute `{actorId}` yourself before calling.
+- **The SDK is stateless, so memory is injected via the prompt.** Across sessions, a Claude agent "remembers" by retrieving long-term records and folding them into the `system` prompt — there is no server-side session on the Anthropic side.
+- **Extraction is asynchronous.** Records appear ~30–90s after `create_event`. Don't retrieve immediately; in production you'd retrieve on the user's next interaction, by which point extraction has completed.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a turn raises. Comment out the delete block to keep the memory between runs — `get_or_create_memory` will reuse it by name.
+
+## Where to go next
+
+- The built-in strategy primitives and AWS CLI walkthrough: [`../../../../01-built-in-strategies/`](../../../../01-built-in-strategies/)
+- The long-term memory overview (all strategies, retrieval, namespaces): [`../../../../README.md`](../../../../README.md)
+- The same patterns in a framework: [`../../with-strands-agent/`](../../with-strands-agent/)
+- Short-term memory with the Claude SDK: [`../../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/`](../../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/claude-sdk-ltm-semantic.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/claude-sdk-ltm-semantic.py
@@ -95,11 +95,9 @@ from datetime import datetime
 # Messages API against Bedrock — no Anthropic API key required.
 from anthropic import AnthropicBedrock
 
-# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
-# and the AWS error type we handle during memory creation.
+# AgentCore Memory client and the StrategyType enum (gives us the exact strategy keys).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -157,8 +155,9 @@ logger.info(f"✅ Clients initialized for region: {REGION}")
 #   vegetarian food"). Records land in the preferences namespace.
 #
 # Built-in strategies require NO IAM execution role — AgentCore manages the extraction
-# and consolidation models. `create_memory_and_wait` blocks until the resource is
-# ACTIVE. If a memory with this name already exists, we reuse its ID instead of failing.
+# and consolidation models. `create_or_get_memory` blocks until the resource is ACTIVE,
+# and if a memory with this name already exists it returns the existing one instead of
+# failing, so the demo is safe to re-run.
 
 
 def get_or_create_memory(name: str) -> str:
@@ -182,32 +181,19 @@ def get_or_create_memory(name: str) -> str:
         },
     ]
 
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # Strategies => long-term extraction is enabled
-            description="Long-term memory for the Claude SDK built-in-strategies tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with built-in strategies: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the resource if its name is free and otherwise
+    # returns the existing memory dict, so we don't have to handle the name-clash case
+    # ourselves. It blocks until the resource is ACTIVE.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # Strategies => long-term extraction is enabled
+        description="Long-term memory for the Claude SDK built-in-strategies tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with built-in strategies ready: {memory_id}")
+    return memory_id
 
 
 # ## Step 4: The conversation turn

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/claude-sdk-ltm-semantic.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/claude-sdk-ltm-semantic.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Long-Term Memory — Built-in Strategies)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to build a **conversational agent** using the
+# **Anthropic Claude SDK** (via Amazon Bedrock) with AgentCore **long-term memory**
+# powered by **built-in strategies**. Where short-term memory stores raw conversation
+# turns verbatim (see the 01-short-term-memory examples), long-term memory runs an
+# asynchronous extraction pipeline over those turns and distills them into reusable,
+# searchable records — standalone facts and stable user preferences.
+#
+# Because the Anthropic SDK is a **stateless API client** with NO built-in conversation
+# management or hooks, the integration is fully explicit. We:
+#   1. create a memory resource WITH strategies (SEMANTIC + USER_PREFERENCE),
+#   2. drive a conversation, persisting each turn with `create_event` (the same call
+#      used for short-term memory — adding strategies is what triggers extraction),
+#   3. wait for the asynchronous extraction to run,
+#   4. retrieve the distilled records with `retrieve_memories`, and
+#   5. inject them into the system prompt of a *new* session so the agent recalls the
+#      user across conversations — even with an empty `messages[]` array.
+#
+# **NOTE:** Built-in strategies do NOT require an IAM execution role. AgentCore Memory
+# manages the extraction/consolidation models for you. To customize those models or
+# prompts, see the strategy-override examples under `02-long-term-memory`.
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent type          | Personal Assistant                                                               |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | AgentCore Built-in Strategies (Semantic + User Preference), create_event, retrieve_memories |
+# | Example complexity  | Intermediate                                                                     |
+#
+# You'll learn to:
+# - Create a memory resource with built-in long-term strategies (no IAM role required)
+# - Call Claude through Amazon Bedrock using the `AnthropicBedrock` client
+# - Store each turn with `create_event` to feed the extraction pipeline
+# - Wait for asynchronous extraction, then read records back with `retrieve_memories`
+# - Inject retrieved long-term memories into the system prompt for a future session
+#
+# ## Architecture
+#
+# ```
+#   ┌──────────────┐                              ┌─────────────────────────────┐
+#   │  Your code   │ ──── 1. create_event ──────▶ │  AgentCore Memory           │
+#   │ (messages[]) │       (each turn)            │                             │
+#   │              │                              │  short-term events ──┐      │
+#   │              │                              │                      │      │
+#   │              │                              │   2. async extraction│      │
+#   │              │                              │      (built-in       ▼      │
+#   │              │                              │       strategies) long-term │
+#   │              │ ◀─── 3. retrieve_memories ── │   • Semantic facts   records│
+#   │              │       (per namespace)        │   • User preferences        │
+#   └──────┬───────┘                              └─────────────────────────────┘
+#          │
+#          │ 4. inject records into system prompt, then messages.create(...)
+#          ▼
+#   ┌──────────────┐
+#   │ Claude via   │  5. assistant reply, now personalized from long-term memory
+#   │ Amazon       │
+#   │ Bedrock      │
+#   └──────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the
+#   Bedrock console under Model access, in your chosen region)
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
+# and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-ltm")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+ACTOR_ID = "user_123"  # Any unique identifier for the end-user / agent
+SESSION_ID = "personal_session_001"  # Unique identifier for the first conversation
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# Namespace templates tell AgentCore where each strategy's records are written. The
+# `{actorId}` placeholder is substituted with the actor at extraction time, keeping
+# every user's records isolated. We retrieve from the resolved path (see Step 5).
+# These follow the built-in defaults: facts per-user, preferences per-user.
+SEMANTIC_NAMESPACE = "/users/{actorId}/facts/"
+PREFERENCE_NAMESPACE = "/users/{actorId}/preferences/"
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event.
+# We poll for them (Step 6) but cap the total wait so the demo always finishes.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+SYSTEM_PROMPT = (
+    "You are a helpful personal assistant. Be friendly, concise, and professional. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the Memory Resource (with built-in long-term strategies)
+#
+# This is the key difference from the short-term tutorial. There we passed
+# `strategies=[]` (raw events only). Here we attach two built-in strategies:
+#
+# - **Semantic** — extracts standalone facts about the user/world (e.g. "User is
+#   planning a trip to Japan"). Records land in the semantic namespace.
+# - **User Preference** — extracts stable, durable preferences (e.g. "Prefers
+#   vegetarian food"). Records land in the preferences namespace.
+#
+# Built-in strategies require NO IAM execution role — AgentCore manages the extraction
+# and consolidation models. `create_memory_and_wait` blocks until the resource is
+# ACTIVE. If a memory with this name already exists, we reuse its ID instead of failing.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a memory with built-in long-term strategies, or reuse it if it exists."""
+    # Each strategy is a single-key dict: the key is the strategy type's wire value
+    # (StrategyType.SEMANTIC.value == "semanticMemoryStrategy"), the value configures it.
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "PersonalAssistantFacts",
+                "description": "Captures standalone facts about the user from conversations",
+                "namespaces": [SEMANTIC_NAMESPACE],
+            }
+        },
+        {
+            StrategyType.USER_PREFERENCE.value: {
+                "name": "PersonalAssistantPreferences",
+                "description": "Captures stable user preferences across sessions",
+                "namespaces": [PREFERENCE_NAMESPACE],
+            }
+        },
+    ]
+
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # Strategies => long-term extraction is enabled
+            description="Long-term memory for the Claude SDK built-in-strategies tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with built-in strategies: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 4: The conversation turn
+#
+# Each turn mirrors the short-term tutorial: append the user message, call Claude with
+# the full local history, append the reply, then persist the exchange with
+# `create_event`. The ONLY difference is that, because this memory has strategies
+# attached, every stored event is *also* fed into the long-term extraction pipeline.
+# We don't call a special "extract" API — `create_event` is the trigger.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; we only want the
+    text blocks (this simple assistant defines no tools, so there are no tool_use
+    blocks to handle here).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def chat_turn(memory_id: str, messages: list, user_text: str, system_prompt: str) -> str:
+    """Run a single conversation turn end-to-end and return the assistant's reply."""
+    # 1. Append the user's message to the local conversation state.
+    messages.append({"role": "user", "content": user_text})
+
+    # 2. Call Claude with the full conversation history and (possibly enriched) prompt.
+    response = claude.messages.create(
+        model=MODEL_ID,
+        max_tokens=1024,
+        system=system_prompt,
+        messages=messages,
+    )
+
+    # 3. Extract the reply and append it so the next turn has full context.
+    assistant_text = extract_text(response)
+    messages.append({"role": "assistant", "content": assistant_text})
+
+    # 4. Persist this exchange. Because the memory has strategies, this event will be
+    #    asynchronously processed into long-term semantic/preference records.
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            messages=[
+                (user_text, "USER"),
+                (assistant_text, "ASSISTANT"),
+            ],
+        )
+        logger.info("✅ Stored turn (queued for long-term extraction)")
+    except Exception as e:
+        # Don't crash the conversation if a single write fails; log and continue.
+        logger.error(f"Memory save error: {e}")
+
+    return assistant_text
+
+
+# ## Step 5: Retrieve long-term memories
+#
+# `retrieve_memories` runs a semantic search over a namespace and returns the most
+# relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported,
+# so we substitute `{actorId}` ourselves. Each returned record is a dict whose
+# `content.text` holds the extracted memory and `score` holds the relevance.
+
+
+def retrieve_long_term(memory_id: str, namespace_template: str, query: str, top_k: int = 5) -> list:
+    """Retrieve extracted long-term records from one resolved namespace."""
+    namespace = namespace_template.format(actorId=ACTOR_ID)
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve memories from {namespace}: {e}")
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info(f"✅ Retrieved {len(texts)} record(s) from {namespace}")
+    return texts
+
+
+def build_memory_enriched_prompt(memory_id: str, query: str) -> str:
+    """Fetch long-term records and fold them into a system prompt for a new session.
+
+    This is how a stateless Claude agent gets 'memory' across conversations: we pull
+    the distilled facts/preferences and prepend them as context, so even a brand-new
+    `messages[]` array carries what the agent learned previously.
+    """
+    facts = retrieve_long_term(memory_id, SEMANTIC_NAMESPACE, query)
+    preferences = retrieve_long_term(memory_id, PREFERENCE_NAMESPACE, query)
+
+    if not facts and not preferences:
+        # Nothing extracted yet — fall back to the base prompt.
+        return SYSTEM_PROMPT
+
+    context_lines = ["", "What you remember about this user from previous conversations:"]
+    for fact in facts:
+        context_lines.append(f"- (fact) {fact}")
+    for preference in preferences:
+        context_lines.append(f"- (preference) {preference}")
+    context_lines.append("Use this context to personalize your responses when relevant.")
+
+    return SYSTEM_PROMPT + "\n".join(context_lines)
+
+
+# ## Step 6: Wait for extraction
+#
+# Long-term extraction is asynchronous — records do not exist the instant
+# `create_event` returns. We poll the semantic namespace until records appear or we hit
+# the cap. In production you would not block like this; you'd retrieve on the next user
+# interaction (typically minutes later) by which point extraction has long completed.
+
+
+def wait_for_extraction(memory_id: str) -> None:
+    """Poll until long-term records appear, or until the max wait elapses."""
+    logger.info("⏳ Waiting for asynchronous long-term extraction to complete...")
+    namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            records = memory_client.retrieve_memories(
+                memory_id=memory_id,
+                namespace=namespace,
+                query="user facts and details",
+                top_k=1,
+            )
+            if records:
+                logger.info("✅ Long-term records are available")
+                return
+        except Exception as e:
+            logger.warning(f"Retrieval probe failed (will retry): {e}")
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Extraction did not surface records within the wait window. "
+        "It may still complete shortly — try re-running retrieval later."
+    )
+
+
+# ## Step 7: Run the demo
+#
+# We run a first conversation (which seeds memory), wait for extraction, then start a
+# SECOND session with a fresh `messages[]` array. The second session's system prompt is
+# enriched with the long-term records retrieved from the first — so the agent recalls
+# the user despite having no short-term history loaded.
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("ClaudeSDKLongTermMemory")
+
+        # ---- First conversation: seed long-term memory --------------------------
+        # A fresh conversation. Each turn is stored and queued for extraction.
+        print("\n=== First Conversation (seeding long-term memory) ===")
+        messages: list = []
+        for user_text in [
+            "Hi! My name is Alex and I'm planning a trip to Japan in the spring.",
+            "I'm vegetarian, and I really prefer quiet, off-the-beaten-path places over crowds.",
+            "I also love photography — especially temples and gardens.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = chat_turn(memory_id, messages, user_text, SYSTEM_PROMPT)
+            print(f"Agent: {reply}\n")
+
+        # ---- Wait for the extraction pipeline -----------------------------------
+        wait_for_extraction(memory_id)
+
+        # ---- Inspect the extracted records --------------------------------------
+        print("=== Extracted Long-Term Memory ===")
+        print("Semantic facts:")
+        for fact in retrieve_long_term(memory_id, SEMANTIC_NAMESPACE, "trip plans and personal details"):
+            print(f"  • {fact}")
+        print("User preferences:")
+        for pref in retrieve_long_term(memory_id, PREFERENCE_NAMESPACE, "travel and food preferences"):
+            print(f"  • {pref}")
+        print()
+
+        # ---- Second session: new state, memory injected into the prompt ---------
+        # Simulate the user returning later. We start with an EMPTY messages[] array
+        # (no short-term history) and instead enrich the system prompt with the
+        # long-term records retrieved above. If extraction worked, the agent still
+        # knows the user's name, dietary needs, and interests.
+        print("=== Second Session (new process, long-term memory injected) ===")
+        follow_up = "Can you suggest an activity for my trip?"
+        enriched_prompt = build_memory_enriched_prompt(memory_id, query=follow_up)
+        new_messages: list = []  # No short-term history — memory comes from the prompt.
+
+        print(f"User:  {follow_up}")
+        reply = chat_turn(memory_id, new_messages, follow_up, enriched_prompt)
+        print(f"Agent: {reply}\n")
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/01-built-in-strategies/requirements.txt
@@ -1,0 +1,7 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient used for long-term memory
+# (create_memory_and_wait with strategies, create_event, retrieve_memories).
+bedrock-agentcore

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/README.md
@@ -1,0 +1,174 @@
+# Long-term memory — Claude SDK, custom strategy override
+
+A conversation loop built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), wired to AgentCore **long-term memory** using a **built-in strategy with overrides** (also called a *custom strategy override*).
+
+The companion tutorial [`01-built-in-strategies`](../01-built-in-strategies/) used AgentCore's default, fully-managed extraction. This tutorial keeps that same managed pipeline and its fixed record schema, but **overrides two things per step**: the **Bedrock model** that runs extraction/consolidation, and the **prompt instructions** appended to that step. That lets you steer *what* gets extracted and *which* model does the work — without owning the whole pipeline.
+
+Because the Anthropic SDK is a stateless API client — no framework, no hooks, no session handling — the full memory lifecycle is explicit and easy to follow: create an IAM role → create with a custom override strategy → store turns → wait for extraction → retrieve records → inject them into a future session's system prompt.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Healthcare intake assistant |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategy | Custom semantic override (`customMemoryStrategy` → `semanticOverride`) — **requires an IAM execution role** |
+| Memory components | `create_memory_and_wait` (with a custom override strategy + execution role), `create_event`, `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Complexity | Advanced |
+
+## What is a strategy override?
+
+A built-in strategy (Semantic, Summary, User Preference, Episodic) runs an AgentCore-managed extraction pipeline with a managed model and a managed prompt, producing records in a fixed schema. A **strategy override** wraps that built-in strategy in a `customMemoryStrategy` and lets you replace, per pipeline step:
+
+- **`appendToPrompt`** — instructions *added* to that step's built-in system prompt. The text narrows or clarifies the default behavior; it does **not** replace the whole prompt or change the output schema.
+- **`modelId`** — the Bedrock model AgentCore invokes for that step, **in your account**, via the execution role you provide.
+
+Each built-in strategy has a matching override key — `semanticOverride`, `summaryOverride`, `userPreferenceOverride`, `episodicOverride` — and each exposes the steps that strategy supports (`extraction`, `consolidation`, and for episodic, `reflection`). This tutorial overrides the **extraction** and **consolidation** steps of a `semanticOverride`.
+
+> **The output schema is fixed.** Overrides change *instructions* and *model*, never the record shape. If you need a different schema, use a [self-managed strategy](../../../../03-self-managed-strategy/) instead.
+
+## When to use overrides vs. built-in vs. self-managed
+
+| | **Built-in** (tutorial 01) | **Override** (this tutorial) | **Self-managed** |
+|---|---|---|---|
+| Who runs extraction | AgentCore (managed model) | AgentCore (your model + prompt) | **You** (your Lambda) |
+| IAM execution role | ❌ Not required | ✅ **Required** | ✅ Required |
+| Record schema | Fixed (built-in) | Fixed (built-in) | **Anything you want** |
+| Choose the model | ❌ | ✅ (any Bedrock model) | ✅ (incl. non-Bedrock) |
+| Custom prompts | ❌ | ✅ extraction / consolidation / reflection | ✅ (your own code) |
+| Bedrock billing | AgentCore's account | **Your** account + quotas | Your account |
+| Setup | Minimal | Moderate | Advanced (S3 + SNS + Lambda) |
+
+Reach for an **override** when the default extraction doesn't quite fit but you still want AgentCore to run the loop:
+
+- **Domain-specific extraction** — capture only a narrow slice (clinical facts, financial events, legal entities) and ignore everything else. This tutorial's intake agent extracts medications, allergies, and conditions, and drops the small talk.
+- **Compliance / model pinning** — regulation or policy requires a specific audited model version, or all inference must stay in-region.
+- **Different language or jargon** — your users speak a language or domain vocabulary the default prompt handles poorly; write the extraction instructions to match.
+- **Custom consolidation rules** — define how new records merge with old ones (e.g. "a severe allergy supersedes a mild one for the same substance").
+- **Cost / latency tuning** — Haiku for high-volume, low-margin extraction; Sonnet for nuanced consolidation — independently per step.
+
+Stay with **plain built-in strategies** when the defaults are fine (simpler, no IAM role). Graduate to **self-managed** only when you need a record schema the built-ins can't produce, a non-Bedrock model, or external lookups before deciding what to store.
+
+## What it does
+
+[`claude-sdk-ltm-custom-override.py`](./claude-sdk-ltm-custom-override.py):
+
+1. Creates (or reuses) the **IAM execution role** that override strategies require — with a trust policy for `bedrock-agentcore.amazonaws.com` and `bedrock:InvokeModel` permission. Set `MEMORY_EXECUTION_ROLE_ARN` to reuse an existing role and skip the IAM writes.
+2. Creates (or reuses) a memory resource with a **custom semantic override** — supplying our own `modelId` and `appendToPrompt` for both the **extraction** and **consolidation** steps, and passing `memory_execution_role_arn`.
+3. Runs a first conversation with Claude through Amazon Bedrock, maintaining the `messages[]` array by hand and storing each turn with `create_event` — which queues the turn for extraction by *our* model under *our* prompt.
+4. Polls until the asynchronous extraction surfaces records (override adds an extra model hop, so we wait up to ~2.5 min).
+5. Retrieves the custom-extracted clinical facts with `retrieve_memories` and prints them — the non-clinical small talk should be absent.
+6. Starts a **second session with an empty `messages[]` array**, injecting the retrieved records into the system prompt — and shows the agent already knows the patient's medications and allergies.
+7. Deletes the memory resource in a `finally` block. (The IAM role is left in place — it's cheap and reusable.)
+
+## Architecture
+
+```
+  ┌──────────────┐                              ┌─────────────────────────────────────┐
+  │  Your code   │ ──── 1. create_event ──────▶ │  AgentCore Memory                   │
+  │ (messages[]) │       (each turn)            │                                     │
+  │              │                              │  short-term events ──┐              │
+  │              │                              │                      │              │
+  │              │                              │   2. async extraction│              │
+  │              │                              │      via YOUR model  ▼              │
+  │              │                              │      + YOUR prompt  ┌──────────────┐│
+  │              │                              │      (semanticOverr-│ Bedrock model││
+  │              │                              │       ide)          │ in your acct ││
+  │              │                              │         ▲           └──────┬───────┘│
+  │              │                              │         │ assumes          │        │
+  │              │                              │   memoryExecutionRoleArn   ▼        │
+  │              │ ◀─── 3. retrieve_memories ── │              long-term records      │
+  │              │       (resolved namespace)   │              (custom-extracted)     │
+  └──────┬───────┘                              └─────────────────────────────────────┘
+         │
+         │ 4. inject records into system prompt, then messages.create(...)
+         ▼
+  ┌──────────────┐
+  │ Claude via   │  5. assistant reply, now grounded in custom-extracted long-term memory
+  │ Amazon       │
+  │ Bedrock      │
+  └──────────────┘
+```
+
+The lifecycle is the same handful of calls as tutorial 01, plus the execution role and the override config:
+
+| Step | Where | How |
+|---|---|---|
+| **Role** | Once, before create | IAM role with a `bedrock-agentcore.amazonaws.com` trust policy + `bedrock:InvokeModel` permission |
+| **Create** | Once, at startup | `create_memory_and_wait(name=..., strategies=[{customMemoryStrategy: {configuration: {semanticOverride: {...}}}}], memory_execution_role_arn=...)` |
+| **Store** | After each turn | `create_event(memory_id, actor_id, session_id, messages=[(text, "USER"), (text, "ASSISTANT")])` — identical to built-in; the override only changes how extraction runs |
+| **Wait** | Before first retrieval | Poll `retrieve_memories` until records appear (extraction is asynchronous; overrides add a model hop) |
+| **Retrieve** | On resume / new session | `retrieve_memories(memory_id, namespace="/patients/<actor>/clinical-facts/", query=..., top_k=...)` |
+| **Inject** | Building the next prompt | Fold retrieved `content.text` records into the `system` prompt |
+
+## The override config used here
+
+```python
+{
+    "customMemoryStrategy": {            # StrategyType.CUSTOM.value
+        "name": "ClinicalFactsOverride",
+        "description": "Semantic extraction overridden for clinical intake facts",
+        "namespaces": ["/patients/{actorId}/clinical-facts/"],
+        "configuration": {
+            "semanticOverride": {        # wraps the built-in Semantic strategy
+                "extraction": {
+                    "appendToPrompt": EXTRACTION_ADDENDUM,     # keep clinical facts only
+                    "modelId": OVERRIDE_MODEL_ID,
+                },
+                "consolidation": {
+                    "appendToPrompt": CONSOLIDATION_ADDENDUM,  # merge rules (severity, recency)
+                    "modelId": OVERRIDE_MODEL_ID,
+                },
+            }
+        },
+    }
+}
+```
+
+This is the exact shape the SDK's `MemoryClient.add_custom_semantic_strategy()` helper builds internally, and what the AWS docs document for the `CreateMemory` API. The other override keys (`summaryOverride`, `userPreferenceOverride`, `episodicOverride`) follow the same `{step: {appendToPrompt, modelId}}` structure; `episodicOverride` additionally supports a `reflection` step.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **all three** of: AgentCore Memory permissions, Amazon Bedrock model-invocation permissions, and IAM permissions to create a role (`iam:CreateRole`, `iam:PutRolePolicy`, `iam:GetRole`). The `AnthropicBedrock` client, `MemoryClient`, and `boto3` IAM/STS clients all resolve credentials from the standard AWS chain.
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region — both for the conversation and for the override extraction/consolidation model. Request it in the Bedrock console under *Model access*. (`us-west-2` is a safe default.)
+- An **IAM execution role is required** for override strategies. The script creates one named `AgentCoreMemoryOverrideExecutionRole`; to reuse an existing role instead, set `MEMORY_EXECUTION_ROLE_ARN` and the script skips all IAM writes.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+# Optional: reuse an existing execution role instead of creating one
+export MEMORY_EXECUTION_ROLE_ARN=arn:aws:iam::<acct>:role/<role>
+
+# Optional: use a cheaper/different model for the override steps (defaults to Sonnet 4.6)
+export OVERRIDE_MODEL_ID=global.anthropic.claude-haiku-4-5-20251001-v1:0
+
+python claude-sdk-ltm-custom-override.py
+```
+
+Expected output: a first conversation where the patient mentions traffic (small talk), their medications, an allergy, and family history; a wait while extraction runs with the override model; the extracted **clinical facts** printed back (the traffic remark absent); then a "second session" — starting with an empty `messages[]` array — where the agent confirms the patient's medications and allergy using only the long-term memory injected into the system prompt. The script then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous and an override adds an extra Bedrock hop. The script polls for up to ~2.5 minutes; if records haven't surfaced by then it warns and continues (they typically appear shortly after). Re-running retrieval a little later will pick them up. This is expected behavior, not an error.
+
+## Key implementation notes
+
+- **Overrides require an IAM execution role.** AgentCore assumes it to invoke your chosen Bedrock model. Plain built-in strategies (tutorial 01) need no role; this is the main operational difference.
+- **You pay for the override Bedrock calls.** Override extraction/consolidation invocations bill against *your* account and count against *your* Bedrock quotas. Throttling can cause ingestion to fail — request quota increases and enable memory log delivery to observe ingestion errors.
+- **`appendToPrompt` is additive.** It's appended to the built-in system prompt; write instructions that *narrow* or *clarify* the default, not contradict it. The record schema is fixed.
+- **`create_event` is unchanged.** The write path is identical to built-in strategies — the override only changes how AgentCore processes the stored events. There is no separate "extract" API.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept wildcards — substitute `{actorId}` yourself before calling.
+- **The SDK is stateless, so memory is injected via the prompt.** Across sessions, a Claude agent "remembers" by retrieving long-term records and folding them into the `system` prompt — there is no server-side session on the Anthropic side.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a turn raises. The IAM role is intentionally left in place (cheap and reusable); delete it manually if you no longer need it. Comment out the delete block to keep the memory between runs — `get_or_create_memory` will reuse it by name.
+
+## Where to go next
+
+- The override primitives and AWS CLI walkthrough (boto3 + SDK surfaces): [`../../../../02-strategy-overrides/`](../../../../02-strategy-overrides/)
+- Own the whole pipeline instead — self-managed strategy (S3 + SNS + Lambda): [`../../../../03-self-managed-strategy/`](../../../../03-self-managed-strategy/)
+- The long-term memory overview (all strategies, retrieval, namespaces): [`../../../../README.md`](../../../../README.md)
+- The same override pattern in a framework: [`../../with-strands-agent/02-custom-hook/`](../../with-strands-agent/02-custom-hook/)
+- Built-in strategies with the Claude SDK (start here): [`../01-built-in-strategies/`](../01-built-in-strategies/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/claude-sdk-ltm-custom-override.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/claude-sdk-ltm-custom-override.py
@@ -333,8 +333,9 @@ def create_memory_execution_role() -> str:
 # - `modelId` — the Bedrock model AgentCore invokes for that step (billed to your account).
 #
 # The override keeps the built-in semantic record SCHEMA — only the instructions and the
-# model change. `create_memory_and_wait` blocks until the resource is ACTIVE, and (unlike
-# tutorial 01) we MUST pass `memory_execution_role_arn`.
+# model change. `create_or_get_memory` blocks until the resource is ACTIVE, reuses an
+# existing memory of the same name, and (unlike tutorial 01) we MUST pass
+# `memory_execution_role_arn`.
 
 
 def get_or_create_memory(name: str, execution_role_arn: str) -> str:
@@ -366,32 +367,19 @@ def get_or_create_memory(name: str, execution_role_arn: str) -> str:
         }
     ]
 
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # customMemoryStrategy => override pipeline is enabled
-            description="Long-term memory for the Claude SDK custom-strategy-override tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-            memory_execution_role_arn=execution_role_arn,  # REQUIRED for overrides
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with custom override strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # `create_or_get_memory` creates the memory (waiting until ACTIVE) or, on a name
+    # clash, returns the existing memory dict — so we don't hand-roll the reuse scan.
+    # It passes `memory_execution_role_arn` straight through, which overrides require.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # customMemoryStrategy => override pipeline is enabled
+        description="Long-term memory for the Claude SDK custom-strategy-override tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        memory_execution_role_arn=execution_role_arn,  # REQUIRED for overrides
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with custom override strategy ready: {memory_id}")
+    return memory_id
 
 
 # ## Step 5: The conversation turn
@@ -499,8 +487,7 @@ def build_memory_enriched_prompt(memory_id: str, query: str) -> str:
     for fact in facts:
         context_lines.append(f"- {fact}")
     context_lines.append(
-        "Use this context to avoid re-asking what you already know. Do not provide "
-        "diagnoses or medical advice."
+        "Use this context to avoid re-asking what you already know. Do not provide diagnoses or medical advice."
     )
     return SYSTEM_PROMPT + "\n".join(context_lines)
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/claude-sdk-ltm-custom-override.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/claude-sdk-ltm-custom-override.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Long-Term Memory — Custom Strategy Override)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to build a **conversational agent** using the
+# **Anthropic Claude SDK** (via Amazon Bedrock) with AgentCore **long-term memory**
+# powered by a **built-in strategy with overrides** (also called a *custom strategy
+# override*). The companion tutorial `01-built-in-strategies` used the default
+# AgentCore-managed extraction pipeline. Here we keep that same pipeline and fixed
+# output schema, but override two things:
+#
+#   - the **model** used for each step (extraction / consolidation), and
+#   - the **prompt instructions** appended to that step's system prompt.
+#
+# This is the middle rung of customization. Built-in strategies (tutorial 01) give you
+# zero-config extraction with AgentCore-managed models. Self-managed strategies (the far
+# end — see `02-long-term-memory/03-self-managed-strategy`) hand you the entire pipeline
+# via S3 + SNS + your own Lambda. Overrides sit in between: you keep AgentCore's managed
+# extraction loop and its fixed record schema, but you steer *what* it extracts and
+# *which* model does the work.
+#
+# Because the Anthropic SDK is a **stateless API client** with NO built-in conversation
+# management or hooks, the integration is fully explicit. We:
+#   1. create an IAM execution role (REQUIRED for overrides — Bedrock bills your account),
+#   2. create a memory resource with a CUSTOM strategy wrapping a `semanticOverride`,
+#      supplying our own extraction/consolidation models and prompt addenda,
+#   3. drive a conversation, persisting each turn with `create_event` (the same call used
+#      for built-in strategies — the override only changes how extraction runs),
+#   4. wait for the asynchronous extraction to run with OUR model + prompt,
+#   5. retrieve the custom-extracted records with `retrieve_memories`, and
+#   6. inject them into the system prompt of a *new* session so the agent recalls the
+#      user across conversations.
+#
+# **NOTE:** Built-in *with overrides* strategies REQUIRE an IAM execution role
+# (`memory_execution_role_arn`). AgentCore assumes that role to invoke the Bedrock model
+# you specified, and the invocations bill against YOUR account and quotas. This is the
+# key operational difference from the plain built-in strategies in tutorial 01.
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent type          | Healthcare Intake Assistant                                                      |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | AgentCore Custom Strategy Override (semanticOverride: extraction + consolidation), create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Create the IAM execution role that override strategies require
+# - Create a memory resource with a `customMemoryStrategy` wrapping a `semanticOverride`
+# - Supply your own `modelId` and `appendToPrompt` for extraction AND consolidation
+# - Call Claude through Amazon Bedrock using the `AnthropicBedrock` client
+# - Store each turn with `create_event` — extraction now runs with YOUR model + prompt
+# - Retrieve the domain-scoped records with `retrieve_memories` and inject them downstream
+#
+# ## When to use overrides vs. built-in strategies
+#
+# Reach for a custom strategy override when the *default* extraction doesn't fit, but you
+# still want AgentCore to run the pipeline for you:
+#
+# - **Domain-specific extraction.** You only care about a narrow slice of the conversation
+#   (clinical facts, financial events, legal entities) and want everything else ignored.
+#   This tutorial's healthcare intake agent is exactly this case — extract medications,
+#   allergies, and conditions; ignore chit-chat.
+# - **Compliance / model pinning.** Regulation or policy requires a specific, audited model
+#   version for any LLM that touches user data, or you must keep all inference in-region.
+# - **Different language or tone.** The user base speaks a language (or jargon) the default
+#   prompt doesn't handle well, and you want extraction instructions in that language.
+# - **Custom consolidation rules.** You need explicit rules for how new records merge with
+#   old ones (e.g. "a severe allergy supersedes a mild one"; "prefer the most recent dose").
+# - **Cost / latency tuning.** Swap in Haiku for high-volume, low-margin extraction or
+#   Sonnet for nuanced consolidation — independently per step.
+#
+# Stick with **plain built-in strategies** (tutorial 01) when the defaults are fine: it's
+# simpler and needs no IAM role. Graduate to a **self-managed strategy** only when you need
+# a record schema the built-ins can't produce, a non-Bedrock model, or external lookups
+# before deciding what to store — overrides cannot change the record shape, only the
+# instructions and the model.
+#
+# ## Architecture
+#
+# ```
+#   ┌──────────────┐                              ┌─────────────────────────────────────┐
+#   │  Your code   │ ──── 1. create_event ──────▶ │  AgentCore Memory                   │
+#   │ (messages[]) │       (each turn)            │                                     │
+#   │              │                              │  short-term events ──┐              │
+#   │              │                              │                      │              │
+#   │              │                              │   2. async extraction│              │
+#   │              │                              │      via YOUR model  ▼              │
+#   │              │                              │      + YOUR prompt  ┌──────────────┐│
+#   │              │                              │      (semanticOverr-│ Bedrock model││
+#   │              │                              │       ide)          │ in your acct ││
+#   │              │                              │         ▲           └──────┬───────┘│
+#   │              │                              │         │ assumes          │        │
+#   │              │                              │   memoryExecutionRoleArn   ▼        │
+#   │              │ ◀─── 3. retrieve_memories ── │              long-term records      │
+#   │              │       (resolved namespace)   │              (custom-extracted)     │
+#   └──────┬───────┘                              └─────────────────────────────────────┘
+#          │
+#          │ 4. inject records into system prompt, then messages.create(...)
+#          ▼
+#   ┌──────────────┐
+#   │ Claude via   │  5. assistant reply, now grounded in custom-extracted long-term memory
+#   │ Amazon       │
+#   │ Bedrock      │
+#   └──────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions, Amazon Bedrock model access, AND
+#   IAM permissions to create a role (iam:CreateRole, iam:PutRolePolicy, iam:GetRole) —
+#   or pass an existing role ARN via the MEMORY_EXECUTION_ROLE_ARN environment variable.
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the Bedrock
+#   console under Model access, in your chosen region). The override model you pick must
+#   also be accessible to the execution role.
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import json
+import logging
+import os
+import time
+from datetime import datetime
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# boto3 is used to create the IAM execution role that override strategies require.
+import boto3
+
+# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
+# and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-ltm-override")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for Bedrock, Memory, and IAM
+ACTOR_ID = "patient_456"  # Any unique identifier for the end-user / agent
+SESSION_ID = "intake_session_001"  # Unique identifier for the first conversation
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# The model AgentCore should use for the OVERRIDDEN extraction and consolidation steps.
+# This is the heart of the override: instead of AgentCore's managed default, the
+# extraction pipeline invokes THIS model (in your account, via the execution role).
+# We use the same Sonnet 4.6 endpoint here, but you can pick any Bedrock model the
+# execution role can invoke — e.g. Haiku for cheaper high-volume extraction.
+OVERRIDE_MODEL_ID = os.getenv("OVERRIDE_MODEL_ID", "global.anthropic.claude-sonnet-4-6")
+
+# Namespace template for the custom semantic records. `{actorId}` is substituted at
+# extraction time, keeping every patient's clinical facts isolated. We retrieve from
+# the resolved path (see Step 6).
+CLINICAL_NAMESPACE = "/patients/{actorId}/clinical-facts/"
+
+# Custom prompt addenda. `appendToPrompt` is ADDED to AgentCore's built-in system prompt
+# for each step — it should NARROW or CLARIFY the default behavior, not contradict it.
+# The output record schema is fixed; only these instructions and the model change.
+EXTRACTION_ADDENDUM = (
+    "You are extracting clinical intake facts. Capture ONLY health-relevant information: "
+    "current medications and dosages, drug or food allergies and their severity, active "
+    "diagnoses and chronic conditions, and relevant family medical history. Ignore "
+    "scheduling chit-chat, pleasantries, and any non-clinical content."
+)
+CONSOLIDATION_ADDENDUM = (
+    "When a new clinical fact relates to an existing record, prefer the more recent and "
+    "more specific information. A more severe allergy supersedes a milder one for the "
+    "same substance; an updated dosage supersedes an older dosage for the same medication."
+)
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event.
+# Override strategies can take a little longer (an extra model hop), so we cap generously.
+EXTRACTION_MAX_WAIT_SECONDS = 150
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+SYSTEM_PROMPT = (
+    "You are a careful, friendly healthcare intake assistant. You help patients record "
+    "their medical background before an appointment. Be concise and professional, confirm "
+    "what you heard, and never give medical advice or diagnoses. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+# Name of the IAM execution role we create (or reuse) for override model invocation.
+EXECUTION_ROLE_NAME = "AgentCoreMemoryOverrideExecutionRole"
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the IAM Execution Role (REQUIRED for overrides)
+#
+# Unlike plain built-in strategies, an override strategy makes AgentCore invoke a Bedrock
+# model *in your account*. To allow that, you create an IAM role AgentCore can assume and
+# pass its ARN as `memory_execution_role_arn` when creating the memory. The role needs:
+#
+# - a **trust policy** letting `bedrock-agentcore.amazonaws.com` assume it (scoped to your
+#   account + region), and
+# - a **permissions policy** allowing `bedrock:InvokeModel` /
+#   `bedrock:InvokeModelWithResponseStream` on the override model.
+#
+# These policies mirror the AWS documentation for built-in-with-overrides strategies. If
+# you already have a suitable role, set MEMORY_EXECUTION_ROLE_ARN and we'll use it as-is.
+
+
+def create_memory_execution_role() -> str:
+    """Create (or reuse) the IAM role AgentCore assumes to invoke the override model.
+
+    Returns the role ARN. Honors the MEMORY_EXECUTION_ROLE_ARN env var if set, so you
+    can supply a pre-existing role and skip IAM writes entirely.
+    """
+    preset = os.getenv("MEMORY_EXECUTION_ROLE_ARN")
+    if preset:
+        logger.info(f"✅ Using execution role from MEMORY_EXECUTION_ROLE_ARN: {preset}")
+        return preset
+
+    iam = boto3.client("iam", region_name=REGION)
+    account_id = boto3.client("sts", region_name=REGION).get_caller_identity()["Account"]
+    role_arn = f"arn:aws:iam::{account_id}:role/{EXECUTION_ROLE_NAME}"
+
+    # Trust policy: only the AgentCore Memory service, only for this account + region.
+    trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"Service": ["bedrock-agentcore.amazonaws.com"]},
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "StringEquals": {"aws:SourceAccount": account_id},
+                    "ArnLike": {"aws:SourceArn": f"arn:aws:bedrock-agentcore:{REGION}:{account_id}:*"},
+                },
+            }
+        ],
+    }
+
+    # Permissions policy: invoke Bedrock models, scoped to your own account's resources.
+    permissions_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+                "Resource": [
+                    "arn:aws:bedrock:*::foundation-model/*",
+                    "arn:aws:bedrock:*:*:inference-profile/*",
+                ],
+                "Condition": {"StringEquals": {"aws:ResourceAccount": account_id}},
+            }
+        ],
+    }
+
+    try:
+        # Reuse the role if it already exists.
+        try:
+            iam.get_role(RoleName=EXECUTION_ROLE_NAME)
+            logger.info(f"✅ IAM execution role already exists: {role_arn}")
+            return role_arn
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+
+        logger.info(f"Creating IAM execution role: {EXECUTION_ROLE_NAME}")
+        iam.create_role(
+            RoleName=EXECUTION_ROLE_NAME,
+            AssumeRolePolicyDocument=json.dumps(trust_policy),
+            Description="Execution role for AgentCore Memory custom strategy overrides",
+            Tags=[{"Key": "Purpose", "Value": "AgentCoreMemoryOverride"}],
+        )
+        iam.put_role_policy(
+            RoleName=EXECUTION_ROLE_NAME,
+            PolicyName="AgentCoreMemoryBedrockAccess",
+            PolicyDocument=json.dumps(permissions_policy),
+        )
+        logger.info(f"✅ Created IAM execution role: {role_arn}")
+        # IAM is eventually consistent; give the role a moment to propagate before
+        # AgentCore tries to assume it during memory creation.
+        time.sleep(10)
+        return role_arn
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AccessDenied":
+            logger.error(
+                "❌ Access denied creating the IAM role. Either grant iam:CreateRole / "
+                "iam:PutRolePolicy / iam:GetRole, or set MEMORY_EXECUTION_ROLE_ARN to an "
+                "existing role and re-run."
+            )
+        else:
+            logger.error(f"❌ Failed to create IAM role: {e}")
+        raise
+
+
+# ## Step 4: Create the Memory Resource (with a custom strategy override)
+#
+# This is the key difference from tutorial 01. There we attached a plain
+# `semanticMemoryStrategy`. Here we attach a `customMemoryStrategy` whose configuration
+# wraps a `semanticOverride`. Each step (`extraction`, `consolidation`) takes:
+#
+# - `appendToPrompt` — instructions added to that step's built-in system prompt, and
+# - `modelId` — the Bedrock model AgentCore invokes for that step (billed to your account).
+#
+# The override keeps the built-in semantic record SCHEMA — only the instructions and the
+# model change. `create_memory_and_wait` blocks until the resource is ACTIVE, and (unlike
+# tutorial 01) we MUST pass `memory_execution_role_arn`.
+
+
+def get_or_create_memory(name: str, execution_role_arn: str) -> str:
+    """Create a memory with a custom semantic override strategy, or reuse it if it exists."""
+    # A single-key dict keyed by the CUSTOM strategy's wire value
+    # (StrategyType.CUSTOM.value == "customMemoryStrategy"). The `semanticOverride` block
+    # carries our extraction + consolidation overrides. This is the exact shape the SDK's
+    # `add_custom_semantic_strategy` helper builds, and what the AWS docs document for
+    # `CreateMemory`.
+    strategies = [
+        {
+            StrategyType.CUSTOM.value: {
+                "name": "ClinicalFactsOverride",
+                "description": "Semantic extraction overridden for clinical intake facts",
+                "namespaces": [CLINICAL_NAMESPACE],
+                "configuration": {
+                    "semanticOverride": {
+                        "extraction": {
+                            "appendToPrompt": EXTRACTION_ADDENDUM,
+                            "modelId": OVERRIDE_MODEL_ID,
+                        },
+                        "consolidation": {
+                            "appendToPrompt": CONSOLIDATION_ADDENDUM,
+                            "modelId": OVERRIDE_MODEL_ID,
+                        },
+                    }
+                },
+            }
+        }
+    ]
+
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # customMemoryStrategy => override pipeline is enabled
+            description="Long-term memory for the Claude SDK custom-strategy-override tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+            memory_execution_role_arn=execution_role_arn,  # REQUIRED for overrides
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with custom override strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 5: The conversation turn
+#
+# Each turn mirrors tutorial 01: append the user message, call Claude with the full local
+# history, append the reply, then persist the exchange with `create_event`. The override
+# changes nothing on the WRITE path — `create_event` is identical. The difference is purely
+# on AgentCore's side: extraction now runs with our model and our prompt addendum.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; we only want the
+    text blocks (this simple assistant defines no tools, so there are no tool_use
+    blocks to handle here).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def chat_turn(memory_id: str, messages: list, user_text: str, system_prompt: str) -> str:
+    """Run a single conversation turn end-to-end and return the assistant's reply."""
+    # 1. Append the user's message to the local conversation state.
+    messages.append({"role": "user", "content": user_text})
+
+    # 2. Call Claude with the full conversation history and (possibly enriched) prompt.
+    response = claude.messages.create(
+        model=MODEL_ID,
+        max_tokens=1024,
+        system=system_prompt,
+        messages=messages,
+    )
+
+    # 3. Extract the reply and append it so the next turn has full context.
+    assistant_text = extract_text(response)
+    messages.append({"role": "assistant", "content": assistant_text})
+
+    # 4. Persist this exchange. Because the memory has a custom override strategy, this
+    #    event is asynchronously processed into long-term records by OUR model + prompt.
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            messages=[
+                (user_text, "USER"),
+                (assistant_text, "ASSISTANT"),
+            ],
+        )
+        logger.info("✅ Stored turn (queued for custom-override extraction)")
+    except Exception as e:
+        # Don't crash the conversation if a single write fails; log and continue.
+        logger.error(f"Memory save error: {e}")
+
+    return assistant_text
+
+
+# ## Step 6: Retrieve long-term memories
+#
+# `retrieve_memories` runs a semantic search over a namespace and returns the most
+# relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported,
+# so we substitute `{actorId}` ourselves. Each returned record is a dict whose
+# `content.text` holds the extracted memory and `score` holds the relevance. The records
+# here were produced by our override model under our extraction prompt.
+
+
+def retrieve_long_term(memory_id: str, namespace_template: str, query: str, top_k: int = 5) -> list:
+    """Retrieve custom-extracted long-term records from one resolved namespace."""
+    namespace = namespace_template.format(actorId=ACTOR_ID)
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve memories from {namespace}: {e}")
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info(f"✅ Retrieved {len(texts)} record(s) from {namespace}")
+    return texts
+
+
+def build_memory_enriched_prompt(memory_id: str, query: str) -> str:
+    """Fetch custom-extracted records and fold them into a system prompt for a new session.
+
+    This is how a stateless Claude agent gets 'memory' across conversations: we pull the
+    distilled clinical facts and prepend them as context, so even a brand-new `messages[]`
+    array carries what the agent learned previously.
+    """
+    facts = retrieve_long_term(memory_id, CLINICAL_NAMESPACE, query)
+    if not facts:
+        # Nothing extracted yet — fall back to the base prompt.
+        return SYSTEM_PROMPT
+
+    context_lines = ["", "Clinical background you have on file for this patient:"]
+    for fact in facts:
+        context_lines.append(f"- {fact}")
+    context_lines.append(
+        "Use this context to avoid re-asking what you already know. Do not provide "
+        "diagnoses or medical advice."
+    )
+    return SYSTEM_PROMPT + "\n".join(context_lines)
+
+
+# ## Step 7: Wait for extraction
+#
+# Long-term extraction is asynchronous — records do not exist the instant `create_event`
+# returns, and an override adds an extra model hop. We poll the clinical namespace until
+# records appear or we hit the cap. In production you would not block like this; you'd
+# retrieve on the next user interaction (typically minutes later) by which point
+# extraction has long completed.
+
+
+def wait_for_extraction(memory_id: str) -> None:
+    """Poll until custom-extracted records appear, or until the max wait elapses."""
+    logger.info("⏳ Waiting for asynchronous custom-override extraction to complete...")
+    namespace = CLINICAL_NAMESPACE.format(actorId=ACTOR_ID)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            records = memory_client.retrieve_memories(
+                memory_id=memory_id,
+                namespace=namespace,
+                query="patient clinical facts",
+                top_k=1,
+            )
+            if records:
+                logger.info("✅ Custom-extracted records are available")
+                return
+        except Exception as e:
+            logger.warning(f"Retrieval probe failed (will retry): {e}")
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Extraction did not surface records within the wait window. Override strategies "
+        "invoke Bedrock in your account — if records never appear, check that the execution "
+        "role can invoke the model and that you are not being throttled (enable memory log "
+        "delivery to see ingestion errors)."
+    )
+
+
+# ## Step 8: Run the demo
+#
+# We run a first conversation (which seeds memory), wait for extraction, then start a
+# SECOND session with a fresh `messages[]` array. The second session's system prompt is
+# enriched with the custom-extracted records retrieved from the first — so the agent
+# recalls the patient's clinical background despite having no short-term history loaded.
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        # ---- Required IAM execution role for overrides --------------------------
+        execution_role_arn = create_memory_execution_role()
+
+        memory_id = get_or_create_memory("ClaudeSDKLongTermOverride", execution_role_arn)
+
+        # ---- First conversation: seed long-term memory --------------------------
+        # The override extraction prompt keeps clinical facts and drops the small talk.
+        print("\n=== First Conversation (seeding long-term memory) ===")
+        messages: list = []
+        for user_text in [
+            "Hi, thanks for fitting me in! By the way, traffic was awful this morning.",
+            "I take metformin 500mg twice daily for type 2 diabetes, and lisinopril 10mg "
+            "once a day for blood pressure.",
+            "I'm severely allergic to penicillin — it gives me hives and trouble breathing. "
+            "Also, my mom had breast cancer in her early 50s.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = chat_turn(memory_id, messages, user_text, SYSTEM_PROMPT)
+            print(f"Agent: {reply}\n")
+
+        # ---- Wait for the extraction pipeline -----------------------------------
+        wait_for_extraction(memory_id)
+
+        # ---- Inspect the custom-extracted records -------------------------------
+        # Expect clinical facts (medications, allergy, family history). The traffic
+        # small-talk should NOT appear — the override extraction prompt suppresses it.
+        print("=== Custom-Extracted Long-Term Memory (clinical facts) ===")
+        for fact in retrieve_long_term(memory_id, CLINICAL_NAMESPACE, "medications, allergies, conditions"):
+            print(f"  • {fact}")
+        print("(The 'traffic was awful' small talk should NOT appear — the override drops it.)\n")
+
+        # ---- Second session: new state, memory injected into the prompt ---------
+        # Simulate the patient returning later. We start with an EMPTY messages[] array
+        # (no short-term history) and instead enrich the system prompt with the custom
+        # records retrieved above. If extraction worked, the agent already knows the
+        # patient's medications and allergies.
+        print("=== Second Session (new process, long-term memory injected) ===")
+        follow_up = "I'm here for a follow-up. Can you confirm what you have on file for me?"
+        enriched_prompt = build_memory_enriched_prompt(memory_id, query=follow_up)
+        new_messages: list = []  # No short-term history — memory comes from the prompt.
+
+        print(f"User:  {follow_up}")
+        reply = chat_turn(memory_id, new_messages, follow_up, enriched_prompt)
+        print(f"Agent: {reply}\n")
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        #
+        # NOTE: we intentionally do NOT delete the IAM execution role here — it's cheap,
+        # reusable across runs, and may be shared. Delete it manually if you no longer
+        # need it (detach the inline policy, then delete the role).
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/02-custom-strategy-override/requirements.txt
@@ -1,0 +1,13 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient used for long-term memory
+# (create_memory_and_wait with a custom override strategy, create_event, retrieve_memories).
+bedrock-agentcore
+
+# boto3 is used directly to create the IAM execution role that override strategies
+# require (AgentCore assumes it to invoke your chosen Bedrock model). It is also pulled
+# in transitively by anthropic[bedrock] and bedrock-agentcore, but we list it explicitly
+# because this tutorial imports it.
+boto3

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/README.md
@@ -1,0 +1,133 @@
+# Long-term memory — Claude SDK, memory as a tool
+
+A conversation loop built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), where AgentCore **long-term memory** is exposed as **tools the model decides to call**.
+
+The two companion tutorials wired memory *around* the model. [`01-built-in-strategies`](../01-built-in-strategies/) stored every turn and injected retrieved records into the system prompt; [`02-custom-strategy-override`](../02-custom-strategy-override/) did the same with a customized extraction pipeline. In both, **your code** decided when to save and when to recall. Here we hand that decision to the agent: we define `store_memory` and `recall_memory`, pass them to Claude via the `tools=` parameter, and run the standard **agentic loop** — the model chooses, on its own, when to persist a durable fact and when to search its past knowledge.
+
+Because the Anthropic SDK is a stateless API client — no framework, no hooks, no session handling — the entire loop is explicit. That makes this the clearest possible view of the memory-as-tool pattern: the model asks (via `tool_use` blocks), your loop dispatches to the tool implementations, and AgentCore stores (`create_event`) and retrieves (`retrieve_memories`).
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Personal assistant |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | `create_memory_and_wait` (with a Semantic strategy), `create_event`, `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Tool components | `tools=` parameter, `tool_use` / `tool_result` agentic loop (per Anthropic's spec) |
+| Complexity | Advanced |
+
+## What it does
+
+[`claude-sdk-ltm-memory-tool.py`](./claude-sdk-ltm-memory-tool.py):
+
+1. Creates (or reuses) a memory resource with a built-in **Semantic** strategy. No IAM execution role is required.
+2. Declares two tools — `store_memory` and `recall_memory` — and passes them to Claude on every `messages.create` call.
+3. Runs **Session 1**: a multi-turn conversation where the user shares durable facts (name, dietary restrictions, a training goal). The agent calls `store_memory` on its own as those facts come up — backed by `create_event`.
+4. Polls until the asynchronous extraction surfaces records (~30–90s).
+5. Runs **Session 2**: a brand-new conversation with an **empty `messages[]` array** — no short-term history. The user asks something that depends on the past, and the agent calls `recall_memory` itself (backed by `retrieve_memories`) to recover the context before answering.
+6. Deletes the memory resource in a `finally` block.
+
+Crucially, the demo never injects memory into the prompt and never calls `create_event` / `retrieve_memories` directly in the conversation flow — **every memory operation happens because the model asked for it.**
+
+## Architecture
+
+```
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │  Agentic loop (your code)                                                  │
+  │                                                                            │
+  │   messages.create(tools=[store_memory, recall_memory]) ──▶ Claude (Bedrock)│
+  │                          ▲                                      │          │
+  │                          │                                      ▼          │
+  │             tool_result  │                            stop_reason ==       │
+  │             (USER turn)  │                              "tool_use"?        │
+  │                          │                                      │ yes      │
+  │                          │                                      ▼          │
+  │                          │                       ┌──────────────────────┐  │
+  │                          └───────────────────────┤ dispatch tool_use:   │  │
+  │                                                  │  • store_memory      │  │
+  │                                                  │  • recall_memory     │  │
+  │                                                  └──────────┬───────────┘  │
+  └─────────────────────────────────────────────────────────────┼────────────┘
+                                                                  │
+             store_memory → create_event                         │
+             recall_memory → retrieve_memories                   ▼
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │  AgentCore Memory                                                        │
+  │   create_event ──▶ short-term events ──▶ async Semantic extraction ──▶   │
+  │   long-term records ◀── retrieve_memories (semantic search by namespace) │
+  └────────────────────────────────────────────────────────────────────────┘
+```
+
+## The agentic loop (per Anthropic's tool-use spec)
+
+The loop in `run_agent` follows the Messages API tool-use contract exactly:
+
+| Step | What happens |
+|---|---|
+| **1. Call** | `messages.create(model=..., tools=TOOLS, messages=...)` |
+| **2. Echo** | Append the assistant's **full** `response.content` to `messages` — this preserves the `tool_use` blocks the next request must match |
+| **3. Done?** | If `stop_reason != "tool_use"`, the model produced its final answer — return the text |
+| **4. Execute** | For each `tool_use` block, run the tool and build one `tool_result` (matched by `tool_use_id`); set `is_error: true` if it failed |
+| **5. Feed back** | Append all `tool_result` blocks as a single `user` message, then loop |
+
+The loop is bounded by `MAX_TOOL_ITERATIONS` as a guardrail. A well-behaved model finishes in 1–3 iterations.
+
+## The tools
+
+| Tool | Model calls it when… | Backed by |
+|---|---|---|
+| **`store_memory`** | the user shares a durable fact worth remembering across sessions (name, preferences, goals, constraints) | `create_event(memory_id, actor_id, session_id, messages=[(fact, "USER")])` — feeds the Semantic extraction pipeline |
+| **`recall_memory`** | answering well depends on something the user said before (typically at the start of a conversation) | `retrieve_memories(memory_id, namespace="/users/<actor>/facts/", query=..., top_k=...)` |
+
+Tool **descriptions are load-bearing** — Claude decides whether and when to call a tool almost entirely from its description, so each one states its trigger conditions explicitly. The **system prompt** reinforces this: it tells the agent it has memory tools and *when* to use them, doing the steering that tutorials 01/02 did in code.
+
+## Memory-as-tool vs. the other two patterns
+
+| | 01 — Built-in (post-response) | 02 — Custom override | 03 — Memory as a tool (this) |
+|---|---|---|---|
+| **Who decides to store** | Your code, after every turn | Your code, after every turn | **The model**, via `store_memory` |
+| **Who decides to recall** | Your code, at session start | Your code, at session start | **The model**, via `recall_memory` |
+| **How memory reaches the model** | Injected into the system prompt | Injected into the system prompt | Returned as a `tool_result` the model requested |
+| **Control flow** | Linear (store → retrieve → prompt) | Linear | **Agentic loop** (model drives) |
+| **Best when** | You want deterministic, always-on memory | …plus customized extraction | The model should manage its own memory lifecycle |
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions. The `AnthropicBedrock` client and `MemoryClient` both resolve credentials from the standard AWS chain (environment variables, `~/.aws/credentials`, or an instance/role profile).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region. Request it in the Bedrock console under *Model access*. (Model availability varies by region; `us-west-2` is a safe default.)
+- No IAM execution role is required — built-in strategies use AgentCore-managed models for extraction and consolidation.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-ltm-memory-tool.py
+```
+
+Expected output: in **Session 1** the user shares their name, dietary restrictions, and a training goal, and the agent calls `store_memory` (watch for `🧠 store_memory` log lines) as those facts come up. After a wait for extraction, **Session 2** starts with an empty `messages[]` array; the agent calls `recall_memory` (watch for the `🔎 recall_memory` log line) and uses the recovered facts to suggest a vegetarian, high-protein, shellfish-free dinner — despite having no short-term history. The script then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous. A fact saved in one turn is **not** instantly searchable in the next — that's why the demo seeds memory in Session 1, waits, then recalls in Session 2. The script polls for up to ~2 minutes; if records haven't surfaced by then it warns and continues (they typically appear shortly after). This is expected behavior, not an error.
+
+## Key implementation notes
+
+- **The model owns the lifecycle.** Storage and recall happen only when the model emits a `tool_use` block. Your loop dispatches it; AgentCore does the work. There is no code path that stores or recalls on the model's behalf.
+- **Echo `response.content` verbatim.** Appending the assistant's full content (text + `tool_use` blocks) is what lets the API match your `tool_result` blocks on the next request. Extracting only the text would break the loop.
+- **One `tool_result` per `tool_use`, matched by `tool_use_id`.** The API rejects the follow-up if any `tool_use` block lacks a matching result.
+- **Errors go back to the model, not up the stack.** `dispatch_tool` catches exceptions and returns an error `tool_result` (`is_error: true`) so the model can adapt — retry, ask the user, or proceed without the tool.
+- **Store and recall are separated by extraction latency.** `store_memory` queues a fact for asynchronous Semantic extraction; `recall_memory` reads the distilled records. They are not instantaneous round-trips — design conversations (and the demo's two sessions) accordingly.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept wildcards — `recall_memory` substitutes `{actorId}` itself before calling.
+- **Built-in strategies need no IAM role.** AgentCore manages the extraction/consolidation models. To swap in your own models or prompts, see [`02-custom-strategy-override`](../02-custom-strategy-override/).
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a turn raises. Comment out the delete block to keep the memory between runs — `get_or_create_memory` will reuse it by name.
+
+## Where to go next
+
+- The other two integration patterns: [`01-built-in-strategies`](../01-built-in-strategies/), [`02-custom-strategy-override`](../02-custom-strategy-override/)
+- The long-term memory overview (all strategies, retrieval, namespaces): [`../../../../README.md`](../../../../README.md)
+- The same pattern in a framework: [`../../with-strands-agent/03-memory-tool/`](../../with-strands-agent/03-memory-tool/), [`../../with-llamaindex-agent/03-memory-tool/`](../../with-llamaindex-agent/03-memory-tool/)
+- Short-term memory with the Claude SDK: [`../../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/`](../../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/claude-sdk-ltm-memory-tool.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/claude-sdk-ltm-memory-tool.py
@@ -121,11 +121,9 @@ from datetime import datetime
 # Messages API against Bedrock — no Anthropic API key required.
 from anthropic import AnthropicBedrock
 
-# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
-# and the AWS error type we handle during memory creation.
+# AgentCore Memory client and the StrategyType enum (gives us the exact strategy keys).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -410,9 +408,10 @@ def run_agent(memory_id: str, session_id: str, messages: list, user_text: str) -
 # ## Step 5: Create the memory resource, and wait-for-extraction helper
 #
 # We create a memory with a single built-in **Semantic** strategy (no IAM role
-# required), reusing it by name if it already exists. The wait helper polls the
-# semantic namespace until the records `store_memory` queued have been extracted, so the
-# second session's `recall_memory` has something to find.
+# required) via `create_or_get_memory`, which returns the existing memory by name if it
+# already exists. The wait helper polls the semantic namespace until the records
+# `store_memory` queued have been extracted, so the second session's `recall_memory` has
+# something to find.
 
 
 def get_or_create_memory(name: str) -> str:
@@ -429,32 +428,19 @@ def get_or_create_memory(name: str) -> str:
         }
     ]
 
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # Strategies => long-term extraction is enabled
-            description="Long-term memory for the Claude SDK memory-as-tool tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # `create_or_get_memory` creates the resource, or returns the existing one if a
+    # memory with this name already exists — so we don't hand-roll the "already exists"
+    # path ourselves. Either way we get the memory dict back, keyed by "id".
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # Strategies => long-term extraction is enabled
+        description="Long-term memory for the Claude SDK memory-as-tool tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with built-in Semantic strategy ready: {memory_id}")
+    return memory_id
 
 
 def wait_for_extraction(memory_id: str) -> None:

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/claude-sdk-ltm-memory-tool.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/claude-sdk-ltm-memory-tool.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Long-Term Memory — Memory as a Tool)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to build a **conversational agent** using the
+# **Anthropic Claude SDK** (via Amazon Bedrock) with AgentCore **long-term memory**
+# exposed as **tools the model decides to call**. The two companion tutorials wired
+# memory in *around* the model: `01-built-in-strategies` stored every turn and
+# injected retrieved records into the system prompt; `02-custom-strategy-override`
+# did the same with a customized extraction pipeline. In both, *your code* decided
+# when to save and when to recall.
+#
+# Here we hand that decision to the agent. We define two tools —
+# `store_memory` and `recall_memory` — and pass them to Claude via the `tools=`
+# parameter. Claude chooses, on its own, when to persist a durable fact and when to
+# search its past knowledge, by emitting `tool_use` blocks. We run the standard
+# **agentic loop** (call the model → execute the tools it requested → feed the
+# results back → repeat until it stops asking for tools), and the tool
+# implementations call AgentCore Memory directly: `create_event` to store,
+# `retrieve_memories` to recall.
+#
+# Because the Anthropic SDK is a **stateless API client** with NO built-in
+# conversation management or hooks, the entire loop is explicit. That makes this the
+# clearest possible view of the memory-as-tool pattern: there is no framework
+# deciding anything for you — the model asks, your loop dispatches, AgentCore stores
+# and retrieves.
+#
+# **NOTE:** We use a built-in **Semantic** strategy, so `store_memory`'s `create_event`
+# call feeds the same asynchronous extraction pipeline used in tutorial 01, and
+# `recall_memory`'s `retrieve_memories` reads the distilled records back. Built-in
+# strategies require NO IAM execution role. Extraction is asynchronous (~30-90s), so a
+# fact saved in one turn is not instantly searchable in the next — we therefore seed
+# memory in a first session, wait for extraction, then show a *new* session where the
+# agent recalls across the gap (exactly how it behaves in production).
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent type          | Personal Assistant                                                               |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | AgentCore Built-in Semantic strategy, tool use (store_memory + recall_memory), create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Define memory operations (`store_memory`, `recall_memory`) as Claude tools via `tools=`
+# - Run the agentic loop (tool_use → tool_result → continue) per Anthropic's spec
+# - Back those tools with AgentCore Memory: `create_event` to store, `retrieve_memories` to recall
+# - Let the model decide WHEN to save a durable fact and WHEN to search its past knowledge
+# - Show cross-session recall: a fresh session with empty `messages[]` where the agent
+#   recovers context entirely by calling `recall_memory` itself
+#
+# ## Memory-as-tool vs. the other two patterns
+#
+# | | 01 — Built-in (post-response) | 02 — Custom override | 03 — Memory as a tool (this) |
+# |---|---|---|---|
+# | **Who decides to store** | Your code, after every turn | Your code, after every turn | **The model**, via `store_memory` |
+# | **Who decides to recall** | Your code, at session start | Your code, at session start | **The model**, via `recall_memory` |
+# | **How memory reaches the model** | Injected into the system prompt | Injected into the system prompt | Returned as a `tool_result` the model requested |
+# | **Control flow** | Linear (store → retrieve → prompt) | Linear | **Agentic loop** (model drives) |
+# | **Best when** | You want deterministic, always-on memory | …plus customized extraction | The model should manage its own memory lifecycle |
+#
+# ## Architecture
+#
+# ```
+#   ┌──────────────────────────────────────────────────────────────────────────┐
+#   │  Agentic loop (your code)                                                  │
+#   │                                                                            │
+#   │   messages.create(tools=[store_memory, recall_memory]) ──▶ Claude (Bedrock)│
+#   │                          ▲                                      │          │
+#   │                          │                                      ▼          │
+#   │             tool_result  │                            stop_reason ==       │
+#   │             (USER turn)  │                              "tool_use"?        │
+#   │                          │                                      │ yes      │
+#   │                          │                                      ▼          │
+#   │                          │                       ┌──────────────────────┐  │
+#   │                          └───────────────────────┤ dispatch tool_use:   │  │
+#   │                                                  │  • store_memory      │  │
+#   │                                                  │  • recall_memory     │  │
+#   │                                                  └──────────┬───────────┘  │
+#   └─────────────────────────────────────────────────────────────┼────────────┘
+#                                                                   │
+#              store_memory → create_event                          │
+#              recall_memory → retrieve_memories                    ▼
+#   ┌────────────────────────────────────────────────────────────────────────┐
+#   │  AgentCore Memory                                                        │
+#   │   create_event ──▶ short-term events ──▶ async Semantic extraction ──▶   │
+#   │   long-term records ◀── retrieve_memories (semantic search by namespace) │
+#   └────────────────────────────────────────────────────────────────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the
+#   Bedrock console under Model access, in your chosen region)
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
+# and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-ltm-tool")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+ACTOR_ID = "user_789"  # Any unique identifier for the end-user / agent
+
+# Two distinct sessions: the first seeds memory, the second (a "new conversation")
+# recalls across the gap. Both share the same ACTOR_ID — that's what ties a user's
+# long-term records together across sessions.
+SEED_SESSION_ID = "assistant_session_001"
+NEW_SESSION_ID = "assistant_session_002"
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# Namespace template for the semantic records. `{actorId}` is substituted at extraction
+# time, keeping every user's facts isolated. `recall_memory` retrieves from the resolved
+# path (see Step 3). This follows the built-in default: facts per-user.
+SEMANTIC_NAMESPACE = "/users/{actorId}/facts/"
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event.
+# We poll for them (Step 5) but cap the total wait so the demo always finishes.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# Safety bound on the agentic loop. A well-behaved model finishes in 1-3 iterations;
+# the cap guarantees we never spin forever if it keeps requesting tools.
+MAX_TOOL_ITERATIONS = 6
+
+# The system prompt is where we tell the agent it HAS memory tools and WHEN to use
+# them. With the memory-as-tool pattern, this prompt is doing the steering that
+# tutorials 01/02 did in code — be explicit so the model reaches for the tools.
+SYSTEM_PROMPT = (
+    "You are a helpful personal assistant with persistent long-term memory.\n"
+    "\n"
+    "You have two memory tools:\n"
+    "- store_memory: save a durable fact about the user so you can recall it in future "
+    "conversations. Call it whenever the user shares something worth remembering long-term "
+    "— their name, preferences, goals, constraints, important dates. Do NOT store transient "
+    "small talk or things that won't matter later.\n"
+    "- recall_memory: search your long-term memory for facts you saved previously. Call it "
+    "at the START of a conversation, and any time answering well depends on something the "
+    "user may have told you before.\n"
+    "\n"
+    "Use these tools proactively and on your own judgment — the user will not remind you. "
+    "Be friendly, concise, and professional. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Define the memory tools (schemas + implementations)
+#
+# A tool is two things: a JSON-Schema declaration the model sees (name, description,
+# input shape) and a Python function that runs when the model calls it. The model only
+# ever sees the declarations; it emits a `tool_use` block naming a tool and supplying
+# arguments, and our loop (Step 4) routes that to the matching implementation.
+#
+# The descriptions are load-bearing — Claude decides WHETHER and WHEN to call a tool
+# almost entirely from its description, so we state the trigger conditions explicitly.
+
+TOOLS = [
+    {
+        "name": "store_memory",
+        "description": (
+            "Save an important, durable fact about the user to long-term memory so it can "
+            "be recalled in future conversations. Call this whenever the user shares "
+            "information worth remembering across sessions — their name, preferences, goals, "
+            "constraints, or notable personal details. Do NOT call it for transient small "
+            "talk or anything that won't matter later."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "fact": {
+                    "type": "string",
+                    "description": (
+                        "A concise, self-contained statement of the fact to remember, written "
+                        "in the third person. Example: 'The user is vegetarian and allergic to "
+                        "shellfish.'"
+                    ),
+                }
+            },
+            "required": ["fact"],
+        },
+    },
+    {
+        "name": "recall_memory",
+        "description": (
+            "Search your long-term memory for facts you previously saved about the user. Call "
+            "this at the start of a conversation, or whenever answering well depends on "
+            "something the user told you before (preferences, history, personal details). "
+            "Returns the most relevant remembered facts, or a note that none were found."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "What you want to recall, phrased as a search query. "
+                        "Example: 'dietary restrictions and food preferences'."
+                    ),
+                }
+            },
+            "required": ["query"],
+        },
+    },
+]
+
+
+def tool_store_memory(memory_id: str, session_id: str, fact: str) -> str:
+    """Implementation of the `store_memory` tool: persist a fact via create_event.
+
+    We write the fact as a single conversational USER message. Because the memory
+    resource has a Semantic strategy attached, this event feeds the same asynchronous
+    extraction pipeline used in tutorial 01 — `create_event` is the trigger; there is
+    no separate "extract" API. Raises are caught by the dispatcher (Step 4), which
+    reports them back to the model as an error tool_result.
+    """
+    memory_client.create_event(
+        memory_id=memory_id,
+        actor_id=ACTOR_ID,
+        session_id=session_id,
+        messages=[(fact, "USER")],
+    )
+    logger.info(f"🧠 store_memory: queued for extraction — {fact!r}")
+    return f"Saved to long-term memory: {fact}"
+
+
+def tool_recall_memory(memory_id: str, query: str, top_k: int = 5) -> str:
+    """Implementation of the `recall_memory` tool: semantic search via retrieve_memories.
+
+    `retrieve_memories` searches a namespace and returns the most relevant extracted
+    records. The namespace must be FULLY RESOLVED — wildcards are not supported — so we
+    substitute `{actorId}` ourselves. Each record is a dict whose `content.text` holds
+    the extracted memory and `score` holds the relevance. We return a compact,
+    model-readable string (the tool_result content).
+    """
+    namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+    records = memory_client.retrieve_memories(
+        memory_id=memory_id,
+        namespace=namespace,
+        query=query,
+        top_k=top_k,
+    )
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+
+    logger.info(f"🔎 recall_memory: {len(texts)} record(s) for query {query!r}")
+    if not texts:
+        return "No relevant memories found. This may be a new user, or extraction may still be processing."
+    return "Relevant memories about the user:\n" + "\n".join(f"- {t}" for t in texts)
+
+
+def dispatch_tool(name: str, tool_input: dict, memory_id: str, session_id: str) -> tuple:
+    """Route one tool_use block to its implementation.
+
+    Returns (content, is_error). We never let a tool exception crash the loop — instead
+    we hand the error text back to the model as an error tool_result so it can adapt
+    (retry, ask the user, or proceed without the tool), exactly as Anthropic recommends.
+    """
+    try:
+        if name == "store_memory":
+            return tool_store_memory(memory_id, session_id, tool_input["fact"]), False
+        if name == "recall_memory":
+            return tool_recall_memory(memory_id, tool_input["query"]), False
+        # The model invented a tool we don't expose — tell it so.
+        return f"Unknown tool: {name}", True
+    except Exception as e:
+        logger.error(f"Tool '{name}' failed: {e}")
+        return f"Error running {name}: {e}", True
+
+
+# ## Step 4: The agentic loop
+#
+# This is the heart of the memory-as-tool pattern, and it follows Anthropic's tool-use
+# spec exactly:
+#
+#   1. Call `messages.create(...)` with the `tools=` list.
+#   2. Append the assistant's FULL `response.content` to `messages` — this preserves the
+#      `tool_use` blocks the next request needs.
+#   3. If `stop_reason != "tool_use"`, the model is done — return its text.
+#   4. Otherwise, execute every `tool_use` block and append ONE `tool_result` per block
+#      (matched by `tool_use_id`) as a single USER message.
+#   5. Loop. The model now sees the results and continues (it may call more tools, or
+#      produce a final answer).
+#
+# We bound the loop with MAX_TOOL_ITERATIONS as a guardrail.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; here we want only
+    the text blocks (the model may also emit `tool_use` blocks, which the loop handles
+    separately).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def run_agent(memory_id: str, session_id: str, messages: list, user_text: str) -> str:
+    """Run one user turn through the agentic loop and return the assistant's final reply.
+
+    `messages` is the running conversation state (mutated in place). The model may call
+    store_memory / recall_memory zero or more times before producing its final text.
+    """
+    # Append the user's message to the local conversation state.
+    messages.append({"role": "user", "content": user_text})
+
+    final_text = ""
+    for _ in range(MAX_TOOL_ITERATIONS):
+        # 1. Call Claude with the full history and the tool declarations.
+        response = claude.messages.create(
+            model=MODEL_ID,
+            max_tokens=1024,
+            system=SYSTEM_PROMPT,
+            tools=TOOLS,
+            messages=messages,
+        )
+
+        # 2. Append the assistant's full content (text + any tool_use blocks). Passing
+        #    response.content back verbatim preserves the tool_use blocks the API needs
+        #    to match our tool_result blocks on the next request.
+        messages.append({"role": "assistant", "content": response.content})
+
+        # 3. No tool calls => the model is done. Capture its text and stop.
+        if response.stop_reason != "tool_use":
+            final_text = extract_text(response)
+            break
+
+        # 4. Execute every tool_use block and collect one tool_result per block. The
+        #    API requires a matching tool_result (by tool_use_id) for each tool_use.
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                content, is_error = dispatch_tool(block.name, block.input, memory_id, session_id)
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,  # Must match the tool_use block's id
+                        "content": content,
+                        "is_error": is_error,
+                    }
+                )
+
+        # 5. Feed the results back as a single USER turn, then loop so the model can
+        #    continue with the tool output in hand.
+        messages.append({"role": "user", "content": tool_results})
+    else:
+        # The loop hit MAX_TOOL_ITERATIONS without a final answer. Surface whatever text
+        # the last response carried so the caller still gets something.
+        logger.warning("⚠️ Hit MAX_TOOL_ITERATIONS without a final answer.")
+        final_text = final_text or "(stopped: tool-use iteration limit reached)"
+
+    return final_text
+
+
+# ## Step 5: Create the memory resource, and wait-for-extraction helper
+#
+# We create a memory with a single built-in **Semantic** strategy (no IAM role
+# required), reusing it by name if it already exists. The wait helper polls the
+# semantic namespace until the records `store_memory` queued have been extracted, so the
+# second session's `recall_memory` has something to find.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a memory with a built-in Semantic strategy, or reuse it if it exists."""
+    # A single-key dict keyed by the strategy type's wire value
+    # (StrategyType.SEMANTIC.value == "semanticMemoryStrategy").
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "PersonalAssistantFacts",
+                "description": "Captures standalone facts about the user from conversations",
+                "namespaces": [SEMANTIC_NAMESPACE],
+            }
+        }
+    ]
+
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # Strategies => long-term extraction is enabled
+            description="Long-term memory for the Claude SDK memory-as-tool tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+def wait_for_extraction(memory_id: str) -> None:
+    """Poll until long-term records appear, or until the max wait elapses.
+
+    In production you would NOT block like this — the agent simply calls recall_memory on
+    the user's next visit (minutes or days later), by which point extraction has long
+    completed. We block here only so the demo's second session has data to recall.
+    """
+    logger.info("⏳ Waiting for asynchronous long-term extraction to complete...")
+    namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            records = memory_client.retrieve_memories(
+                memory_id=memory_id,
+                namespace=namespace,
+                query="user facts and details",
+                top_k=1,
+            )
+            if records:
+                logger.info("✅ Long-term records are available")
+                return
+        except Exception as e:
+            logger.warning(f"Retrieval probe failed (will retry): {e}")
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Extraction did not surface records within the wait window. "
+        "It may still complete shortly — try re-running retrieval later."
+    )
+
+
+# ## Step 6: Run the demo
+#
+# Two sessions, same ACTOR_ID:
+#
+#   • Session 1 (seed): a multi-turn conversation where the user shares durable facts.
+#     The agent should call `store_memory` on its own as those facts come up.
+#   • (wait for extraction)
+#   • Session 2 (new): a FRESH `messages[]` array — no short-term history at all. The
+#     user asks something that depends on the past. The agent should call `recall_memory`
+#     itself to recover the context, then answer.
+#
+# We never inject memory into the prompt and never call create_event/retrieve_memories
+# directly in the demo flow — every memory operation happens because the MODEL asked.
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("ClaudeSDKMemoryAsTool")
+
+        # ---- Session 1: the agent saves facts as it learns them -----------------
+        print("\n=== Session 1 (the agent decides what to store) ===")
+        seed_messages: list = []
+        for user_text in [
+            "Hi! I'm Sam. I just moved to Seattle and I'm trying to cook at home more.",
+            "I should mention I'm vegetarian, and I'm allergic to shellfish.",
+            "I'm also training for a half marathon in October, so I'm watching my protein intake.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_agent(memory_id, SEED_SESSION_ID, seed_messages, user_text)
+            print(f"Agent: {reply}\n")
+
+        # ---- Wait for the extraction pipeline -----------------------------------
+        wait_for_extraction(memory_id)
+
+        # ---- Session 2: brand-new conversation, the agent recalls on its own ----
+        # Empty messages[] => the agent has NO short-term history. The only way it can
+        # personalize its answer is to call recall_memory itself.
+        print("=== Session 2 (new conversation — the agent decides what to recall) ===")
+        new_messages: list = []
+        for user_text in [
+            "Hey, it's Sam again. Can you suggest a high-protein dinner I could make tonight?",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_agent(memory_id, NEW_SESSION_ID, new_messages, user_text)
+            print(f"Agent: {reply}\n")
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/03-memory-as-tool/requirements.txt
@@ -1,0 +1,7 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient used for long-term memory
+# (create_memory_and_wait with strategies, create_event, retrieve_memories).
+bedrock-agentcore

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/README.md
@@ -1,0 +1,183 @@
+# Long-term memory — Claude SDK, Episodic strategy
+
+A debugging assistant built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), wired to AgentCore **long-term memory** using the built-in **Episodic** strategy.
+
+The earlier built-in-strategies tutorial used **Semantic** memory to distill isolated *facts* about the user. The Episodic strategy is different: it captures whole **episodes** — meaningful, multi-turn interaction sequences that hang together as one event ("debugged a memory leak in the payment service on Tuesday") — and adds a **Reflection** step that derives patterns *across* episodes. That's the distinction this tutorial is built to demonstrate:
+
+- **Semantic** answers *"what facts do I know about this user?"* → "The user runs a Python payment service."
+- **Episodic** answers *"what happened last time, and how did it go?"* → "Last Tuesday we chased a memory leak; root cause was an unbounded cache with no TTL; fixed in v2.4.1." — plus reflections like "unbounded caches are a recurring leak source for this team."
+
+Because the Anthropic SDK is a stateless API client — no framework, no hooks, no session handling — the full memory lifecycle is explicit and easy to follow: create with the Episodic strategy → run multiple sessions (each one episode) → wait for the pipeline → retrieve episodes → inject them into a future session's system prompt.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Debugging assistant |
+| Framework | Anthropic Claude SDK (no framework) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategy | Episodic — **built-in** (`episodicMemoryStrategy`, no IAM execution role) |
+| Memory components | `create_memory_and_wait` (Episodic strategy), `get_memory_strategies`, `create_event` (per session), `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Complexity | Intermediate |
+
+## What it does
+
+[`claude-sdk-ltm-episodic.py`](./claude-sdk-ltm-episodic.py):
+
+1. Creates (or reuses) a memory resource with the **built-in Episodic strategy** — no IAM execution role required — and **verifies at runtime** that an Episodic strategy is actually configured (see "Verifying the strategy" below).
+2. Runs **two distinct debugging sessions** with Claude through Amazon Bedrock. Each session is one **episode**: a multi-turn flow (symptom → hypothesis → isolation → fix), persisted as a single `create_event` so the episode boundary stays clean.
+3. Polls until the asynchronous **Extraction → Consolidation → Reflection** pipeline surfaces episode records (~60–120s; reflection can take longer).
+4. Retrieves the consolidated episodes with `retrieve_memories` and prints them.
+5. Starts a **third session** for a new-but-similar bug, injecting the retrieved episodes into the system prompt — and shows the agent recalling *what happened last time* (the unbounded-cache root cause) rather than investigating cold.
+6. Deletes the memory resource in a `finally` block.
+
+## Architecture
+
+```
+  ┌──────────────┐    1. create_event (per session)     ┌─────────────────────────────┐
+  │  Your code   │ ───  each multi-turn session  ──────▶ │  AgentCore Memory           │
+  │ (messages[]) │      = ONE episode                    │                             │
+  │              │                                       │  short-term events ──┐      │
+  │  session A ──┤                                       │                      │      │
+  │  session B ──┤                                       │  2. async episodic   ▼      │
+  │  session C ──┤                                       │     pipeline:               │
+  │              │                                       │     Extraction →            │
+  │              │                                       │     Consolidation →         │
+  │              │ ◀── 3. retrieve_memories ──────────── │     Reflection   long-term  │
+  │              │     (episodes namespace)              │   • Episodes      records   │
+  └──────┬───────┘                                       │   • Reflections             │
+         │                                               └─────────────────────────────┘
+         │ 4. inject past episodes into system prompt, then messages.create(...)
+         ▼
+  ┌──────────────┐
+  │ Claude via   │  5. assistant reply, now aware of HOW past sessions went
+  │ Amazon       │
+  │ Bedrock      │
+  └──────────────┘
+```
+
+The lifecycle is a handful of calls, because the SDK gives you nowhere else to hang them:
+
+| Step | Where | How |
+|---|---|---|
+| **Create** | Once, at startup | `create_memory_and_wait(name=..., strategies=[{episodicMemoryStrategy: {...}}])` |
+| **Verify** | Right after create | `get_memory_strategies(memory_id)` → assert a strategy `type` contains `EPISODIC` |
+| **Store** | After each session | `create_event(memory_id, actor_id, session_id, messages=[(text, role), ...])` — one event per session = one episode |
+| **Wait** | Before first retrieval | Poll `retrieve_memories` until episodes appear (the pipeline is asynchronous and three-step) |
+| **Retrieve** | On resume / new session | `retrieve_memories(memory_id, namespace="/episodes/<actor>/", query=..., top_k=...)` |
+| **Inject** | Building the next prompt | Fold retrieved episode `content.text` into the `system` prompt |
+
+## How episodic is *actually* configured (the truth)
+
+This section is the heart of the tutorial. The built-in Episodic strategy is a **first-class strategy type** in the SDK — not a flavor of Semantic.
+
+Verified directly in the SDK source, `bedrock_agentcore/memory/constants.py`:
+
+```python
+class StrategyType(Enum):
+    SEMANTIC = "semanticMemoryStrategy"
+    SUMMARY = "summaryMemoryStrategy"
+    USER_PREFERENCE = "userPreferenceMemoryStrategy"
+    EPISODIC = "episodicMemoryStrategy"     # ← the real episodic strategy
+    CUSTOM = "customMemoryStrategy"
+```
+
+So configuring episodic memory is exactly this — a single-key dict whose key is `StrategyType.EPISODIC.value` (`"episodicMemoryStrategy"`):
+
+```python
+strategies = [
+    {
+        StrategyType.EPISODIC.value: {        # "episodicMemoryStrategy"
+            "name": "DebuggingEpisodes",
+            "description": "Captures complete debugging sessions as episodes ...",
+            "namespaces": ["/episodes/{actorId}/"],
+        }
+    }
+]
+memory = client.create_memory_and_wait(name=..., strategies=strategies, event_expiry_days=7)
+```
+
+There is **no `add_episodic_strategy()` helper** on `MemoryClient` (unlike the semantic/preference helpers). You pass the raw `episodicMemoryStrategy` shape to `create_memory_and_wait`, which is the documented pattern in this repo's [`01-built-in-strategies/episodic.py`](../../../../01-built-in-strategies/episodic.py).
+
+### ⚠️ The mistake this tutorial avoids
+
+Several sibling examples in this repository are *named* "episodic" but do **not** configure the Episodic strategy:
+
+| Example | What it's named | What it actually configures |
+|---|---|---|
+| `with-strands-agent/01-built-in-hook/meeting-notes-assistant-using-episodic` | "episodic" | **`SEMANTIC`** (`StrategyType.SEMANTIC.value`) |
+| `with-strands-agent/03-memory-tool/debugging-agent` (`..._episodic_memory.py`) | "episodic" | **`semanticMemoryStrategy`** |
+| `with-langgraph-agent/02-custom-callback/episodic-memory` | "episodic" | **`customMemoryStrategy`** with a `semanticOverride` |
+
+Those configure semantic extraction (standalone facts) and relabel it "episodic." They do not produce episodes or cross-episode reflections from the dedicated pipeline. **This tutorial uses `episodicMemoryStrategy`** — the genuine strategy — and proves it.
+
+### Verifying the strategy at runtime
+
+Don't trust the request you sent — confirm what the service stored. The script calls `get_memory_strategies(memory_id)` after creation and asserts that a strategy's `type` contains `EPISODIC` (the control plane reports the type as the enum-style value `EPISODIC`). If you reuse an existing memory that was created with a different strategy, the script warns loudly instead of silently pretending it's episodic.
+
+You can do the same from the CLI:
+
+```bash
+aws bedrock-agentcore-control get-memory --region "$AWS_REGION" --memory-id "$MEMORY_ID" \
+  --query 'memory.strategies[].type'
+# Expect: [ "EPISODIC" ]
+```
+
+## What makes Episodic different (concepts)
+
+| | Semantic | Episodic |
+|---|---|---|
+| **Captures** | Standalone facts | Whole interaction sequences (episodes) |
+| **Pipeline** | Extraction → Consolidation | Extraction → Consolidation → **Reflection** |
+| **Unit of memory** | A fact | An episode (situation, intent, actions, outcome) + cross-episode reflections |
+| **Answers** | "What do I know?" | "What happened last time, and how did it go?" |
+| **Good for** | Personalization, static knowledge | Stateful multi-session workflows, learning from experience |
+
+The Reflection step is unique to Episodic: after multiple episodes accumulate, AgentCore generates higher-level insights spanning them (recurring root causes, effective strategies, common pitfalls). Reflections and episodes share the namespace prefix; a reflection namespace must be the same as, or a prefix of, the episodic namespace.
+
+### Session boundaries = episode boundaries
+
+The most important implementation detail: **one session is one episode.** We give each debugging session a distinct `session_id` and write its turns with a **single `create_event`** call. Grouping a session's turns into one event hands the episodic pipeline a clean, self-contained sequence to consolidate into exactly one episode. Spreading one logical session across many tiny events, or mixing unrelated sessions under one `session_id`, muddies the episode boundaries.
+
+### Namespace choice
+
+This tutorial uses an **actor-level** namespace, `/episodes/{actorId}/`, rather than the SDK's session-scoped default (`/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}/`). The reason is the use case: "what happened in my *previous* debugging sessions?" requires a single retrieval to span all of a developer's episodes. An actor-level namespace makes every session's episode retrievable together; a session-scoped namespace would isolate each episode to its own session and defeat cross-session recall.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions. The `AnthropicBedrock` client and `MemoryClient` both resolve credentials from the standard AWS chain (environment variables, `~/.aws/credentials`, or an instance/role profile).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region. Request it in the Bedrock console under *Model access*. (Model availability varies by region; `us-west-2` is a safe default.)
+- No IAM execution role is required — built-in strategies (Episodic included) use AgentCore-managed models for extraction, consolidation, and reflection.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-ltm-episodic.py
+```
+
+Expected output: two full debugging sessions (a memory leak, then API timeouts), each stored as an episode; a wait while the episodic pipeline runs; the extracted episodes printed back; then a "third session" for a new-but-similar memory leak — where the agent recalls the earlier unbounded-cache episode and applies the lesson, using only the episodic memory injected into the system prompt. The script then deletes the memory resource.
+
+> **Note on timing:** the episodic pipeline is asynchronous and three-step (Extraction → Consolidation → Reflection), so it takes longer than single-step semantic extraction. The script polls for up to ~3 minutes; if episodes haven't surfaced by then it warns and continues (they typically appear shortly after, and reflections later still). Re-running retrieval a little later will pick them up. This is expected behavior, not an error.
+
+## Key implementation notes
+
+- **The strategy is what makes memory episodic.** The `create_event` call is identical to the semantic and short-term tutorials — attaching the `episodicMemoryStrategy` is the only difference, and it's what routes stored sessions through the episode pipeline.
+- **Verify, don't assume.** The script checks `get_memory_strategies` for an `EPISODIC` type, so a misconfiguration (or a reused memory with the wrong strategy) is caught loudly.
+- **One session = one episode.** Each session gets its own `session_id` and a single `create_event`, keeping episode boundaries clean.
+- **Built-in strategies need no IAM role.** AgentCore manages the extraction/consolidation/reflection models. To swap in your own models or prompts, use the strategy-override examples under `02-long-term-memory` (Episodic override keys: `episodicExtractionOverride`, `episodicConsolidationOverride`, `episodicReflectionOverride`).
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept wildcards — substitute `{actorId}` yourself before calling.
+- **The SDK is stateless, so memory is injected via the prompt.** Across sessions, a Claude agent "remembers" by retrieving episodes and folding them into the `system` prompt — there is no server-side session on the Anthropic side.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if a turn raises. Comment out the delete block to keep the memory between runs (and to let Reflection finish) — `get_or_create_memory` will reuse it by name.
+
+## Where to go next
+
+- The built-in Episodic strategy primitive and AWS CLI walkthrough: [`../../../../01-built-in-strategies/episodic.py`](../../../../01-built-in-strategies/episodic.py) and its [README](../../../../01-built-in-strategies/README.md)
+- The long-term memory overview (all strategies, retrieval, namespaces): [`../../../../README.md`](../../../../README.md)
+- The same Claude SDK patterns: [`../01-built-in-strategies/`](../01-built-in-strategies/) (Semantic), [`../02-custom-strategy-override/`](../02-custom-strategy-override/), [`../03-memory-as-tool/`](../03-memory-as-tool/)
+- Episodic memory in a framework: [`../../with-strands-agent/`](../../with-strands-agent/), [`../../with-langgraph-agent/`](../../with-langgraph-agent/)
+```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/claude-sdk-ltm-episodic.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/claude-sdk-ltm-episodic.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python
+
+# # Claude SDK with AgentCore Memory (Long-Term Memory — Episodic Strategy)
+#
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to build a **debugging assistant** using the
+# **Anthropic Claude SDK** (via Amazon Bedrock) with AgentCore **long-term memory**
+# powered by the **built-in Episodic strategy**. Where the Semantic strategy distills
+# isolated *facts* about the user (see `01-built-in-strategies`), the Episodic strategy
+# captures whole *episodes* — meaningful, multi-turn interaction sequences that hang
+# together as one event ("debugged a memory leak in the payment service on Tuesday").
+#
+# That difference is the whole point of this tutorial:
+#   - **Semantic** answers "what facts do I know about this user?"
+#     → "The user runs a Python payment service."
+#   - **Episodic** answers "what happened last time, and how did it go?"
+#     → "Last Tuesday we chased a memory leak; the root cause was an unbounded cache
+#        with no TTL; fixed in v2.4.1." plus cross-episode **reflections** that surface
+#        patterns ("unbounded caches are a recurring leak source for this team").
+#
+# Because the Anthropic SDK is a **stateless API client** with NO built-in conversation
+# management or hooks, the integration is fully explicit. We:
+#   1. create a memory resource with the EPISODIC strategy,
+#   2. run MULTIPLE distinct debugging sessions with Claude — each session is one
+#      **episode**, persisted turn-by-turn with `create_event`,
+#   3. wait for the asynchronous Extraction → Consolidation → Reflection pipeline,
+#   4. retrieve past episodes with `retrieve_memories`, and
+#   5. inject them into the system prompt of a *new* debugging session so the agent
+#      recalls "what happened last time" — not just static facts.
+#
+# **NOTE:** Built-in strategies (Episodic included) do NOT require an IAM execution role.
+# AgentCore Memory manages the extraction/consolidation/reflection models for you. To
+# customize those models or prompts, see the strategy-override examples under
+# `02-long-term-memory` (the Episodic override key is `episodicMemoryStrategy` inside a
+# `customMemoryStrategy`, with `episodicExtractionOverride` / `episodicConsolidationOverride`
+# / `episodicReflectionOverride` configuration blocks).
+#
+#
+# ### A note on "episodic" examples elsewhere in this repo
+#
+# Some sibling examples are *named* "episodic" but actually configure a **Semantic**
+# strategy (`semanticMemoryStrategy`) or a `customMemoryStrategy` with a semantic
+# override — not the dedicated Episodic strategy. This tutorial deliberately uses the
+# REAL built-in Episodic strategy, whose wire key is `episodicMemoryStrategy`
+# (verified against the SDK: `bedrock_agentcore.memory.constants.StrategyType.EPISODIC`).
+# See the README's "Verifying the strategy" section for how to confirm this at runtime.
+#
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent type          | Debugging Assistant                                                              |
+# | Agentic Framework   | Anthropic Claude SDK (no framework)                                              |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | AgentCore Episodic Strategy, create_event (per session), retrieve_memories       |
+# | Example complexity  | Intermediate                                                                     |
+#
+# You'll learn to:
+# - Create a memory resource with the built-in **Episodic** strategy (no IAM role required)
+# - Call Claude through Amazon Bedrock using the `AnthropicBedrock` client
+# - Run MULTIPLE sessions, each a distinct episode, storing turns with `create_event`
+# - Wait for the asynchronous Extraction → Consolidation → Reflection pipeline
+# - Retrieve past episodes (and cross-episode reflections) with `retrieve_memories`
+# - Inject episodic recall into a new session so the agent knows "what happened last time"
+#
+# ## Architecture
+#
+# ```
+#   ┌──────────────┐    1. create_event (per session)     ┌─────────────────────────────┐
+#   │  Your code   │ ───  each multi-turn session  ──────▶ │  AgentCore Memory           │
+#   │ (messages[]) │      = ONE episode                    │                             │
+#   │              │                                       │  short-term events ──┐      │
+#   │  session A ──┤                                       │                      │      │
+#   │  session B ──┤                                       │  2. async episodic   ▼      │
+#   │  session C ──┤                                       │     pipeline:               │
+#   │              │                                       │     Extraction →            │
+#   │              │                                       │     Consolidation →         │
+#   │              │ ◀── 3. retrieve_memories ──────────── │     Reflection   long-term  │
+#   │              │     (episodes namespace)              │   • Episodes      records   │
+#   └──────┬───────┘                                       │   • Reflections             │
+#          │                                               └─────────────────────────────┘
+#          │ 4. inject past episodes into system prompt, then messages.create(...)
+#          ▼
+#   ┌──────────────┐
+#   │ Claude via   │  5. assistant reply, now aware of HOW past sessions went
+#   │ Amazon       │
+#   │ Bedrock      │
+#   └──────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# To execute this tutorial you will need:
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the
+#   Bedrock console under Model access, in your chosen region)
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Optional
+
+# The Anthropic SDK's Amazon Bedrock client. `pip install "anthropic[bedrock]"`
+# provides this; it signs requests with your AWS credentials (SigV4) and speaks the
+# Messages API against Bedrock — no Anthropic API key required.
+from anthropic import AnthropicBedrock
+
+# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
+# and the AWS error type we handle during memory creation.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("claude-sdk-ltm-episodic")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+ACTOR_ID = "developer_001"  # Any unique identifier for the end-user / agent
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock.
+# The `global.` prefix selects the global (cross-region) inference endpoint, which is
+# the default for Sonnet 4.6 and carries no regional pricing premium. To pin traffic
+# to a region instead, swap the prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# The Episodic strategy writes EPISODE records to this namespace. We use an ACTOR-level
+# template (no {sessionId}) so a single retrieval surfaces episodes from ALL of the
+# developer's past sessions — exactly what "what happened in previous debugging sessions?"
+# needs. `{actorId}` is substituted at extraction time, keeping each developer's episodes
+# isolated. The SDK default for EPISODIC is session-scoped
+# (/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}/); we override it
+# here precisely so episodes accumulate per-actor and remain retrievable across sessions.
+# NOTE: we pass this under `namespaceTemplates` (the current field). The older `namespaces`
+# field was deprecated 2026-03-02 in favor of `namespaceTemplates`; the service stores the
+# same value either way, so the resolved retrieval namespace below is unchanged.
+EPISODIC_NAMESPACE = "/episodes/{actorId}/"
+
+# Cross-episode REFLECTIONS (insights folded across episodes, e.g. "unbounded caches are a
+# recurring leak source for this team") need their own namespace, and the service REQUIRES
+# `reflectionConfiguration` for the episodic strategy — omitting it is the root cause of
+# the CreateMemory ValidationException this tutorial previously hit.
+#
+# The service also enforces a SECOND rule the API model doesn't declare: the reflection
+# namespace "must be the same as or a prefix of the episodic namespace." A disjoint path
+# (e.g. "/reflections/{actorId}/") is rejected. We set the reflection namespace EQUAL to
+# the episode namespace, which satisfies the "same as" rule and keeps this tutorial's
+# single-namespace design intact: both episodes and reflections land in
+# "/episodes/{actorId}/", so one `retrieve_memories` call surfaces both — exactly the
+# "episodes (and cross-episode reflections)" behavior the retrieval code documents.
+# (The repo's working episodic example instead NESTS them — reflection
+# "/meetings/actor/{actorId}/" as a prefix of episode "/meetings/actor/{actorId}/episodes/";
+# either shape is valid. Equal is the smaller change here.)
+REFLECTION_NAMESPACE = EPISODIC_NAMESPACE
+
+# Episodic extraction is asynchronous and runs THREE steps (Extraction → Consolidation →
+# Reflection), so it takes far longer to surface than a single-step semantic extraction.
+# Episodes typically appear ~1 min after a session's events are written, but Reflection
+# can take 10–15 minutes (per AWS guidance and the repo's working episodic examples). We
+# poll but cap the total wait at 15 minutes so the demo reliably surfaces episode records.
+EXTRACTION_MAX_WAIT_SECONDS = 1200  # 20 minutes — episodes observed surfacing ~16 min after seeding
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# Base persona for the assistant. When we resume, we APPEND retrieved episodes to this.
+SYSTEM_PROMPT = (
+    "You are an expert debugging assistant. You help developers diagnose and fix software "
+    "defects methodically: clarify symptoms, form hypotheses, isolate the root cause, and "
+    "confirm the fix. Be concise and concrete. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+
+# ## Step 2: Initialize the Claude (Bedrock) and Memory clients
+#
+# The `AnthropicBedrock` client resolves AWS credentials the same way boto3 does
+# (environment variables, shared `~/.aws/credentials`, or an instance/role profile).
+# We only need to tell it which region to call.
+
+
+claude = AnthropicBedrock(aws_region=REGION)
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ Clients initialized for region: {REGION}")
+
+
+# ## Step 3: Create the Memory Resource (with the built-in EPISODIC strategy)
+#
+# This is the key difference from the semantic tutorial. There we attached Semantic +
+# User Preference strategies, which extract standalone facts. Here we attach the
+# **Episodic** strategy, which captures whole interaction sequences as episodes and runs
+# an extra **Reflection** step to derive cross-episode insights.
+#
+# The strategy is a single-key dict whose key is the wire value of
+# `StrategyType.EPISODIC` — i.e. the literal string `"episodicMemoryStrategy"`. We use
+# the enum (`StrategyType.EPISODIC.value`) rather than hardcoding the string so the code
+# stays correct if the SDK ever changes the wire name.
+#
+# Built-in strategies require NO IAM execution role — AgentCore manages the extraction,
+# consolidation, AND reflection models. `create_memory_and_wait` blocks until the
+# resource is ACTIVE. If a memory with this name already exists, we reuse its ID.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a memory with the built-in Episodic strategy, or reuse it if it exists."""
+    # StrategyType.EPISODIC.value == "episodicMemoryStrategy" (verified in the SDK:
+    # bedrock_agentcore/memory/constants.py). This is the REAL episodic strategy — not a
+    # semantic strategy renamed "episodic", which is a mistake some examples make.
+    strategies = [
+        {
+            StrategyType.EPISODIC.value: {
+                "name": "DebuggingEpisodes",
+                "description": (
+                    "Captures complete debugging sessions as episodes (situation, "
+                    "intent, actions, outcome) and reflects across them to surface "
+                    "recurring root causes and effective strategies."
+                ),
+                # Episode records land here (current field is `namespaceTemplates`; the
+                # legacy `namespaces` field was deprecated 2026-03-02).
+                "namespaceTemplates": [EPISODIC_NAMESPACE],
+                # REQUIRED by the service for the episodic strategy. Omitting this is what
+                # caused the CreateMemory ValidationException. The Reflection step writes
+                # cross-episode insights into this (less-nested) namespace.
+                "reflectionConfiguration": {
+                    "namespaceTemplates": [REFLECTION_NAMESPACE],
+                },
+            }
+        }
+    ]
+
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # Episodic strategy => long-term episode extraction
+            description="Long-term episodic memory for the Claude SDK debugging-assistant tutorial",
+            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with EPISODIC strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        # If the memory already exists, retrieve and reuse its ID.
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        # Any other client error is unexpected — surface it.
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+# ## Step 3b: Verify the configured strategy is actually EPISODIC
+#
+# The whole premise of this tutorial is "use the REAL episodic strategy." So we verify it
+# at runtime instead of trusting the request we sent. `get_memory_strategies` returns the
+# strategies as the service stored them; we assert at least one reports an episodic type.
+# (The control plane reports the strategy `type` as the enum-style value `EPISODIC`.)
+
+
+def verify_episodic_strategy(memory_id: str) -> None:
+    """Confirm the memory actually has an Episodic strategy configured (not Semantic)."""
+    try:
+        strategies = memory_client.get_memory_strategies(memory_id)
+    except Exception as e:
+        logger.warning(f"Could not verify strategies (continuing): {e}")
+        return
+
+    types = [s.get("type") or s.get("memoryStrategyType") or s.get("strategyType") for s in strategies]
+    logger.info(f"Configured strategy types: {types}")
+
+    # Log the namespaces the SERVICE actually stored for the episodic strategy. The SDK
+    # injects a session-scoped default `namespaces` when only `namespaceTemplates` is
+    # passed, so this read-back confirms episodes/reflections land where retrieve_episodes
+    # looks (`/episodes/{actorId}/`). A mismatch here — not "nothing extracted" — would be
+    # the reason retrieval returns zero, so we surface it up front rather than after the
+    # long wait.
+    for s in strategies:
+        stype = s.get("type") or s.get("memoryStrategyType") or s.get("strategyType")
+        if stype and "EPISODIC" in str(stype).upper():
+            episode_ns = s.get("namespaces") or s.get("namespaceTemplates") or []
+            reflection_ns = (s.get("reflectionConfiguration") or {})
+            reflection_ns = reflection_ns.get("namespaces") or reflection_ns.get("namespaceTemplates") or []
+            logger.info(f"   Episode namespaces (as stored):    {episode_ns}")
+            logger.info(f"   Reflection namespaces (as stored): {reflection_ns}")
+            logger.info(f"   Retrieval will query (resolved):   {EPISODIC_NAMESPACE.format(actorId=ACTOR_ID)}")
+
+    if any(t and "EPISODIC" in str(t).upper() for t in types):
+        logger.info("✅ Verified: an EPISODIC strategy is configured on this memory")
+    else:
+        # Don't crash — but make the discrepancy loud, since this is the exact bug the
+        # tutorial is meant to avoid.
+        logger.warning(
+            "⚠️ No EPISODIC strategy detected on this memory (found %s). "
+            "If you reused an existing memory created with a different strategy, "
+            "delete it and re-run so the Episodic strategy is created fresh.",
+            types,
+        )
+
+
+# ## Step 4: Run a debugging session (one episode)
+#
+# Each *session* is one episode. Within a session we run several turns — mirroring the
+# back-and-forth of a real debugging session (symptom → hypothesis → isolation → fix) —
+# keeping the `messages[]` array by hand, exactly like the semantic tutorial. The
+# difference is purely in how AgentCore processes the stored events: the Episodic strategy
+# groups the turns of a session into a coherent episode.
+#
+# We accumulate the (text, role) tuples for the whole session and write them with a SINGLE
+# `create_event` per session. `create_event` accepts the full ordered list of turns, and
+# grouping a session's turns in one event gives the episodic pipeline a clean,
+# self-contained sequence to consolidate into one episode.
+
+
+def extract_text(response) -> str:
+    """Concatenate all text blocks from a Claude response.
+
+    A Messages API response `.content` is a list of content blocks; we only want the
+    text blocks (this assistant defines no tools, so there are no tool_use blocks).
+    """
+    return "".join(block.text for block in response.content if block.type == "text")
+
+
+def run_debugging_session(
+    memory_id: str,
+    session_id: str,
+    user_turns: list,
+    system_prompt: str,
+    tool_note: Optional[str] = None,
+    closing_user_turn: Optional[str] = None,
+) -> list:
+    """Run one multi-turn debugging session and persist it as a single episode.
+
+    Args:
+        memory_id: The AgentCore memory resource ID.
+        session_id: Unique ID for THIS session — this is what scopes the episode.
+        user_turns: Ordered list of user utterances that make up the session.
+        system_prompt: The system prompt (base, or memory-enriched on resume).
+        tool_note: Optional text persisted as a single ``TOOL`` turn after the first
+            exchange. The episodic extractor's prompt is built around tool usage,
+            arguments, and reasoning, and AWS guidance says including ``TOOL`` results
+            "yields optimal results" — so we seed one representative tool observation
+            (e.g. a metrics/log read) into the persisted transcript. This assistant
+            defines no real tools, so the note is added to the *persisted* transcript
+            only; it is NOT sent to Claude (which would require a matching tool_use
+            block), keeping the Messages API call valid.
+        closing_user_turn: Optional final USER utterance appended to the persisted
+            transcript to signal the episode has concluded (e.g. "Thanks, that
+            resolved it. The session is complete."). The extractor decides an episode
+            is complete per-turn "by considering messages in the next turns"; its rule
+            is that with no following turn and no clear conclusion signal, the episode
+            stays "in progress." Ending on an explicit USER closure gives the detector
+            an unambiguous completion signal. Like ``tool_note`` this is added to the
+            persisted transcript only, not the live Claude conversation.
+
+    Returns:
+        The full (text, role) transcript that was persisted, for inspection.
+    """
+    print(f"\n--- Session '{session_id}' (one episode) ---")
+    messages: list = []  # local conversation state for THIS session
+    transcript: list = []  # (text, role) tuples we will persist as one event
+
+    for i, user_text in enumerate(user_turns):
+        # 1. Append the user's message to local conversation state.
+        messages.append({"role": "user", "content": user_text})
+        print(f"User:  {user_text}")
+
+        # 2. Call Claude with the full session history.
+        response = claude.messages.create(
+            model=MODEL_ID,
+            max_tokens=1024,
+            system=system_prompt,
+            messages=messages,
+        )
+
+        # 3. Extract the reply and append it so the next turn has full context.
+        assistant_text = extract_text(response)
+        messages.append({"role": "assistant", "content": assistant_text})
+        print(f"Agent: {assistant_text}\n")
+
+        # 4. Record both turns for the episode transcript.
+        transcript.append((user_text, "USER"))
+        transcript.append((assistant_text, "ASSISTANT"))
+
+        # 4b. After the first exchange, optionally seed a representative TOOL turn into
+        #     the persisted transcript (see ``tool_note`` docstring). Persisted only.
+        if tool_note and i == 0:
+            transcript.append((tool_note, "TOOL"))
+            print(f"Tool:  {tool_note}\n")
+
+    # 4c. Optionally append an explicit closing USER turn so the episodic extractor sees
+    #     a clear "inquiry has concluded" signal — FOLLOWED by a confirming ASSISTANT turn.
+    #     The extractor decides completion per-turn "by considering messages in the next
+    #     turns"; a closing USER turn with NO following turn can still read as "in progress"
+    #     (rule: no next turn + no clear conclusion => not an episode end). Appending a short
+    #     ASSISTANT acknowledgement AFTER the closing USER turn gives the detector the
+    #     "next turn" it needs to mark the episode complete. Verified empirically: episodes
+    #     extract with the trailing ASSISTANT turn, and do not without it. Persisted only.
+    if closing_user_turn:
+        transcript.append((closing_user_turn, "USER"))
+        print(f"User:  {closing_user_turn}\n")
+        closing_ack = "Glad I could help — the root cause and fix are recorded. Closing this debugging session."
+        transcript.append((closing_ack, "ASSISTANT"))
+        print(f"Agent: {closing_ack}\n")
+
+    # 5. Persist the WHOLE session as one event. Because the memory has the Episodic
+    #    strategy, this multi-turn event is asynchronously consolidated into one episode
+    #    (and later folded into cross-episode reflections). Writing the session's turns in
+    #    a single create_event keeps the episode boundary clean: one session => one event
+    #    => one episode.
+    try:
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=session_id,
+            messages=transcript,
+        )
+        logger.info(f"✅ Stored session '{session_id}' ({len(transcript)} turns) for episode extraction")
+    except Exception as e:
+        # Don't crash the demo if a single write fails; log and continue.
+        logger.error(f"Memory save error for session '{session_id}': {e}")
+
+    return transcript
+
+
+# ## Step 5: Retrieve past episodes
+#
+# `retrieve_memories` runs a semantic search over a namespace and returns the most
+# relevant records. The namespace must be FULLY RESOLVED — wildcards are not supported,
+# so we substitute `{actorId}` ourselves. For the Episodic strategy, the returned records
+# are episodes (and cross-episode reflections), each carrying its summary in
+# `content.text`.
+
+
+def retrieve_episodes(memory_id: str, query: str, top_k: int = 5) -> list:
+    """Retrieve past episodes relevant to a query from the resolved episodes namespace."""
+    namespace = EPISODIC_NAMESPACE.format(actorId=ACTOR_ID)
+    try:
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve episodes from {namespace}: {e}")
+        return []
+
+    texts = []
+    for record in records:
+        # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+        content = record.get("content", {})
+        text = content.get("text", "").strip() if isinstance(content, dict) else ""
+        if text:
+            texts.append(text)
+    logger.info(f"✅ Retrieved {len(texts)} episode record(s) from {namespace}")
+    return texts
+
+
+def build_episode_enriched_prompt(memory_id: str, query: str) -> str:
+    """Fetch past episodes and fold them into a system prompt for a new session.
+
+    This is how a stateless Claude agent gains episodic recall across sessions: we pull
+    the consolidated episodes (and reflections) relevant to the current problem and
+    prepend them as context. The agent then knows not just *facts*, but *what happened
+    last time* — which past sessions are relevant, how they were resolved, and what
+    patterns recur.
+    """
+    episodes = retrieve_episodes(memory_id, query)
+
+    if not episodes:
+        # Nothing extracted yet — fall back to the base prompt.
+        return SYSTEM_PROMPT
+
+    context_lines = [
+        "",
+        "Relevant past debugging sessions (episodic memory) — use these to recall what "
+        "happened last time and avoid repeating earlier investigation:",
+    ]
+    for i, episode in enumerate(episodes, 1):
+        context_lines.append(f"- [Past episode {i}] {episode}")
+    context_lines.append(
+        "When a current problem resembles a past episode, reference how it was resolved "
+        "and apply the lesson learned."
+    )
+
+    return SYSTEM_PROMPT + "\n".join(context_lines)
+
+
+# ## Step 6: Wait for the episodic pipeline
+#
+# Episodic extraction is asynchronous and runs THREE steps (Extraction → Consolidation →
+# Reflection), so it takes longer than a single-step semantic extraction. We poll the
+# episodes namespace until records appear or we hit the cap. In production you would not
+# block like this; you'd retrieve on the developer's next session (typically minutes or
+# days later), by which point the pipeline has long completed.
+
+
+def wait_for_episodes(memory_id: str) -> None:
+    """Poll until episode records appear, or until the max wait elapses."""
+    logger.info(
+        "⏳ Waiting up to %d min for asynchronous episodic extraction "
+        "(Extraction → Consolidation → Reflection)...",
+        EXTRACTION_MAX_WAIT_SECONDS // 60,
+    )
+    start = time.time()
+    deadline = start + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        episodes = retrieve_episodes(memory_id, query="debugging session", top_k=1)
+        if episodes:
+            logger.info("✅ Episode records are available after %ds", int(time.time() - start))
+            return
+        elapsed = int(time.time() - start)
+        remaining = int(deadline - time.time())
+        logger.info("   …no episodes yet (elapsed %ds, ~%ds remaining); polling again", elapsed, max(remaining, 0))
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Episodes did not surface within the %d-min wait window. The episodic pipeline "
+        "(especially Reflection) can take 10–15 min — try re-running retrieval later.",
+        EXTRACTION_MAX_WAIT_SECONDS // 60,
+    )
+
+
+# ## Step 7: Run the demo
+#
+# We run TWO distinct debugging sessions (episodes), wait for the episodic pipeline, then
+# start a THIRD session whose system prompt is enriched with the retrieved episodes. The
+# third session demonstrates episodic recall: faced with a new-but-similar bug, the agent
+# recalls *what happened last time* rather than starting cold.
+
+
+# Session 1 (episode A): a memory leak caused by an unbounded cache.
+SESSION_1_TURNS = [
+    "Our payment service's memory usage climbs steadily after the latest deploy until the pod OOM-kills. Where do I start?",
+    "The deploy added a new in-process caching layer for currency-conversion rates.",
+    "You're right — the cache has no eviction. Entries are keyed by request ID, so it grows unbounded. I'll add a TTL and a max size.",
+    "Confirmed fixed in v2.4.1: memory is now flat. The root cause was the unbounded cache with no TTL.",
+]
+# A representative tool observation for episode A (persisted as a TOOL turn). The episodic
+# extractor is built around tool usage/arguments/reasoning, and TOOL results "yield optimal
+# results" per AWS guidance.
+SESSION_1_TOOL_NOTE = (
+    "[tool: read_metrics(service='payment', metric='container_memory_rss_bytes', window='6h')] "
+    "RSS rises monotonically from 180Mi to 1.4Gi over 6h with no plateau; GC pauses normal; "
+    "heap-object histogram shows currency-rate cache entries dominating retained set."
+)
+# An explicit closing USER turn that signals the inquiry has concluded, so the episodic
+# completion detector sees an unambiguous end-of-episode signal as the final turn.
+SESSION_1_CLOSING = "Thanks, that resolved my issue. The session is complete."
+
+# Session 2 (episode B): intermittent API timeouts under load.
+SESSION_2_TURNS = [
+    "The checkout service intermittently times out calling the inventory API, but only under load. Logs show no errors.",
+    "Connection pool size is 10 and we run 50 concurrent workers. Latency spikes correlate with traffic peaks.",
+    "Makes sense — workers are starving on connections. I raised the pool to 64 and added a 2s acquire timeout with retries.",
+    "Resolved. Timeouts disappeared after sizing the connection pool to the worker count.",
+]
+SESSION_2_TOOL_NOTE = (
+    "[tool: query_traces(service='checkout', op='inventory.call', filter='duration>2s', window='1h')] "
+    "Slow spans cluster at traffic peaks; time is spent in 'connection-acquire' (~1.9s), not in the "
+    "downstream call (~40ms); active connections pinned at pool max of 10 while 50 workers run."
+)
+SESSION_2_CLOSING = "Perfect, that fixed it. We can close this out — the session is complete."
+
+
+def main() -> None:
+    memory_id = None  # Initialize so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("ClaudeSDKEpisodicMemory")
+        verify_episodic_strategy(memory_id)
+
+        # ---- Episode A: first debugging session ---------------------------------
+        # A unique session_id scopes this episode. Each session => one episode.
+        print("\n=== Debugging Session 1 (seeding episodic memory) ===")
+        run_debugging_session(
+            memory_id,
+            session_id="debug_session_memory_leak",
+            user_turns=SESSION_1_TURNS,
+            system_prompt=SYSTEM_PROMPT,
+            tool_note=SESSION_1_TOOL_NOTE,
+            closing_user_turn=SESSION_1_CLOSING,
+        )
+
+        # ---- Episode B: second, unrelated debugging session ---------------------
+        print("\n=== Debugging Session 2 (seeding episodic memory) ===")
+        run_debugging_session(
+            memory_id,
+            session_id="debug_session_api_timeout",
+            user_turns=SESSION_2_TURNS,
+            system_prompt=SYSTEM_PROMPT,
+            tool_note=SESSION_2_TOOL_NOTE,
+            closing_user_turn=SESSION_2_CLOSING,
+        )
+
+        # ---- Wait for the episodic pipeline -------------------------------------
+        wait_for_episodes(memory_id)
+
+        # ---- Inspect the extracted episodes -------------------------------------
+        print("\n=== Extracted Episodes (episodic memory) ===")
+        for episode in retrieve_episodes(memory_id, "past debugging sessions and their resolutions"):
+            print(f"  • {episode}")
+        print()
+
+        # ---- Episode C: a NEW session that benefits from episodic recall --------
+        # The new problem (steadily growing memory) resembles episode A. We retrieve past
+        # episodes relevant to this problem and inject them into the system prompt, so the
+        # agent recalls "what happened last time" — the unbounded-cache root cause — rather
+        # than investigating from scratch. This is episodic recall ("what happened") vs.
+        # semantic recall ("what facts do I know").
+        print("=== Debugging Session 3 (new session, episodic memory injected) ===")
+        new_problem = (
+            "A different service — the notifications worker — is now slowly leaking memory "
+            "after we added a per-recipient template cache. Memory climbs until it crashes. "
+            "Have we seen anything like this before, and how should I approach it?"
+        )
+        enriched_prompt = build_episode_enriched_prompt(memory_id, query=new_problem)
+        run_debugging_session(
+            memory_id,
+            session_id="debug_session_notifications_leak",
+            user_turns=[new_problem],
+            system_prompt=enriched_prompt,
+        )
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect episodes in the
+        # console, or to let Reflection finish), comment out the block below —
+        # `get_or_create_memory` will reuse it by name.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/claude-sdk-ltm-episodic.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/claude-sdk-ltm-episodic.py
@@ -119,11 +119,9 @@ from typing import Optional
 # Messages API against Bedrock — no Anthropic API key required.
 from anthropic import AnthropicBedrock
 
-# AgentCore Memory client, the StrategyType enum (gives us the exact strategy keys),
-# and the AWS error type we handle during memory creation.
+# AgentCore Memory client and the StrategyType enum (gives us the exact strategy keys).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -210,8 +208,9 @@ logger.info(f"✅ Clients initialized for region: {REGION}")
 # stays correct if the SDK ever changes the wire name.
 #
 # Built-in strategies require NO IAM execution role — AgentCore manages the extraction,
-# consolidation, AND reflection models. `create_memory_and_wait` blocks until the
-# resource is ACTIVE. If a memory with this name already exists, we reuse its ID.
+# consolidation, AND reflection models. `create_or_get_memory` blocks until the resource
+# is ACTIVE, and on a name clash it returns the existing memory instead of erroring — so
+# re-running the tutorial reuses the same memory by name.
 
 
 def get_or_create_memory(name: str) -> str:
@@ -241,32 +240,19 @@ def get_or_create_memory(name: str) -> str:
         }
     ]
 
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # Episodic strategy => long-term episode extraction
-            description="Long-term episodic memory for the Claude SDK debugging-assistant tutorial",
-            event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with EPISODIC strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        # If the memory already exists, retrieve and reuse its ID.
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        # Any other client error is unexpected — surface it.
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the resource and waits until it's ACTIVE, or — if a
+    # memory with this name already exists — returns that existing memory dict instead of
+    # raising. Either way we get back a dict carrying the resource "id".
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # Episodic strategy => long-term episode extraction
+        description="Long-term episodic memory for the Claude SDK debugging-assistant tutorial",
+        event_expiry_days=7,  # Retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with EPISODIC strategy ready: {memory_id}")
+    return memory_id
 
 
 # ## Step 3b: Verify the configured strategy is actually EPISODIC
@@ -298,7 +284,7 @@ def verify_episodic_strategy(memory_id: str) -> None:
         stype = s.get("type") or s.get("memoryStrategyType") or s.get("strategyType")
         if stype and "EPISODIC" in str(stype).upper():
             episode_ns = s.get("namespaces") or s.get("namespaceTemplates") or []
-            reflection_ns = (s.get("reflectionConfiguration") or {})
+            reflection_ns = s.get("reflectionConfiguration") or {}
             reflection_ns = reflection_ns.get("namespaces") or reflection_ns.get("namespaceTemplates") or []
             logger.info(f"   Episode namespaces (as stored):    {episode_ns}")
             logger.info(f"   Reflection namespaces (as stored): {reflection_ns}")
@@ -499,8 +485,7 @@ def build_episode_enriched_prompt(memory_id: str, query: str) -> str:
     for i, episode in enumerate(episodes, 1):
         context_lines.append(f"- [Past episode {i}] {episode}")
     context_lines.append(
-        "When a current problem resembles a past episode, reference how it was resolved "
-        "and apply the lesson learned."
+        "When a current problem resembles a past episode, reference how it was resolved and apply the lesson learned."
     )
 
     return SYSTEM_PROMPT + "\n".join(context_lines)
@@ -518,8 +503,7 @@ def build_episode_enriched_prompt(memory_id: str, query: str) -> str:
 def wait_for_episodes(memory_id: str) -> None:
     """Poll until episode records appear, or until the max wait elapses."""
     logger.info(
-        "⏳ Waiting up to %d min for asynchronous episodic extraction "
-        "(Extraction → Consolidation → Reflection)...",
+        "⏳ Waiting up to %d min for asynchronous episodic extraction (Extraction → Consolidation → Reflection)...",
         EXTRACTION_MAX_WAIT_SECONDS // 60,
     )
     start = time.time()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/04-episodic-memory/requirements.txt
@@ -1,0 +1,7 @@
+# Anthropic SDK with the Amazon Bedrock backend (provides the AnthropicBedrock client).
+# The [bedrock] extra pulls in boto3/botocore for AWS SigV4 request signing.
+anthropic[bedrock]>=0.40.0
+
+# Amazon Bedrock AgentCore SDK — provides the MemoryClient used for long-term memory
+# (create_memory_and_wait with the episodicMemoryStrategy, create_event, retrieve_memories).
+bedrock-agentcore

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/README.md
@@ -1,0 +1,58 @@
+# Long-term memory — Claude SDK single-agent
+
+Long-term memory examples built directly on the **Anthropic Claude SDK** (via Amazon Bedrock), with **no agent framework**. The Anthropic SDK is a stateless API client — no built-in conversation management, hooks, or session handling — so every memory operation is explicit. That makes these the clearest illustration of what AgentCore long-term memory actually does for you.
+
+## Short-term vs. long-term memory
+
+| | Short-term memory | Long-term memory |
+|---|---|---|
+| **Stores** | Raw conversation turns, verbatim | Distilled records: facts, summaries, preferences, episodes |
+| **How** | `create_event` → `get_last_k_turns` | `create_event` → asynchronous extraction → `retrieve_memories` |
+| **Scope** | Within a session (resume a conversation) | Across sessions (remember the user over time) |
+| **Retrieval** | Recency (last *k* turns) | Semantic search over a namespace |
+| **Latency** | Immediate | Extraction runs ~30–90s after the event |
+| **Where it lives here** | [`../../../01-short-term-memory/examples/single-agent/with-claude-sdk/`](../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/) | This folder |
+
+Both use the **same** `create_event` call. Attaching **strategies** to the memory resource is what turns stored turns into long-term records — no separate extraction API.
+
+## The three integration patterns
+
+Long-term memory can be wired into an agent in three ways. The same patterns appear across every framework (Strands, LangGraph, LlamaIndex); here they're shown on the raw Claude SDK.
+
+| Pattern | What it is | Status |
+|---|---|---|
+| **[01 — Built-in strategies](./01-built-in-strategies/)** | Create the memory with built-in strategies (Semantic, User Preference, …); store every turn with `create_event`; retrieve distilled records with `retrieve_memories` and inject them into the system prompt. No IAM role required. This is the post-response pattern: store after each reply, retrieve at the start of the next session. | ✅ Available |
+| **[02 — Custom hook / strategy override](./02-custom-strategy-override/)** | Override the built-in extraction or consolidation models and prompts, or orchestrate retrieval/storage with custom logic (conditional saves, multi-strategy merges, citations). | ✅ Available |
+| **[03 — Memory as a tool](./03-memory-as-tool/)** | Expose memory operations (`store_memory`, `recall_memory`) as tools the LLM decides to call via the `tools=` parameter; run the agentic loop (`tool_use` → `tool_result` → continue) so the agent manages its own memory lifecycle. `store_memory` calls `create_event`; `recall_memory` calls `retrieve_memories`. | ✅ Available |
+
+> **Why "post-response" for pattern 01?** Frameworks like Strands provide an `AgentCoreMemoryHook` that fires on the agent lifecycle (e.g. after invocation) to save the turn and before the next to retrieve. The Claude SDK has no such lifecycle, so we replicate the same behavior explicitly — store with `create_event` right after each assistant reply, and retrieve + inject at the start of the next session.
+
+## Models
+
+All examples use **Claude Sonnet 4.6** on Amazon Bedrock — `global.anthropic.claude-sonnet-4-6`. The `global.` prefix selects Bedrock's global (cross-region) inference endpoint (the default for Sonnet 4.6, no regional pricing premium). Swap to `us.anthropic.claude-sonnet-4-6` to pin traffic to US regions.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model-invocation permissions.
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region (request it in the Bedrock console under *Model access*; `us-west-2` is a safe default).
+
+## How to run
+
+Each sub-folder is self-contained:
+
+```bash
+cd 01-built-in-strategies
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python claude-sdk-ltm-semantic.py
+```
+
+## Where to go next
+
+- Long-term memory overview (strategies, namespaces, retrieval, AWS CLI): [`../../../README.md`](../../../README.md)
+- The same patterns in a framework: [`../with-strands-agent/`](../with-strands-agent/), [`../with-langgraph-agent/`](../with-langgraph-agent/), [`../with-llamaindex-agent/`](../with-llamaindex-agent/)
+- Short-term memory with the Claude SDK: [`../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/`](../../../../01-short-term-memory/examples/single-agent/with-claude-sdk/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-claude-sdk/README.md
@@ -27,6 +27,14 @@ Long-term memory can be wired into an agent in three ways. The same patterns app
 
 > **Why "post-response" for pattern 01?** Frameworks like Strands provide an `AgentCoreMemoryHook` that fires on the agent lifecycle (e.g. after invocation) to save the turn and before the next to retrieve. The Claude SDK has no such lifecycle, so we replicate the same behavior explicitly — store with `create_event` right after each assistant reply, and retrieve + inject at the start of the next session.
 
+## Strategy variation: Episodic memory
+
+The patterns above use the **Semantic** strategy (distill isolated *facts*). The Episodic strategy is different — it captures whole multi-turn *episodes* ("what happened last time, and how did it go?") and adds a **Reflection** step that derives cross-episode patterns. It uses the same `create_event` / `retrieve_memories` calls as pattern 01; only the strategy configuration changes.
+
+| Strategy variation | What it is | Status |
+|---|---|---|
+| **[04 — Episodic memory](./04-episodic-memory/)** | Use the built-in Episodic strategy to capture complete debugging sessions as episodes (situation, intent, actions, outcome) plus cross-episode Reflections. Requires a `reflectionConfiguration` namespace, and each episode must end with a clear conclusion so AgentCore detects episode completion. Extraction is slower than Semantic (episodes surface ~15–20 min after the events). | ✅ Available |
+
 ## Models
 
 All examples use **Claude Sonnet 4.6** on Amazon Bedrock — `global.anthropic.claude-sonnet-4-6`. The `global.` prefix selects Bedrock's global (cross-region) inference endpoint (the default for Sonnet 4.6, no regional pricing premium). Swap to `us.anthropic.claude-sonnet-4-6` to pin traffic to US regions.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/README.md
@@ -1,0 +1,170 @@
+# Long-term memory — LangGraph, built-in callback
+
+A LangGraph agent whose **long-term memory is wired in by the framework**, using the
+[`langgraph-checkpoint-aws`](https://pypi.org/project/langgraph-checkpoint-aws/) package's
+two AgentCore integrations:
+
+- **`AgentCoreMemorySaver`** — a LangGraph **checkpointer** that persists and resumes
+  conversation state automatically, keyed by `thread_id` (session) and `actor_id`.
+- **`AgentCoreMemoryStore`** — a LangGraph **store** backed by AgentCore long-term
+  strategies. Two small middleware callbacks (`@dynamic_prompt` to recall, `@after_model`
+  to persist) are the entire memory wiring — the store turns `store.put` into a
+  `create_event` and `store.search` into a `retrieve_memories`, and the AgentCore
+  **Semantic strategy** extracts durable facts asynchronously in the background.
+
+This is the **lowest-effort** integration: you declare *where* memory hooks into the
+graph and the package does the rest. You never call `create_event` / `retrieve_memories`
+yourself. Contrast with [`02-custom-callback/`](../02-custom-callback/), where the
+callbacks hand-roll retrieval, context injection, and storage.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent usecase | Nutrition assistant |
+| Framework | LangGraph (v1.0 `create_agent` + middleware) |
+| LLM model | Claude Haiku 4.5 — `global.anthropic.claude-haiku-4-5-20251001-v1:0` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | `AgentCoreMemorySaver`, `AgentCoreMemoryStore`, `create_memory_and_wait`, `retrieve_memories`, `delete_memory_and_wait` |
+| Callback components | `@dynamic_prompt` (recall), `@after_model` (persist), `context_schema` (runtime identity) |
+| Complexity | Intermediate |
+
+> ### ⚠️ LangGraph v1.0 API note
+> LangGraph v1.0 **deprecated** `langgraph.prebuilt.create_react_agent` together with its
+> `pre_model_hook` / `post_model_hook` arguments. The current API is
+> **`from langchain.agents import create_agent`** with the **middleware** system
+> (`@before_model`, `@after_model`, `@dynamic_prompt`, `@wrap_model_call`) from
+> `langchain.agents.middleware`. **This tutorial uses the current API.** The sibling
+> [`02-custom-callback/`](../02-custom-callback/) examples still use the deprecated
+> `create_react_agent` + pre/post hooks; both styles work today, but new code should
+> prefer middleware.
+>
+> One consequence: middleware callbacks receive `(state, runtime)` — **not** the
+> invocation `config`. So per-user identity (`actor_id`, `session_id`) travels in a typed
+> **runtime context** (`context_schema=MemoryContext`), supplied at invoke time with
+> `context=...`. The checkpointer still reads `thread_id` / `actor_id` from
+> `config["configurable"]` as it always has — so each `invoke` passes **both** `config`
+> and `context`.
+
+## What it does
+
+[`langgraph-ltm-built-in-callback.py`](./langgraph-ltm-built-in-callback.py):
+
+1. Creates (or reuses) a memory resource with a built-in **Semantic** strategy
+   (namespace `/users/{actorId}/facts/`). No IAM execution role required.
+2. Builds the agent with `create_agent`, passing the `AgentCoreMemoryStore`, the
+   `AgentCoreMemorySaver` checkpointer, two middleware callbacks, and `context_schema`.
+3. Runs **Session 1**: the user shares durable facts (vegetarian, shellfish allergy,
+   half-marathon training). `@after_model` persists each turn to the store automatically.
+4. Polls until the asynchronous Semantic extraction surfaces records (~30–90s).
+5. Runs **Session 2**: a brand-new session (new `thread_id`). `@dynamic_prompt` recalls
+   the facts from session 1 and folds them into the system prompt, so the agent suggests
+   a vegetarian, high-protein, shellfish-free dinner — with no short-term history.
+6. Deletes the memory resource in a `finally` block.
+
+## Architecture
+
+```
+  ┌───────────────────────────── create_agent (LangGraph v1.0) ─────────────────────────────┐
+  │                                                                                          │
+  │   @dynamic_prompt  ──▶  model (Bedrock)  ──▶  @after_model  ──▶  (tools, if any)          │
+  │   (inject recalled        Claude Haiku        (persist the                                │
+  │    facts into the          4.5                 turn for                                   │
+  │    system prompt)                              extraction)                                │
+  │        │                                            │                                     │
+  └────────┼────────────────────────────────────────────┼─────────────────────────────────────┘
+           │ store.search(("users", actor, "facts/"))    │ store.put((actor, session), msg)
+           ▼                                              ▼
+  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+  │  AgentCore Memory  (one resource)                                                          │
+  │                                                                                            │
+  │   AgentCoreMemoryStore   ── create_event ─▶ short-term events ─▶ async Semantic extraction  │
+  │                          ◀─ retrieve_memories ── long-term records in /users/{actor}/facts/ │
+  │                                                                                            │
+  │   AgentCoreMemorySaver   ── checkpoints graph state per (thread_id, actor_id)  [automatic]  │
+  └──────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## The two callbacks
+
+| Callback | Decorator | When it runs | What it does |
+|---|---|---|---|
+| **`inject_recalled_facts`** | `@dynamic_prompt` | before the model, every turn | `store.search` the user's Semantic namespace with the latest message; append any recalled facts to the system prompt |
+| **`persist_turn`** | `@after_model` | after the model responds | `store.put` the newest human + AI messages; the store's `create_event` feeds asynchronous Semantic extraction |
+
+The checkpointer (`AgentCoreMemorySaver`) needs **no** callback — passing it to
+`create_agent(checkpointer=...)` makes state persistence fully automatic.
+
+## Checkpointer vs. store (two distinct jobs)
+
+| | `AgentCoreMemorySaver` (checkpointer) | `AgentCoreMemoryStore` (store) |
+|---|---|---|
+| **Persists** | Full graph **state** (the running conversation) | Individual **messages** for long-term extraction |
+| **Scope** | Per `(thread_id, actor_id)` — one session/thread | Cross-session, per `actor_id` namespace |
+| **Purpose** | Resume a conversation exactly where it left off | Recall durable facts in a *different* session |
+| **Wiring** | `create_agent(checkpointer=...)` — automatic | `create_agent(store=...)` + the two callbacks |
+| **Reads identity from** | `config["configurable"]` (`thread_id`, `actor_id`) | `runtime.context` (`actor_id`, `session_id`) |
+
+They are complementary: the saver gives you short-term continuity within a session; the
+store + Semantic strategy gives you durable knowledge across sessions.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock
+  model-invocation permissions (resolved from the standard AWS chain).
+- **Amazon Bedrock model access for Claude Haiku 4.5** in your region (request it in the
+  Bedrock console under *Model access*; `us-west-2` is a safe default).
+- **No IAM execution role required** — built-in strategies use AgentCore-managed models
+  for extraction and consolidation.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python langgraph-ltm-built-in-callback.py
+```
+
+Expected output: in **Session 1** the user shares facts and you'll see `🧠 persisted
+turn` log lines. After a wait for extraction, **Session 2** starts on a new thread; watch
+for `🔎 recalled N long-term fact(s)`, and the agent answers with a vegetarian,
+high-protein, shellfish-free suggestion. The script then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous. A fact saved in one turn is **not**
+> instantly searchable in the next — that's why the demo seeds memory in Session 1,
+> waits, then recalls in Session 2. The script polls for up to ~2 minutes; if records
+> haven't surfaced it warns and continues (they typically appear shortly after).
+
+## Key implementation notes
+
+- **The framework owns the lifecycle.** You declare callbacks and integrations; the
+  package translates `store.put`/`store.search` into AgentCore API calls and the Semantic
+  strategy extracts facts in the background. No direct `create_event`/`retrieve_memories`.
+- **Identity travels in `runtime.context`, not `config`.** v1.0 middleware gets
+  `(state, runtime)`. We declare `MemoryContext(actor_id, session_id)` as `context_schema`
+  and pass an instance at `invoke(..., context=...)`. The checkpointer separately reads
+  `thread_id`/`actor_id` from `config["configurable"]`.
+- **Store write namespaces are 2-tuples.** `store.put` requires `(actor_id, session_id)`
+  (verified in the package source). Search namespaces become `"/" + "/".join(tuple)`, so
+  `("users", actor, "facts/")` matches the strategy template `/users/{actorId}/facts/`.
+- **Recalled records live under `item.value["content"]`.** The store maps an AgentCore
+  memory record into a LangGraph `Item` whose `value["content"]` holds the extracted text.
+- **Failures never break a turn.** Both callbacks catch exceptions and continue without
+  memory rather than crashing the conversation.
+- **Built-in strategies need no IAM role.** To customize extraction prompts/models, see
+  [`02-custom-callback/`](../02-custom-callback/), which attaches a custom-override strategy.
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if
+  a turn raises. Comment out the delete block to keep it between runs.
+
+## Where to go next
+
+- The custom-callback pattern (hand-rolled hooks + custom strategy):
+  [`../02-custom-callback/`](../02-custom-callback/)
+- Memory as tools the model invokes: [`../03-memory-as-tool/`](../03-memory-as-tool/)
+- The long-term memory overview (all strategies, retrieval, namespaces):
+  [`../../../../README.md`](../../../../README.md)
+- The same pattern with the Claude SDK:
+  [`../../with-claude-sdk/01-built-in-strategies/`](../../with-claude-sdk/01-built-in-strategies/)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/langgraph-ltm-built-in-callback.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/langgraph-ltm-built-in-callback.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python
+
+# # LangGraph with AgentCore Memory — Built-in Callback (Long-term Memory)
+#
+# ## Introduction
+#
+# This tutorial demonstrates the **lowest-effort** way to give a LangGraph agent
+# long-term memory: let the `langgraph-checkpoint-aws` package wire AgentCore Memory
+# into the agent's lifecycle for you. Two AgentCore integrations do the work, and your
+# code never calls `create_event` / `retrieve_memories` directly:
+#
+# 1. **`AgentCoreMemorySaver`** — a LangGraph **checkpointer** backed by AgentCore
+#    Memory. Once you pass it to the agent, conversation **state is persisted and
+#    resumed automatically** at every super-step, keyed by `thread_id` (session) and
+#    `actor_id`. No save/load code at all.
+# 2. **`AgentCoreMemoryStore`** — a LangGraph **store** backed by AgentCore Memory's
+#    long-term strategies. We attach two tiny **middleware callbacks** (`@after_model`
+#    to persist each turn, `@dynamic_prompt` to inject recalled facts). The store turns
+#    `store.put(...)` into a `create_event` and `store.search(...)` into a
+#    `retrieve_memories` under the hood, and the AgentCore **Semantic strategy** does the
+#    extraction asynchronously in the background.
+#
+# This is the "framework handles the lifecycle" pattern: you declare *where* memory
+# hooks into the graph and the integration does the rest. Compare with
+# [`02-custom-callback/`](../02-custom-callback/), where the callbacks hand-roll the
+# retrieval, context injection, and storage logic themselves.
+#
+# > **LangGraph API note (v1.0):** `langgraph.prebuilt.create_react_agent` and its
+# > `pre_model_hook` / `post_model_hook` arguments are **deprecated** in LangGraph v1.0.
+# > The current API is `from langchain.agents import create_agent` with the
+# > **middleware** system (`@before_model`, `@after_model`, `@dynamic_prompt`,
+# > `@wrap_model_call`) from `langchain.agents.middleware`. This tutorial uses the
+# > current API. Middleware callbacks receive `(state, runtime)` — not `config` — so we
+# > carry the per-user identity (`actor_id`, `session_id`) in a typed **runtime context**
+# > (`context_schema`), and the checkpointer reads `thread_id` / `actor_id` from the
+# > runtime `config` as it always has.
+#
+# ## Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent usecase       | Nutrition Assistant                                                              |
+# | Agentic Framework   | LangGraph (v1.0 `create_agent` + middleware)                                     |
+# | LLM model           | Anthropic Claude Haiku 4.5 (via Amazon Bedrock)                                  |
+# | Tutorial components | AgentCoreMemorySaver (checkpointer), AgentCoreMemoryStore, before/after-model middleware, built-in Semantic strategy |
+# | Example complexity  | Intermediate                                                                     |
+#
+# You'll learn to:
+# - Use `AgentCoreMemorySaver` as a **checkpointer** so conversation state persists automatically
+# - Use `AgentCoreMemoryStore` as the long-term backend with **minimal** callback wiring
+# - Write v1.0 **middleware** (`@after_model`, `@dynamic_prompt`) instead of deprecated pre/post hooks
+# - Pass per-user identity through a typed **runtime context** (`context_schema`)
+# - Let the AgentCore Semantic strategy extract durable facts in the background
+#
+# ### Scenario Context
+#
+# We build a **Nutrition Assistant** that remembers user context (dietary restrictions,
+# goals, preferences) across sessions. The user shares facts in session 1; after the
+# Semantic strategy extracts them, a brand-new session 2 recalls them automatically —
+# the `@dynamic_prompt` callback injects the recalled facts before the model runs.
+#
+# ## Architecture
+#
+# ```
+#   ┌───────────────────────────── create_agent (LangGraph v1.0) ─────────────────────────────┐
+#   │                                                                                          │
+#   │   @dynamic_prompt  ──▶  model (Bedrock)  ──▶  @after_model  ──▶  (tools, if any)          │
+#   │   (inject recalled        Claude Haiku        (persist the                                │
+#   │    facts into the          4.5                 turn for                                   │
+#   │    system prompt)                              extraction)                                │
+#   │        │                                            │                                     │
+#   └────────┼────────────────────────────────────────────┼─────────────────────────────────────┘
+#            │ store.search(("users", actor, "facts/"))    │ store.put((actor, session), msg)
+#            ▼                                              ▼
+#   ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+#   │  AgentCore Memory  (one resource)                                                          │
+#   │                                                                                            │
+#   │   AgentCoreMemoryStore   ── create_event ─▶ short-term events ─▶ async Semantic extraction  │
+#   │                          ◀─ retrieve_memories ── long-term records in /users/{actor}/facts/ │
+#   │                                                                                            │
+#   │   AgentCoreMemorySaver   ── checkpoints graph state per (thread_id, actor_id)  [automatic]  │
+#   └──────────────────────────────────────────────────────────────────────────────────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS account with appropriate permissions
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Haiku 4.5 model in Amazon Bedrock (request it in the Bedrock
+#   console under *Model access*, in your chosen region)
+# - No IAM execution role required — we use a **built-in** Semantic strategy, for which
+#   AgentCore manages the extraction/consolidation models.
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+# LangGraph v1.0 agent factory + middleware. NOTE: this replaces the deprecated
+# `from langgraph.prebuilt import create_react_agent` and its pre/post model hooks.
+from langchain.agents import create_agent
+from langchain.agents.middleware import after_model, dynamic_prompt
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import AIMessage, HumanMessage
+
+# The AgentCore Memory integrations for LangGraph (the `langgraph-checkpoint-aws`
+# package). `AgentCoreMemorySaver` is the checkpointer; `AgentCoreMemoryStore` is the
+# long-term store. Both are thin adapters over the AgentCore Memory data-plane API.
+from langgraph_checkpoint_aws import AgentCoreMemorySaver, AgentCoreMemoryStore
+
+# AgentCore Memory control-plane client (create the resource) + the StrategyType enum
+# (gives us the exact wire key for the Semantic strategy) + the error we handle on reuse.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("langgraph-ltm-built-in")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+
+# Model ID for Claude Haiku 4.5 on Amazon Bedrock. The `global.` prefix selects the
+# global (cross-region) inference endpoint. To pin traffic to a region instead, swap the
+# prefix (e.g. "us.anthropic.claude-haiku-4-5-20251001-v1:0").
+MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+# One end-user. Two sessions: the first seeds memory, the second (a "new conversation")
+# recalls across the gap. Both share the same ACTOR_ID — that's what ties a user's
+# long-term records together across sessions.
+ACTOR_ID = "user-1"
+SEED_SESSION_ID = "nutrition-session-1"
+NEW_SESSION_ID = "nutrition-session-2"
+
+# Namespace template for the extracted Semantic records. `{actorId}` is substituted at
+# extraction time, keeping every user's facts isolated. The `@dynamic_prompt` callback
+# reads from the resolved prefix (see Step 4). Always end the template with "/".
+SEMANTIC_NAMESPACE = "/users/{actorId}/facts/"
+
+# Long-term extraction is asynchronous — records appear ~30-90s after a turn is saved.
+# We poll for them (Step 6) but cap the wait so the demo always finishes.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+
+# ## Step 2: The runtime context (how identity reaches the callbacks)
+#
+# In LangGraph v1.0, middleware callbacks receive `(state, runtime)` — they do NOT get
+# the invocation `config`. Per-run, per-user values therefore travel in a typed
+# **runtime context** object that we declare here and pass to `create_agent` via
+# `context_schema=`. We supply an instance at invoke time with `context=...`, and the
+# callbacks read `runtime.context.actor_id` / `runtime.context.session_id`.
+
+
+@dataclass
+class MemoryContext:
+    """Per-invocation identity made available to middleware as `runtime.context`."""
+
+    actor_id: str
+    session_id: str
+
+
+# ## Step 3: Initialize the clients, the store, and the checkpointer
+#
+# `AgentCoreMemoryStore` takes `memory_id` as a keyword argument; `AgentCoreMemorySaver`
+# takes it positionally (both forward extra kwargs such as `region_name` to boto3). They
+# are created once and reused across sessions — what changes per session is the runtime
+# context and config, not the integrations.
+
+
+memory_client = MemoryClient(region_name=REGION)
+
+
+# ## Step 4: The memory middleware (the "built-in callback")
+#
+# Two small callbacks are the entire long-term-memory wiring. The integration does the
+# heavy lifting: `store.put` becomes a `create_event`, `store.search` becomes a
+# `retrieve_memories`, and the Semantic strategy extracts durable facts in the
+# background. We never touch the AgentCore API directly here.
+
+
+@dynamic_prompt
+def inject_recalled_facts(request) -> str:
+    """BEFORE the model runs: search long-term memory and fold any hits into the prompt.
+
+    `@dynamic_prompt` is the v1.0 convenience middleware for building the system prompt
+    per request. It receives a `ModelRequest` exposing `.state`, `.runtime.context`, and
+    `.runtime.store`. We search the user's Semantic namespace with the latest human
+    message as the query and append whatever we recall to the base system prompt.
+    """
+    base_prompt = (
+        "You are a knowledgeable, friendly nutrition assistant. Give concise, practical "
+        "advice. Personalize using any remembered facts about the user shown below."
+    )
+
+    store = request.runtime.store
+    ctx: MemoryContext = request.runtime.context
+    if store is None or ctx is None:
+        return base_prompt
+
+    # The latest human message is the search query.
+    messages = request.state.get("messages", [])
+    last_human = next((m for m in reversed(messages) if isinstance(m, HumanMessage)), None)
+    if last_human is None:
+        return base_prompt
+
+    # Search the resolved Semantic namespace. The store turns this tuple into the string
+    # "/users/<actor>/facts/" and calls retrieve_memories for us. The last tuple element
+    # keeps its trailing "/" so it matches the strategy's namespace prefix.
+    namespace = ("users", ctx.actor_id, "facts/")
+    try:
+        hits = store.search(namespace, query=last_human.text(), limit=5)
+    except Exception as e:  # never let recall failure break the turn
+        logger.warning(f"recall failed (continuing without memory): {e}")
+        return base_prompt
+
+    if not hits:
+        logger.info("🔎 no long-term facts recalled yet")
+        return base_prompt
+
+    # Each hit's value carries the extracted text under "content" (see store.py).
+    facts = [item.value.get("content", "").strip() for item in hits]
+    facts = [f for f in facts if f]
+    logger.info(f"🔎 recalled {len(facts)} long-term fact(s)")
+    remembered = "\n".join(f"- {f}" for f in facts)
+    return f"{base_prompt}\n\nWhat you remember about this user:\n{remembered}"
+
+
+@after_model
+def persist_turn(state, runtime):
+    """AFTER the model responds: persist the latest user + assistant messages.
+
+    `@after_model` is the v1.0 replacement for `post_model_hook`. It receives
+    `(state, runtime)` and returns state updates or `None`. We write the newest human
+    and AI messages to the store; the store converts each into a `create_event`, which
+    feeds the asynchronous Semantic extraction pipeline. We return `None` because we are
+    not modifying the agent state — only persisting a side copy to memory.
+    """
+    store = runtime.store
+    ctx: MemoryContext = runtime.context
+    if store is None or ctx is None:
+        return None
+
+    # The store REQUIRES a 2-tuple namespace (actor_id, session_id) for writes — this is
+    # the raw short-term event; the strategy later extracts it into /users/<actor>/facts/.
+    namespace = (ctx.actor_id, ctx.session_id)
+    messages = state.get("messages", [])
+
+    # Persist the most recent human turn and the most recent AI turn (if any).
+    for msg_type in (HumanMessage, AIMessage):
+        msg = next((m for m in reversed(messages) if isinstance(m, msg_type)), None)
+        if msg is not None and msg.text().strip():
+            try:
+                store.put(namespace, str(uuid.uuid4()), {"message": msg})
+            except Exception as e:  # don't crash the turn on a save failure
+                logger.warning(f"failed to persist {msg_type.__name__}: {e}")
+    logger.info("🧠 persisted turn to AgentCore Memory (queued for extraction)")
+    return None
+
+
+# ## Step 5: Create the memory resource (built-in Semantic strategy)
+#
+# We create one memory with a single built-in **Semantic** strategy whose namespace
+# template is `/users/{actorId}/facts/`. Built-in strategies require NO IAM execution
+# role — AgentCore manages the extraction/consolidation models. We reuse the resource by
+# name if it already exists.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a memory with a built-in Semantic strategy, or reuse it if it exists."""
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "NutritionFacts",
+                "description": "Durable facts about the user: diet, goals, preferences",
+                "namespaces": [SEMANTIC_NAMESPACE],
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # strategies => long-term extraction is enabled
+            description="LangGraph built-in-callback LTM tutorial (Nutrition Assistant)",
+            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+def wait_for_extraction(memory_id: str) -> None:
+    """Poll until long-term records appear, or until the max wait elapses.
+
+    In production you would NOT block like this — the agent simply recalls on the user's
+    next visit, by which point extraction has long completed. We block here only so the
+    demo's second session has data to recall.
+    """
+    logger.info("⏳ Waiting for asynchronous Semantic extraction to complete...")
+    namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            records = memory_client.retrieve_memories(
+                memory_id=memory_id,
+                namespace=namespace,
+                query="user dietary facts and goals",
+                top_k=1,
+            )
+            if records:
+                logger.info("✅ Long-term records are available")
+                return
+        except Exception as e:
+            logger.warning(f"Retrieval probe failed (will retry): {e}")
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Extraction did not surface records within the wait window. "
+        "It may still complete shortly — try re-running retrieval later."
+    )
+
+
+# ## Step 6: Build the agent and run the demo
+#
+# `create_agent` wires the model, the two memory callbacks (middleware), the
+# `AgentCoreMemoryStore`, and the `AgentCoreMemorySaver` checkpointer. At invoke time we
+# pass BOTH:
+#   • `config={"configurable": {"thread_id", "actor_id"}}` — read by the CHECKPOINTER
+#     (`AgentCoreMemorySaver`) to persist/resume graph state.
+#   • `context=MemoryContext(...)` — read by the MIDDLEWARE callbacks (which only get
+#     `runtime`, not `config`).
+# `thread_id` maps to the AgentCore session_id and `actor_id` to the AgentCore actor_id.
+
+
+def run_turn(graph, actor_id: str, session_id: str, user_text: str) -> str:
+    """Invoke the agent for one user turn and return the assistant's final text."""
+    config = {
+        "configurable": {
+            "thread_id": session_id,  # REQUIRED by the checkpointer (maps to AgentCore session_id)
+            "actor_id": actor_id,  # REQUIRED by the checkpointer (maps to AgentCore actor_id)
+        }
+    }
+    context = MemoryContext(actor_id=actor_id, session_id=session_id)
+    result = graph.invoke(
+        {"messages": [{"role": "user", "content": user_text}]},
+        config=config,
+        context=context,
+    )
+    return result["messages"][-1].text()
+
+
+def main() -> None:
+    memory_id = None  # init so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("LangGraphBuiltInCallback")
+
+        # Build the long-term store and the checkpointer over the SAME memory resource.
+        # AgentCoreMemoryStore: memory_id is keyword-only. AgentCoreMemorySaver: positional.
+        store = AgentCoreMemoryStore(memory_id=memory_id, region_name=REGION)
+        checkpointer = AgentCoreMemorySaver(memory_id, region_name=REGION)
+
+        # Initialize the Bedrock-backed chat model. `init_chat_model(..., "bedrock_converse")`
+        # is the same path the sibling LTM tutorials use; `ChatBedrock` from `langchain_aws`
+        # is an equivalent drop-in.
+        llm = init_chat_model(MODEL_ID, model_provider="bedrock_converse", region_name=REGION)
+
+        # Assemble the agent with the v1.0 factory. The two callbacks are passed as
+        # middleware; the store and checkpointer make memory automatic; context_schema
+        # lets the callbacks read per-user identity from runtime.context.
+        graph = create_agent(
+            model=llm,
+            tools=[],  # no extra tools — memory is handled by the callbacks
+            middleware=[inject_recalled_facts, persist_turn],
+            store=store,
+            checkpointer=checkpointer,
+            context_schema=MemoryContext,
+        )
+
+        # ---- Session 1: the user shares durable facts -----------------------------
+        print("\n=== Session 1 (the callbacks persist each turn automatically) ===")
+        for user_text in [
+            "Hi! I'm Sam. I'm vegetarian and allergic to shellfish.",
+            "I'm training for a half marathon in October, so I'm watching my protein intake.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_turn(graph, ACTOR_ID, SEED_SESSION_ID, user_text)
+            print(f"Agent: {reply}\n")
+
+        # ---- Wait for the Semantic extraction pipeline ----------------------------
+        wait_for_extraction(memory_id)
+
+        # ---- Session 2: a NEW session recalls across the gap ----------------------
+        # New thread_id => fresh checkpointed state. The only way the agent can
+        # personalize is the @dynamic_prompt callback recalling facts from session 1.
+        print("=== Session 2 (new session — the callback recalls facts automatically) ===")
+        for user_text in [
+            "Can you suggest a high-protein dinner I could make tonight?",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_turn(graph, ACTOR_ID, NEW_SESSION_ID, user_text)
+            print(f"Agent: {reply}\n")
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the
+        # demo finishes. To keep the memory between runs (e.g. to inspect it in the
+        # console), comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/langgraph-ltm-built-in-callback.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/langgraph-ltm-built-in-callback.py
@@ -106,7 +106,6 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
 
 # LangGraph v1.0 agent factory + middleware. NOTE: this replaces the deprecated
 # `from langgraph.prebuilt import create_react_agent` and its pre/post model hooks.
@@ -121,10 +120,9 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langgraph_checkpoint_aws import AgentCoreMemorySaver, AgentCoreMemoryStore
 
 # AgentCore Memory control-plane client (create the resource) + the StrategyType enum
-# (gives us the exact wire key for the Semantic strategy) + the error we handle on reuse.
+# (gives us the exact wire key for the Semantic strategy).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -275,8 +273,8 @@ def persist_turn(state, runtime):
 #
 # We create one memory with a single built-in **Semantic** strategy whose namespace
 # template is `/users/{actorId}/facts/`. Built-in strategies require NO IAM execution
-# role — AgentCore manages the extraction/consolidation models. We reuse the resource by
-# name if it already exists.
+# role — AgentCore manages the extraction/consolidation models. The SDK's
+# `create_or_get_memory` reuses the resource by name if it already exists.
 
 
 def get_or_create_memory(name: str) -> str:
@@ -290,30 +288,18 @@ def get_or_create_memory(name: str) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # strategies => long-term extraction is enabled
-            description="LangGraph built-in-callback LTM tutorial (Nutrition Assistant)",
-            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the resource, or returns the existing one (by name)
+    # if it already exists — so we don't have to catch "already exists" ourselves.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # strategies => long-term extraction is enabled
+        description="LangGraph built-in-callback LTM tutorial (Nutrition Assistant)",
+        event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with built-in Semantic strategy ready: {memory_id}")
+    return memory_id
 
 
 def wait_for_extraction(memory_id: str) -> None:

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/01-built-in-callback/requirements.txt
@@ -1,0 +1,10 @@
+boto3
+bedrock_agentcore
+# LangGraph v1.0+: create_agent and the middleware system live in the `langchain`
+# package (>=1.0). `langgraph` is still required as the underlying runtime/checkpointer.
+langchain>=1.0
+langgraph>=1.0
+langchain_aws
+langchain_core
+# AgentCore Memory integrations for LangGraph: AgentCoreMemorySaver + AgentCoreMemoryStore
+langgraph-checkpoint-aws

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/02-custom-callback/custom-user-preferences/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/02-custom-callback/custom-user-preferences/README.md
@@ -1,0 +1,37 @@
+# Long-term memory — LangGraph custom user-preference callback
+
+A nutrition assistant built with **LangGraph** that uses a **custom-override UserPreference strategy** plus pre/post model hooks to automatically extract, store, and recall user preferences across sessions. Custom prompts steer how preferences are extracted and consolidated.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Nutrition Assistant |
+| Framework | LangGraph |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | UserPreference — **custom override** (requires IAM execution role) |
+| Memory components | Custom extraction/consolidation prompts, pre/post model hooks, semantic retrieval |
+| Complexity | Intermediate |
+
+## What it does
+
+[`nutrition-assistant-with-user-preference-saving.py`](./nutrition-assistant-with-user-preference-saving.py):
+
+1. Creates memory with a UserPreference custom-override strategy, using the prompts in [`custom_memory_prompts.py`](./custom_memory_prompts.py).
+2. A **pre-model hook** retrieves relevant preferences and injects them into context.
+3. A **post-model hook** stores new turns for asynchronous extraction.
+4. Across sessions, the agent recalls dietary restrictions, favorite foods, and health goals to personalize advice.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS account with AgentCore Memory permissions and an IAM execution role
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python nutrition-assistant-with-user-preference-saving.py
+```
+
+See the sibling [`episodic-memory/`](../episodic-memory/) for the episodic variant, or the [LangGraph single-agent README](../../README.md) for all three patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/02-custom-callback/episodic-memory/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/02-custom-callback/episodic-memory/README.md
@@ -1,0 +1,37 @@
+# Long-term memory — LangGraph episodic callback
+
+A nutrition assistant built with **LangGraph** that uses the **episodic memory strategy** to capture complete meal-planning sessions as structured episodes. Unlike preference extraction, episodic memory preserves full conversation flow, intent, and outcome — enabling temporal queries ("What did I plan last week?") and dietary-pattern analysis over time.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Nutrition Assistant (episodic) |
+| Framework | LangGraph |
+| LLM model | Anthropic Claude Sonnet 3.7 |
+| Strategies | Episodic (extraction → consolidation → reflection) |
+| Memory components | Session-based episodes, pre/post model hooks, cross-episode reflection |
+| Complexity | Intermediate |
+
+## What it does
+
+[`nutrition-assistant-with-episodic-memory.py`](./nutrition-assistant-with-episodic-memory.py):
+
+1. Creates memory with an episodic strategy, using the prompts in [`custom_memory_prompts.py`](./custom_memory_prompts.py).
+2. Captures each meal-planning conversation as a complete episode (recipes, substitutions, feedback).
+3. Generates reflections across episodes to surface evolving dietary patterns.
+4. Recalls past episodes to ground future recommendations.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS account with AgentCore Memory permissions and an IAM execution role
+- Access to Amazon Bedrock models
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python nutrition-assistant-with-episodic-memory.py
+```
+
+See the sibling [`custom-user-preferences/`](../custom-user-preferences/) for the preference-saving variant, or the [LangGraph single-agent README](../../README.md) for all three patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/README.md
@@ -1,0 +1,166 @@
+# Long-term memory — LangGraph, memory as a tool
+
+A LangGraph agent where AgentCore **long-term memory** is exposed as **tools the model
+decides to call**. We define `store_memory` and `recall_memory` as LangGraph `@tool`s and
+pass them to `create_agent`; the agent runs the standard **ReAct loop** (model ⇄
+`ToolNode`) and chooses, on its own, when to persist a durable fact and when to search its
+past knowledge.
+
+The two callback tutorials wired memory *around* the model.
+[`01-built-in-callback/`](../01-built-in-callback/) persisted and recalled on every turn
+via middleware; [`02-custom-callback/`](../02-custom-callback/) did the same with
+hand-rolled hooks. In both, **your code** decided when to save and recall. Here we hand
+that decision to the agent: the model emits a tool call, LangGraph executes it, and
+AgentCore stores (`create_event`) or retrieves (`retrieve_memories`).
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent usecase | Personal assistant |
+| Framework | LangGraph (v1.0 `create_agent`) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | `create_memory_and_wait` (Semantic strategy), `create_event`, `retrieve_memories`, `list_memories`, `delete_memory_and_wait` |
+| Tool components | LangGraph `@tool`, ToolNode ReAct loop via `create_agent` |
+| Complexity | Advanced |
+
+> ### ⚠️ LangGraph v1.0 API note
+> This tutorial uses the current **`from langchain.agents import create_agent`** API. The
+> older `langgraph.prebuilt.create_react_agent` is **deprecated** in LangGraph v1.0 — it
+> still runs but emits a deprecation warning pointing here. `create_agent` builds the same
+> tool-calling ReAct loop and accepts a `tools=` list directly, so the memory-as-tool
+> pattern carries over unchanged; only the import and the `prompt=`→`system_prompt=`
+> rename differ.
+
+## What it does
+
+[`langgraph-ltm-memory-tool.py`](./langgraph-ltm-memory-tool.py):
+
+1. Creates (or reuses) a memory resource with a built-in **Semantic** strategy. No IAM
+   execution role required.
+2. Declares two tools — `store_memory` and `recall_memory` — bound to the memory resource
+   and session, and passes them to `create_agent`.
+3. Runs **Session 1**: a multi-turn conversation where the user shares durable facts
+   (name, dietary restrictions, a training goal). The agent calls `store_memory` on its
+   own as those facts come up — backed by `create_event`.
+4. Polls until the asynchronous extraction surfaces records (~30–90s).
+5. Runs **Session 2**: a brand-new conversation with a **fresh message list** — no
+   in-session history. The user asks something that depends on the past, and the agent
+   calls `recall_memory` itself (backed by `retrieve_memories`) to recover the context
+   before answering.
+6. Deletes the memory resource in a `finally` block.
+
+Crucially, the demo never injects memory into the prompt and never calls `create_event` /
+`retrieve_memories` directly in the conversation flow — **every memory operation happens
+because the model asked for it.**
+
+## Architecture
+
+```
+  ┌───────────────────────── create_agent (LangGraph ReAct loop) ─────────────────────────┐
+  │                                                                                        │
+  │     model (Bedrock, Claude Sonnet 4.6)  ──tool call──▶  ToolNode                        │
+  │            ▲                                              │                             │
+  │            │  ToolMessage (result)                        │  store_memory / recall_memory│
+  │            └──────────────────────────────────────────────┘                             │
+  └────────────────────────────────────────────────────────────┼──────────────────────────┘
+                                                                 │
+             store_memory → create_event                        │
+             recall_memory → retrieve_memories                  ▼
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │  AgentCore Memory                                                        │
+  │   create_event ──▶ short-term events ──▶ async Semantic extraction ──▶   │
+  │   long-term records ◀── retrieve_memories (semantic search by namespace) │
+  └────────────────────────────────────────────────────────────────────────┘
+```
+
+## The tools
+
+| Tool | Model calls it when… | Backed by |
+|---|---|---|
+| **`store_memory`** | the user shares a durable fact worth remembering across sessions (name, preferences, goals, constraints) | `create_event(memory_id, actor_id, session_id, messages=[(fact, "USER")])` — feeds the Semantic extraction pipeline |
+| **`recall_memory`** | answering well depends on something the user said before (typically at the start of a conversation) | `retrieve_memories(memory_id, namespace="/users/<actor>/facts/", query=..., top_k=...)` |
+
+Tool **docstrings are load-bearing** — with `@tool`, the docstring becomes the description
+the model sees, and it decides whether and when to call a tool almost entirely from that
+text. The **system prompt** reinforces it: it tells the agent it has memory tools and
+*when* to use them, doing the steering the callback tutorials did in code.
+
+## Memory-as-tool vs. the callback patterns
+
+| | 01 — Built-in callback | 02 — Custom callback | 03 — Memory as a tool (this) |
+|---|---|---|---|
+| **Who decides to store** | The framework callback, every turn | Your hook, every turn | **The model**, via `store_memory` |
+| **Who decides to recall** | The framework callback, every turn | Your hook, every turn | **The model**, via `recall_memory` |
+| **How memory reaches the model** | Injected into the prompt by a callback | Injected by your hook | Returned as a `ToolMessage` the model requested |
+| **Control flow** | Linear (recall → model → persist) | Linear | **ReAct loop** (model drives) |
+| **Best when** | You want deterministic, always-on memory | …plus customized extraction | The model should manage its own memory lifecycle |
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock
+  model-invocation permissions (resolved from the standard AWS chain).
+- **Amazon Bedrock model access for Claude Sonnet 4.6** in your region (request it in the
+  Bedrock console under *Model access*; `us-west-2` is a safe default).
+- **No IAM execution role required** — built-in strategies use AgentCore-managed models.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python langgraph-ltm-memory-tool.py
+```
+
+Expected output: in **Session 1** the user shares their name, dietary restrictions, and a
+training goal, and the agent calls `store_memory` (watch for `🧠 store_memory` log lines)
+as those facts come up. After a wait for extraction, **Session 2** starts with a fresh
+message list; the agent calls `recall_memory` (watch for the `🔎 recall_memory` log line)
+and uses the recovered facts to suggest a vegetarian, high-protein, shellfish-free dinner —
+despite having no in-session history. The script then deletes the memory resource.
+
+> **Note on timing:** extraction is asynchronous. A fact saved in one turn is **not**
+> instantly searchable in the next — that's why the demo seeds memory in Session 1, waits,
+> then recalls in Session 2. The script polls for up to ~2 minutes; if records haven't
+> surfaced it warns and continues (they typically appear shortly after).
+
+## Key implementation notes
+
+- **The model owns the lifecycle.** Storage and recall happen only when the model emits a
+  tool call. LangGraph's `ToolNode` dispatches it; AgentCore does the work. There is no
+  code path that stores or recalls on the model's behalf.
+- **Tools close over `memory_id` and `session_id`.** A factory (`build_memory_tools`)
+  binds the IDs so the `@tool` functions stay simple (`store_memory(fact)` /
+  `recall_memory(query)`) — exactly the shape the model fills in. Rebuild the tools per
+  session to bind a new `session_id`.
+- **Store and recall are separated by extraction latency.** `store_memory` queues a fact
+  for asynchronous Semantic extraction; `recall_memory` reads the distilled records. They
+  are not instantaneous round-trips — design conversations (and the demo's two sessions)
+  accordingly.
+- **Retrieval namespaces must be fully resolved.** `retrieve_memories` does not accept
+  wildcards — `recall_memory` substitutes `{actorId}` itself before calling.
+- **Same actor, different session.** Session 2 uses a new `session_id` but the same
+  `ACTOR_ID`, so `recall_memory` reads the same `/users/<actor>/facts/` namespace the
+  facts were extracted into.
+- **Built-in strategies need no IAM role.** To swap in your own models or prompts, attach
+  a custom-override strategy as in [`02-custom-callback/`](../02-custom-callback/).
+- **Cleanup runs in `finally`.** The memory resource is billable, so it's deleted even if
+  a turn raises. Comment out the delete block to keep the memory between runs.
+
+## Where to go next
+
+- The built-in callback pattern (framework-managed lifecycle):
+  [`../01-built-in-callback/`](../01-built-in-callback/)
+- The custom callback pattern (hand-rolled hooks + custom strategy):
+  [`../02-custom-callback/`](../02-custom-callback/)
+- The long-term memory overview (all strategies, retrieval, namespaces):
+  [`../../../../README.md`](../../../../README.md)
+- The same pattern with other frameworks:
+  [`../../with-claude-sdk/03-memory-as-tool/`](../../with-claude-sdk/03-memory-as-tool/),
+  [`../../with-strands-agent/03-memory-tool/`](../../with-strands-agent/03-memory-tool/),
+  [`../../with-llamaindex-agent/03-memory-tool/`](../../with-llamaindex-agent/03-memory-tool/)
+```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/langgraph-ltm-memory-tool.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/langgraph-ltm-memory-tool.py
@@ -99,11 +99,9 @@ from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 
-# AgentCore Memory client + the StrategyType enum (exact strategy wire key) + the error
-# we handle when reusing an existing memory.
+# AgentCore Memory client + the StrategyType enum (exact strategy wire key).
 from bedrock_agentcore.memory import MemoryClient
 from bedrock_agentcore.memory.constants import StrategyType
-from botocore.exceptions import ClientError
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -247,30 +245,19 @@ def get_or_create_memory(name: str) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=name,
-            strategies=strategies,  # strategies => long-term extraction is enabled
-            description="LangGraph memory-as-tool LTM tutorial",
-            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
-            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
-        )
-        memory_id = memory["id"]
-        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
-        return memory_id
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
-            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
-            existing = next(
-                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
-                None,
-            )
-            if not existing:
-                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
-            logger.info(f"✅ Reusing existing memory: {existing}")
-            return existing
-        logger.error(f"❌ Memory creation failed: {e}")
-        raise
+    # create_or_get_memory creates the memory, or returns the existing one (as a dict with
+    # an "id" key) if a memory with this name already exists. The SDK handles the
+    # name-clash lookup for us, so no manual error handling is needed.
+    memory = memory_client.create_or_get_memory(
+        name=name,
+        strategies=strategies,  # strategies => long-term extraction is enabled
+        description="LangGraph memory-as-tool LTM tutorial",
+        event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+        # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+    )
+    memory_id = memory["id"]
+    logger.info(f"✅ Memory with built-in Semantic strategy ready: {memory_id}")
+    return memory_id
 
 
 def wait_for_extraction(memory_id: str) -> None:

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/langgraph-ltm-memory-tool.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/langgraph-ltm-memory-tool.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python
+
+# # LangGraph with AgentCore Memory — Memory as a Tool (Long-term Memory)
+#
+# ## Introduction
+#
+# This tutorial demonstrates how to expose AgentCore **long-term memory** as **tools the
+# model decides to call** inside a LangGraph agent. The companion tutorials wired memory
+# in *around* the model: [`01-built-in-callback/`](../01-built-in-callback/) persisted and
+# recalled on every turn via middleware; [`02-custom-callback/`](../02-custom-callback/)
+# did the same with hand-rolled hooks. In both, **your code** (a callback) decided when to
+# save and when to recall.
+#
+# Here we hand that decision to the agent. We define two LangGraph tools —
+# `store_memory` and `recall_memory` — and pass them to `create_agent`. The agent runs the
+# standard **ReAct loop**: the model emits a tool call, LangGraph's `ToolNode` executes it,
+# the result goes back to the model, and it continues until it produces a final answer. The
+# tool implementations call AgentCore Memory directly: `create_event` to store,
+# `retrieve_memories` to recall.
+#
+# > **LangGraph API note (v1.0):** This tutorial uses the current
+# > **`from langchain.agents import create_agent`** API. The older
+# > `langgraph.prebuilt.create_react_agent` is deprecated in LangGraph v1.0 (it still
+# > runs, but emits a deprecation warning). `create_agent` builds the same tool-calling
+# > ReAct loop — model ⇄ `ToolNode` — and accepts a `tools=` list directly.
+#
+# ## Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term Conversational                                                         |
+# | Agent usecase       | Personal Assistant                                                               |
+# | Agentic Framework   | LangGraph (v1.0 `create_agent`)                                                  |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Tutorial components | LangGraph tools (`@tool`), ToolNode ReAct loop, built-in Semantic strategy, create_event, retrieve_memories |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Define memory operations (`store_memory`, `recall_memory`) as LangGraph `@tool`s
+# - Let the model decide WHEN to save a durable fact and WHEN to search its past knowledge
+# - Back those tools with AgentCore Memory: `create_event` to store, `retrieve_memories` to recall
+# - Run the tool-calling ReAct loop with `create_agent`
+# - Show cross-session recall: a fresh session where the agent recovers context by calling `recall_memory`
+#
+# ## Memory-as-tool vs. the callback patterns
+#
+# | | 01 — Built-in callback | 02 — Custom callback | 03 — Memory as a tool (this) |
+# |---|---|---|---|
+# | **Who decides to store** | The framework callback, every turn | Your hook, every turn | **The model**, via `store_memory` |
+# | **Who decides to recall** | The framework callback, every turn | Your hook, every turn | **The model**, via `recall_memory` |
+# | **How memory reaches the model** | Injected into the prompt by a callback | Injected by your hook | Returned as a `ToolMessage` the model requested |
+# | **Control flow** | Linear (recall → model → persist) | Linear | **ReAct loop** (model drives) |
+# | **Best when** | You want deterministic, always-on memory | …plus customized extraction | The model should manage its own memory lifecycle |
+#
+# ## Architecture
+#
+# ```
+#   ┌───────────────────────── create_agent (LangGraph ReAct loop) ─────────────────────────┐
+#   │                                                                                        │
+#   │     model (Bedrock, Claude Sonnet 4.6)  ──tool call──▶  ToolNode                        │
+#   │            ▲                                              │                             │
+#   │            │  ToolMessage (result)                        │  store_memory / recall_memory│
+#   │            └──────────────────────────────────────────────┘                             │
+#   └────────────────────────────────────────────────────────────┼──────────────────────────┘
+#                                                                  │
+#              store_memory → create_event                         │
+#              recall_memory → retrieve_memories                   ▼
+#   ┌────────────────────────────────────────────────────────────────────────┐
+#   │  AgentCore Memory                                                        │
+#   │   create_event ──▶ short-term events ──▶ async Semantic extraction ──▶   │
+#   │   long-term records ◀── retrieve_memories (semantic search by namespace) │
+#   └────────────────────────────────────────────────────────────────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - Access to the Claude Sonnet 4.6 model in Amazon Bedrock (request it in the Bedrock
+#   console under *Model access*, in your chosen region)
+# - No IAM execution role required — we use a **built-in** Semantic strategy.
+#
+# Let's get started by setting up our environment!
+
+# ## Step 1: Setup and Imports
+
+
+# Run: pip install -qr requirements.txt
+
+
+import logging
+import os
+import time
+from datetime import datetime
+
+# LangGraph v1.0 agent factory (replaces the deprecated create_react_agent).
+from langchain.agents import create_agent
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+# AgentCore Memory client + the StrategyType enum (exact strategy wire key) + the error
+# we handle when reusing an existing memory.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from botocore.exceptions import ClientError
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("langgraph-ltm-memory-tool")
+
+# Configuration
+REGION = os.getenv("AWS_REGION", "us-west-2")  # AWS region for both Bedrock and Memory
+
+# Model ID for Claude Sonnet 4.6 on Amazon Bedrock. The `global.` prefix selects the
+# global (cross-region) inference endpoint. To pin to a region, swap the prefix
+# (e.g. "us.anthropic.claude-sonnet-4-6").
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+# One end-user. Two sessions: the first seeds memory, the second recalls across the gap.
+# Both share the same ACTOR_ID — that's what ties a user's long-term records together.
+ACTOR_ID = "user_789"
+SEED_SESSION_ID = "assistant_session_001"
+NEW_SESSION_ID = "assistant_session_002"
+
+# Namespace template for the Semantic records. `{actorId}` is substituted at extraction
+# time, isolating each user's facts. `recall_memory` retrieves from the resolved path.
+SEMANTIC_NAMESPACE = "/users/{actorId}/facts/"
+
+# Long-term extraction is asynchronous — records appear ~30-90s after create_event. We
+# poll for them (Step 5) but cap the total wait so the demo always finishes.
+EXTRACTION_MAX_WAIT_SECONDS = 120
+EXTRACTION_POLL_INTERVAL_SECONDS = 15
+
+# The system prompt tells the agent it HAS memory tools and WHEN to use them. With the
+# memory-as-tool pattern this prompt does the steering that the callback tutorials did in
+# code — be explicit so the model reaches for the tools on its own.
+SYSTEM_PROMPT = (
+    "You are a helpful personal assistant with persistent long-term memory.\n"
+    "\n"
+    "You have two memory tools:\n"
+    "- store_memory: save a durable fact about the user so you can recall it in future "
+    "conversations. Call it whenever the user shares something worth remembering long-term "
+    "— their name, preferences, goals, constraints, important dates. Do NOT store transient "
+    "small talk.\n"
+    "- recall_memory: search your long-term memory for facts you saved previously. Call it "
+    "at the START of a conversation, and any time answering well depends on something the "
+    "user may have told you before.\n"
+    "\n"
+    "Use these tools proactively and on your own judgment — the user will not remind you. "
+    "Be friendly and concise. "
+    f"Today's date: {datetime.today().strftime('%Y-%m-%d')}."
+)
+
+# A single MemoryClient is reused by both tools (created in Step 2).
+memory_client = MemoryClient(region_name=REGION)
+logger.info(f"✅ MemoryClient initialized for region: {REGION}")
+
+
+# ## Step 2: Define the memory tools
+#
+# Each tool is a plain Python function decorated with LangGraph's `@tool`. The docstring
+# IS the description the model sees — it is load-bearing, because the model decides
+# whether and when to call a tool almost entirely from it, so we state the trigger
+# conditions explicitly.
+#
+# The tools are built by a factory that closes over the `memory_id` and `session_id` for
+# this run. (LangGraph can also inject runtime state into tools, but closing over the IDs
+# keeps the AgentCore mechanics front-and-center and matches the other tutorials.)
+
+
+def build_memory_tools(memory_id: str, session_id: str):
+    """Create the store/recall tools bound to a specific memory resource and session."""
+
+    @tool
+    def store_memory(fact: str) -> str:
+        """Save an important, durable fact about the user to long-term memory so it can be
+        recalled in future conversations. Call this whenever the user shares information
+        worth remembering across sessions — their name, preferences, goals, constraints,
+        or notable personal details. Do NOT call it for transient small talk.
+
+        Args:
+            fact: A concise, self-contained statement of the fact to remember, written in
+                the third person. Example: "The user is vegetarian and allergic to shellfish."
+        """
+        # create_event writes the fact as a single USER message. Because the memory has a
+        # Semantic strategy, this event feeds the asynchronous extraction pipeline — there
+        # is no separate "extract" call.
+        memory_client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=session_id,
+            messages=[(fact, "USER")],
+        )
+        logger.info(f"🧠 store_memory: queued for extraction — {fact!r}")
+        return f"Saved to long-term memory: {fact}"
+
+    @tool
+    def recall_memory(query: str) -> str:
+        """Search your long-term memory for facts you previously saved about the user. Call
+        this at the start of a conversation, or whenever answering well depends on something
+        the user told you before (preferences, history, personal details). Returns the most
+        relevant remembered facts, or a note that none were found.
+
+        Args:
+            query: What you want to recall, phrased as a search query.
+                Example: "dietary restrictions and food preferences".
+        """
+        # retrieve_memories needs a FULLY RESOLVED namespace — wildcards are not supported
+        # — so we substitute {actorId} ourselves.
+        namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+        records = memory_client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query=query,
+            top_k=5,
+        )
+        texts = []
+        for record in records:
+            # Record shape: {"content": {"text": "..."}, "score": 0.87, ...}
+            content = record.get("content", {})
+            text = content.get("text", "").strip() if isinstance(content, dict) else ""
+            if text:
+                texts.append(text)
+        logger.info(f"🔎 recall_memory: {len(texts)} record(s) for query {query!r}")
+        if not texts:
+            return "No relevant memories found. This may be a new user, or extraction may still be processing."
+        return "Relevant memories about the user:\n" + "\n".join(f"- {t}" for t in texts)
+
+    return [store_memory, recall_memory]
+
+
+# ## Step 3: Create the memory resource (built-in Semantic strategy)
+#
+# One memory with a single built-in **Semantic** strategy (no IAM role). We reuse it by
+# name if it already exists.
+
+
+def get_or_create_memory(name: str) -> str:
+    """Create a memory with a built-in Semantic strategy, or reuse it if it exists."""
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "PersonalAssistantFacts",
+                "description": "Captures standalone facts about the user from conversations",
+                "namespaces": [SEMANTIC_NAMESPACE],
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=name,
+            strategies=strategies,  # strategies => long-term extraction is enabled
+            description="LangGraph memory-as-tool LTM tutorial",
+            event_expiry_days=7,  # retain raw events for 7 days (configurable 3-365)
+            # NOTE: no memory_execution_role_arn — built-in strategies don't need one.
+        )
+        memory_id = memory["id"]
+        logger.info(f"✅ Created memory with built-in Semantic strategy: {memory_id}")
+        return memory_id
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ValidationException" and "already exists" in str(e):
+            logger.info(f"Memory '{name}' already exists, retrieving its ID...")
+            existing = next(
+                (m["id"] for m in memory_client.list_memories() if m["name"] == name),
+                None,
+            )
+            if not existing:
+                raise RuntimeError(f"Memory '{name}' reported as existing but was not found")
+            logger.info(f"✅ Reusing existing memory: {existing}")
+            return existing
+        logger.error(f"❌ Memory creation failed: {e}")
+        raise
+
+
+def wait_for_extraction(memory_id: str) -> None:
+    """Poll until long-term records appear, or until the max wait elapses.
+
+    In production you would NOT block like this — the agent simply calls recall_memory on
+    the user's next visit. We block here only so the demo's second session has data to recall.
+    """
+    logger.info("⏳ Waiting for asynchronous Semantic extraction to complete...")
+    namespace = SEMANTIC_NAMESPACE.format(actorId=ACTOR_ID)
+    deadline = time.time() + EXTRACTION_MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            records = memory_client.retrieve_memories(
+                memory_id=memory_id,
+                namespace=namespace,
+                query="user facts and details",
+                top_k=1,
+            )
+            if records:
+                logger.info("✅ Long-term records are available")
+                return
+        except Exception as e:
+            logger.warning(f"Retrieval probe failed (will retry): {e}")
+        time.sleep(EXTRACTION_POLL_INTERVAL_SECONDS)
+    logger.warning(
+        "⚠️ Extraction did not surface records within the wait window. "
+        "It may still complete shortly — try re-running retrieval later."
+    )
+
+
+# ## Step 4: Run one user turn through the agent
+#
+# `create_agent(model, tools, system_prompt=...)` builds the ReAct loop: the model may
+# call store_memory / recall_memory zero or more times before producing its final text.
+# We pass the full message list each turn so the agent has the in-session history.
+
+
+def run_turn(graph, messages: list, user_text: str) -> str:
+    """Append the user's message, invoke the agent, return its final reply text.
+
+    `messages` is the running conversation state (mutated in place) so multi-turn context
+    is preserved within a session.
+    """
+    messages.append(HumanMessage(content=user_text))
+    result = graph.invoke({"messages": messages})
+    # create_agent returns the full message list (including any tool calls/results and the
+    # final AI message). Sync our local history to it and return the last message's text.
+    messages[:] = result["messages"]
+    return messages[-1].text()
+
+
+# ## Step 5: Run the demo
+#
+# Two sessions, same ACTOR_ID:
+#   • Session 1 (seed): the user shares durable facts; the agent should call store_memory.
+#   • (wait for extraction)
+#   • Session 2 (new): a FRESH message list — no in-session history. The user asks
+#     something that depends on the past; the agent should call recall_memory itself.
+#
+# We never inject memory into the prompt and never call create_event/retrieve_memories
+# directly in the demo flow — every memory operation happens because the MODEL asked.
+
+
+def main() -> None:
+    memory_id = None  # init so the finally-block cleanup never hits a NameError
+    try:
+        memory_id = get_or_create_memory("LangGraphMemoryAsTool")
+
+        # Initialize the Bedrock-backed chat model.
+        llm = init_chat_model(MODEL_ID, model_provider="bedrock_converse", region_name=REGION)
+
+        # ---- Session 1: the agent saves facts as it learns them ------------------
+        print("\n=== Session 1 (the agent decides what to store) ===")
+        seed_tools = build_memory_tools(memory_id, SEED_SESSION_ID)
+        seed_graph = create_agent(model=llm, tools=seed_tools, system_prompt=SYSTEM_PROMPT)
+        seed_messages: list = []
+        for user_text in [
+            "Hi! I'm Sam. I just moved to Seattle and I'm trying to cook at home more.",
+            "I should mention I'm vegetarian, and I'm allergic to shellfish.",
+            "I'm also training for a half marathon in October, so I'm watching my protein intake.",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_turn(seed_graph, seed_messages, user_text)
+            print(f"Agent: {reply}\n")
+
+        # ---- Wait for the extraction pipeline ------------------------------------
+        wait_for_extraction(memory_id)
+
+        # ---- Session 2: brand-new conversation, the agent recalls on its own -----
+        # Fresh message list => no in-session history. The only way it can personalize is
+        # to call recall_memory itself. The session_id differs, but the ACTOR_ID is the
+        # same, so recall_memory reads the same /users/<actor>/facts/ namespace.
+        print("=== Session 2 (new conversation — the agent decides what to recall) ===")
+        new_tools = build_memory_tools(memory_id, NEW_SESSION_ID)
+        new_graph = create_agent(model=llm, tools=new_tools, system_prompt=SYSTEM_PROMPT)
+        new_messages: list = []
+        for user_text in [
+            "Hey, it's Sam again. Can you suggest a high-protein dinner I could make tonight?",
+        ]:
+            print(f"User:  {user_text}")
+            reply = run_turn(new_graph, new_messages, user_text)
+            print(f"Agent: {reply}\n")
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable, so we delete the resource when the demo
+        # finishes. To keep the memory between runs (e.g. to inspect it in the console),
+        # comment out the block below — `get_or_create_memory` will reuse it.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info(f"✅ Deleted memory: {memory_id}")
+            except Exception as e:
+                logger.error(f"Failed to delete memory {memory_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/03-memory-as-tool/requirements.txt
@@ -1,0 +1,8 @@
+boto3
+bedrock_agentcore
+# LangGraph v1.0+: create_agent lives in the `langchain` package (>=1.0); `langgraph` is
+# the underlying runtime.
+langchain>=1.0
+langgraph>=1.0
+langchain_aws
+langchain_core

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-langgraph-agent/README.md
@@ -1,25 +1,50 @@
 # Long-term memory — LangGraph single-agent
 
-Three integration patterns matching the LangGraph model.
+Three integration patterns for giving a LangGraph agent long-term memory backed by
+Amazon Bedrock AgentCore Memory. They differ in **who decides when to store and recall**.
 
-| Pattern | Folder | Notes |
+| Pattern | Folder | What it shows |
 |---|---|---|
-| **Built-in callback** — LangGraph's AgentCore memory callback on the default state-graph lifecycle | [`01-built-in-callback/`](./01-built-in-callback/) | Placeholder — content to be authored |
-| **Custom callback** — write your own node / checkpointer that calls the memory API | [`02-custom-callback/`](./02-custom-callback/) | `custom-user-preferences/` (nutrition assistant, user prefs), `episodic-memory/` (nutrition assistant, episodic) |
-| **memory-as-tool** — memory ops exposed as LangGraph tools the LLM invokes | [`03-memory-tool/`](./03-memory-tool/) | Placeholder — content to be authored |
+| **Built-in callback** — the framework manages the memory lifecycle | [`01-built-in-callback/`](./01-built-in-callback/) | `AgentCoreMemorySaver` (checkpointer) + `AgentCoreMemoryStore` (LTM store) wired via tiny `@dynamic_prompt` / `@after_model` middleware. The lowest-effort integration. |
+| **Custom callback** — you hand-roll the hooks and the strategy | [`02-custom-callback/`](./02-custom-callback/) | `custom-user-preferences/` (nutrition assistant, user-preference strategy) and `episodic-memory/` (nutrition assistant, episodic strategy), each with hand-written pre/post hooks. |
+| **Memory as a tool** — the model decides via tool calls | [`03-memory-as-tool/`](./03-memory-as-tool/) | `store_memory` / `recall_memory` exposed as LangGraph `@tool`s; the agent calls them in the ReAct loop. |
 
 See the [long-term memory README](../../../README.md) for the underlying strategies and APIs.
 
+> ### LangGraph API versions
+> The new tutorials (**`01-built-in-callback`**, **`03-memory-as-tool`**) target the
+> current **LangGraph v1.0** API: `from langchain.agents import create_agent` plus the
+> **middleware** system (`@before_model`, `@after_model`, `@dynamic_prompt`) from
+> `langchain.agents.middleware`. The **`02-custom-callback`** examples still use the older
+> `langgraph.prebuilt.create_react_agent` with `pre_model_hook` / `post_model_hook`, which
+> is **deprecated** in v1.0 but still functional. Both styles run today; new code should
+> prefer `create_agent` + middleware. Each folder's `requirements.txt` pins what it needs.
+
 ## Running the Python Scripts
 
-Install dependencies and run scripts from the relevant sub-folders:
+Install dependencies and run scripts from the relevant sub-folders. Each sub-folder has its
+own `requirements.txt`:
 
 ```bash
-# Install dependencies (in each sub-folder)
+# Built-in callback (AgentCoreMemorySaver + AgentCoreMemoryStore via middleware)
+cd 01-built-in-callback
 pip install -r requirements.txt
+python langgraph-ltm-built-in-callback.py
 
-python 02-custom-callback/episodic-memory/custom_memory_prompts.py
-python 02-custom-callback/episodic-memory/nutrition-assistant-with-episodic-memory.py
-python 02-custom-callback/custom-user-preferences/custom_memory_prompts.py
-python 02-custom-callback/custom-user-preferences/nutrition-assistant-with-user-preference-saving.py
+# Custom callback (hand-rolled hooks + custom strategy override)
+cd ../02-custom-callback/episodic-memory
+pip install -r requirements.txt
+python nutrition-assistant-with-episodic-memory.py
+# or:
+cd ../custom-user-preferences
+pip install -r requirements.txt
+python nutrition-assistant-with-user-preference-saving.py
+
+# Memory as a tool (store_memory / recall_memory as LangGraph tools)
+cd ../../03-memory-as-tool
+pip install -r requirements.txt
+python langgraph-ltm-memory-tool.py
 ```
+
+Multi-agent variant (multiple LangGraph agents sharing one memory resource):
+[`../../multi-agent/with-langgraph-agent/`](../../multi-agent/with-langgraph-agent/).

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/README.md
@@ -1,0 +1,148 @@
+# LlamaIndex + AgentCore memory — built-in memory block (long-term)
+
+The idiomatic way to give a LlamaIndex agent long-term memory: a custom **`BaseMemoryBlock`**
+wired into LlamaIndex's **`Memory`** class, backed by Amazon Bedrock AgentCore. Instead of
+exposing memory as a tool the LLM must remember to call (that's
+[`../03-memory-tool/`](../03-memory-tool/)), the block plugs into the agent's memory
+**lifecycle** — the framework calls it automatically.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term, single-agent |
+| Agent usecase | Personal Knowledge Assistant (remembers user facts across sessions) |
+| Framework | LlamaIndex (`Memory` + `BaseMemoryBlock`, `FunctionAgent`) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in** (no IAM execution role) |
+| Memory components | `BaseMemoryBlock` wrapping `create_event` (put) + `search_long_term_memories` (get) |
+| Complexity | Advanced |
+
+> ### ⚠️ LlamaIndex API note — `Memory` + `BaseMemoryBlock` (NOT `ChatMemoryBuffer`)
+> `ChatMemoryBuffer` is **deprecated**. The current integration point is the **`Memory`**
+> class (`llama_index.core.memory.Memory`) composed of one or more **`BaseMemoryBlock`**
+> subclasses. A block implements two async hooks — `_aget` (retrieve, every turn) and
+> `_aput` (persist, on short-term flush) — plus an optional `atruncate`. Verified against
+> `llama-index-core` 0.14.x.
+
+## How the block maps onto AgentCore
+
+| `BaseMemoryBlock` hook | When the framework calls it | AgentCore call |
+|---|---|---|
+| `_aget(messages)` | **Every turn**, before the LLM runs | `search_long_term_memories(query, namespace)` |
+| `_aput(messages)` | When short-term history **flushes** | `create_event` (via `add_turns`) |
+| `atruncate(content, n)` | When assembled memory is too big | in-memory string trim (no AgentCore call) |
+
+### The one lifecycle gotcha
+
+Blocks do **not** receive every message. `_aput` only fires for messages **ejected from the
+short-term FIFO** when it exceeds its token budget (`from_short_term_memory=True`, verified
+in `llama_index/core/memory/memory.py`). Flushing is driven by the **put path**: each
+`agent.run()` puts messages and `_manage_queue()` ejects the oldest ones once the queue
+passes `chat_history_token_ratio * token_limit`. `aget()` is **read-only** and does **not**
+flush. To make this deterministic in a short demo the script sets a small `token_limit`
+(800) and then sends a couple of short "wind-down" turns at the end of session 1 to push the
+last fact-bearing turns past the flush threshold before waiting for extraction. In
+production you'd use a realistic limit and persistence happens naturally as the conversation
+grows.
+
+## Architecture
+
+```
+                        LlamaIndex FunctionAgent
+                                  │
+                   agent.run(msg, memory=Memory)
+                                  │
+              ┌───────────────────┴────────────────────┐
+              │            LlamaIndex Memory            │
+              │  short-term FIFO (token-bounded queue)  │
+              │                  │ flush (over budget)  │
+              │                  ▼                      │
+              │     AgentCoreMemoryBlock (BaseMemoryBlock)
+              └──────────┬──────────────────┬───────────┘
+                 _aget    │                  │  _aput
+        search_long_term_memories      create_event
+                         │                  │
+                         ▼                  ▼
+           ┌──────────────────────────────────────────┐
+           │       AgentCore Memory (one memory_id)     │
+           │  Semantic strategy →                       │
+           │    /llamaindex-ltm/{actorId}/facts/        │  ◀── write AND read here
+           └──────────────────────────────────────────┘
+```
+
+## ✅ Namespace correctness (read this)
+
+The write path (Semantic extraction) and the read path (`search_long_term_memories`) target
+the **same resolved namespace**. The script defines one template and resolves it once:
+
+```python
+NAMESPACE_TEMPLATE = "/llamaindex-ltm/{actorId}/facts/"
+RESOLVED_NAMESPACE  = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
+# strategy "namespaces": [NAMESPACE_TEMPLATE]   ← writes here
+# _aget search namespace_prefix=RESOLVED_NAMESPACE ← reads here
+```
+
+This avoids a bug present in the older memory-as-tool tutorials, which searched a hard-coded
+`/strategies/` prefix that did **not** match where the Semantic strategy actually wrote — so
+retrieval silently returned nothing. **Always read from the same namespace your strategy
+writes to.**
+
+## What it does
+
+[`llamaindex-ltm-built-in-memory-block.py`](./llamaindex-ltm-built-in-memory-block.py):
+
+1. Creates (or reuses) one memory resource with a built-in **Semantic** strategy whose
+   namespace template is `/llamaindex-ltm/{actorId}/facts/`. No IAM execution role.
+2. **Session 1** teaches the assistant facts about the user (language, allergy, trip,
+   hobbies). The small token budget flushes those turns into AgentCore via the block's
+   `_aput`; the Semantic strategy extracts durable records.
+3. Waits ~90s for asynchronous extraction.
+4. **Session 2** uses a *fresh* `Memory` (empty short-term FIFO), so the only way the
+   assistant can answer recall questions is the block's `_aget` reading AgentCore long-term
+   memory.
+5. Deletes the memory resource in a `finally` block.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model access
+- IAM permissions: `bedrock-agentcore:CreateMemory`, `:DeleteMemory`, `:GetMemory`,
+  `:CreateEvent`, `:RetrieveMemoryRecords`
+- Amazon Bedrock model access for **Claude Sonnet 4.6** in your region (`us-west-2` is a
+  safe default)
+- **No IAM execution role required** — built-in strategies use AgentCore-managed models.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+
+# Optional: override the region (defaults to us-west-2)
+export AWS_REGION=us-west-2
+
+python llamaindex-ltm-built-in-memory-block.py
+```
+
+Expected output: Session 1 prints each turn and a `🧠 Persisted … to AgentCore` line as the
+FIFO flushes; then `⏳ Waiting …` for extraction; then Session 2 recalls the Rust + peanut
+allergy, Lisbon + vegetarian, and classical-guitar facts — none of which were stated in
+Session 2.
+
+## Key implementation notes
+
+- **The agent has no "remember" tool.** Persistence and recall are automatic via the block's
+  lifecycle hooks — that's the whole point versus the memory-as-tool pattern.
+- **Retrieval failures are non-fatal.** `_aget` logs and returns `""` on error, so a
+  transient memory issue degrades gracefully instead of breaking the turn.
+- **`priority=0`** on the block means it's never truncated out of context.
+- **`MemorySessionManager` is a `PrivateAttr`,** created lazily — it isn't a pydantic value,
+  so the block stays clonable/serialisable.
+- **Cleanup runs in `finally`.** The resource is billable; comment out the delete block to
+  keep it between runs.
+
+## Where to go next
+
+- The simpler memory-as-tool pattern: [`../03-memory-tool/`](../03-memory-tool/)
+- A more sophisticated block (conditional storage, scored retrieval):
+  [`../02-custom-memory-block/`](../02-custom-memory-block/)
+- The long-term memory overview (all strategies, retrieval, namespaces):
+  [`../../../../README.md`](../../../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/llamaindex-ltm-built-in-memory-block.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/llamaindex-ltm-built-in-memory-block.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python
+
+# # LlamaIndex with AgentCore Memory - Built-in Memory Block (Long-term Memory)
+#
+# ## Introduction
+#
+# This tutorial demonstrates the **idiomatic** way to give a LlamaIndex agent long-term
+# memory backed by Amazon Bedrock AgentCore: a custom **memory block** wired into
+# LlamaIndex's **`Memory`** class. Instead of exposing memory as a tool the LLM has to
+# remember to call (see `../03-memory-tool/`), the block plugs into the agent's memory
+# **lifecycle** — the framework calls it automatically at the right points:
+#
+#   * On **retrieval** (every turn) the block runs a semantic search against AgentCore
+#     long-term memory and injects the results into the agent's context.
+#   * On **flush** (when short-term history exceeds its token budget) the framework hands
+#     the ejected messages to the block, which writes them to AgentCore as an event; the
+#     memory's Semantic strategy then extracts durable records from them.
+#
+# > ### ⚠️ LlamaIndex API note — `Memory` + `BaseMemoryBlock` (NOT `ChatMemoryBuffer`)
+# > `ChatMemoryBuffer` is **deprecated**. The current integration point is the
+# > **`Memory`** class (`llama_index.core.memory.Memory`) composed of one or more
+# > **`BaseMemoryBlock`** subclasses. A memory block implements two async hooks —
+# > `_aget` (retrieve, every turn) and `_aput` (persist, on short-term flush) — plus an
+# > optional `atruncate`. This file subclasses `BaseMemoryBlock[str]`; verified against
+# > `llama-index-core` 0.14.x.
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term, single-agent                                                          |
+# | Agent usecase       | Personal Knowledge Assistant (remembers facts about the user across sessions)    |
+# | Agentic Framework   | LlamaIndex (`Memory` + `BaseMemoryBlock`, `FunctionAgent`)                        |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                  |
+# | Strategies          | Semantic (facts) — **built-in** (no IAM execution role)                          |
+# | Memory components    | `BaseMemoryBlock` wrapping `create_event` (put) + `search_long_term_memories` (get) |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Subclass `BaseMemoryBlock` to wrap AgentCore Memory (retrieve on get, persist on put)
+# - Compose it into the LlamaIndex `Memory` class and hand that to a `FunctionAgent`
+# - Let the framework drive persistence/retrieval instead of calling memory yourself
+# - Keep the write namespace and the read namespace identical (a common source of bugs)
+#
+# ## How the block maps onto AgentCore
+#
+# | LlamaIndex `BaseMemoryBlock` hook | When the framework calls it      | AgentCore call                                  |
+# |-----------------------------------|----------------------------------|-------------------------------------------------|
+# | `_aget(messages)`                 | Every turn, before the LLM runs  | `search_long_term_memories(query, namespace)`   |
+# | `_aput(messages)`                 | When short-term history flushes  | `create_event(actor_id, session_id, messages)`  |
+# | `atruncate(content, n)`           | When assembled memory is too big | (in-memory string trim — no AgentCore call)      |
+#
+# ## Architecture
+#
+# ```
+#                         LlamaIndex FunctionAgent
+#                                   │
+#                    agent.run(msg, memory=Memory)
+#                                   │
+#               ┌───────────────────┴────────────────────┐
+#               │            LlamaIndex Memory            │
+#               │  short-term FIFO (token-bounded queue)  │
+#               │                  │ flush (over budget)  │
+#               │                  ▼                      │
+#               │     AgentCoreMemoryBlock (BaseMemoryBlock)
+#               └──────────┬──────────────────┬───────────┘
+#                  _aget    │                  │  _aput
+#         search_long_term_memories      create_event
+#                          │                  │
+#                          ▼                  ▼
+#            ┌──────────────────────────────────────────┐
+#            │        AgentCore Memory (one memory_id)    │
+#            │  Semantic strategy →                       │
+#            │    /llamaindex-ltm/{actorId}/facts/        │  ◀── write AND read here
+#            └──────────────────────────────────────────┘
+# ```
+#
+# The write path (`create_event` → Semantic extraction) and the read path
+# (`search_long_term_memories`) target the **same resolved namespace**. This is deliberate:
+# the older memory-as-tool tutorials searched a hard-coded `/strategies/` prefix that did
+# **not** match where the Semantic strategy actually wrote, so retrieval silently returned
+# nothing. We resolve one namespace template and use it for both directions.
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - AWS IAM permissions:
+#   - `bedrock-agentcore:CreateMemory`, `:DeleteMemory`, `:GetMemory`
+#   - `bedrock-agentcore:CreateEvent`, `:RetrieveMemoryRecords`
+# - Amazon Bedrock model access for Claude Sonnet 4.6 in your region
+# - No IAM execution role required — we use a **built-in** Semantic strategy.
+# - `pip install -r requirements.txt`
+
+# ## Step 1: Setup and Imports
+
+
+import asyncio as _asyncio
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+# AgentCore Memory: control-plane client (create/delete) + data-plane session manager
+# (events + long-term search). Both are verified from the bedrock_agentcore SDK source.
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from bedrock_agentcore.memory.session import MemorySessionManager
+from bedrock_agentcore.memory.constants import ConversationalMessage, MessageRole as ACMessageRole
+
+# LlamaIndex current memory API: the Memory container + the BaseMemoryBlock base class.
+# (ChatMemoryBuffer is deprecated and intentionally NOT used here.)
+from llama_index.core.memory import Memory, BaseMemoryBlock, InsertMethod
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.bedrock_converse import BedrockConverse as _BedrockConverseBase
+from pydantic import Field, PrivateAttr
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("llamaindex-builtin-memory-block")
+
+# ---- Configuration --------------------------------------------------------------
+REGION = os.getenv("AWS_REGION", "us-west-2")
+
+# Claude Sonnet 4.6 on Amazon Bedrock. The `global.` prefix selects the global
+# (cross-region) inference endpoint; swap it to pin to a single region.
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+MEMORY_NAME = "LlamaIndexBuiltInMemoryBlock"
+ACTOR_ID = "knowledge-user-001"  # WHO the memories belong to
+
+# Namespace TEMPLATE for the Semantic strategy. `{actorId}` is substituted by AgentCore at
+# extraction time. We resolve it ONCE (below) and use the resolved value for BOTH writes
+# (via the strategy) and reads (via search) so the two never drift apart.
+NAMESPACE_TEMPLATE = "/llamaindex-ltm/{actorId}/facts/"
+RESOLVED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
+
+# Long-term extraction is asynchronous — records surface ~30-90s after an event is written.
+EXTRACTION_WAIT_SECONDS = 90
+
+
+# ## Step 2: A Bedrock LLM that is safe to call from async code
+#
+# `BedrockConverse.achat` uses aiobotocore, which has a credential-loading issue on some
+# Python 3.13 setups. We subclass it to run the synchronous `chat` on a worker thread for
+# every async entry point the agent uses. This keeps the agent fully async without the
+# aiobotocore code path. (Same wrapper used by the sibling LlamaIndex tutorials.)
+
+
+class BedrockConverse(_BedrockConverseBase):
+    """Sync-on-thread wrapper to avoid the aiobotocore Python 3.13 credential issue."""
+
+    async def achat(self, messages, **kwargs):
+        return await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+    async def astream_chat(self, messages, **kwargs):
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+        return _gen()
+
+    async def astream_chat_with_tools(
+        self,
+        tools,
+        user_msg=None,
+        chat_history=None,
+        verbose=False,
+        allow_parallel_tool_calls=False,
+        tool_required=False,
+        **kwargs,
+    ):
+        chat_kwargs = self._prepare_chat_with_tools_compat(
+            tools,
+            user_msg=user_msg,
+            chat_history=chat_history,
+            verbose=verbose,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+            tool_required=tool_required,
+            **kwargs,
+        )
+
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, **chat_kwargs)
+
+        return _gen()
+
+
+# ## Step 3: The custom memory block — `BaseMemoryBlock` wrapping AgentCore
+#
+# This is the heart of the tutorial. `BaseMemoryBlock[str]` is a (pydantic) base whose two
+# abstract hooks we implement:
+#
+#   * `_aget(messages)`  → called EVERY turn. We take the latest user message as the query,
+#     run a semantic search over AgentCore long-term memory, and return a formatted string.
+#     The `Memory` container injects that string into the agent's context
+#     (`InsertMethod.SYSTEM`).
+#   * `_aput(messages)`  → called when the short-term FIFO overflows its token budget and
+#     ejects old messages. We persist those messages to AgentCore via `create_event`; the
+#     Semantic strategy then extracts durable facts from them asynchronously.
+#
+# IMPORTANT lifecycle detail (verified in `llama_index/core/memory/memory.py`): blocks do
+# NOT receive every message — `_aput` only fires for messages **flushed** from short-term
+# memory (`from_short_term_memory=True`). For this demo we set a deliberately small
+# `token_limit` (Step 5) so flushing — and therefore persistence — happens within a short
+# conversation. In production you'd use a realistic limit and persistence happens naturally
+# as the conversation grows.
+
+
+class AgentCoreMemoryBlock(BaseMemoryBlock[str]):
+    """A LlamaIndex memory block backed by Amazon Bedrock AgentCore long-term memory.
+
+    Retrieval (`_aget`) runs a semantic search; persistence (`_aput`) writes flushed
+    short-term messages as an AgentCore event for the Semantic strategy to extract.
+    """
+
+    # --- pydantic fields (configuration) -----------------------------------------
+    memory_id: str = Field(description="AgentCore Memory resource id (the shared store).")
+    actor_id: str = Field(description="WHO these memories belong to.")
+    session_id: str = Field(description="Session the persisted events are grouped under.")
+    namespace: str = Field(description="Fully-resolved namespace for BOTH read and write.")
+    region: str = Field(default="us-west-2", description="AWS region for AgentCore.")
+    retrieval_top_k: int = Field(default=5, description="How many records to retrieve per turn.")
+
+    # The boto-backed session manager is not a pydantic value; keep it as a private,
+    # lazily-initialised attribute so the block stays serialisable/clonable.
+    _manager: Optional[MemorySessionManager] = PrivateAttr(default=None)
+
+    def _session_manager(self) -> MemorySessionManager:
+        """Lazily create (and cache) the AgentCore data-plane session manager."""
+        if self._manager is None:
+            self._manager = MemorySessionManager(memory_id=self.memory_id, region_name=self.region)
+        return self._manager
+
+    @staticmethod
+    def _latest_user_text(messages: Optional[List[ChatMessage]]) -> str:
+        """Use the most recent user message as the semantic-search query."""
+        if not messages:
+            return ""
+        for message in reversed(messages):
+            if message.role == MessageRole.USER and message.content:
+                return str(message.content)
+        return ""
+
+    async def _aget(self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any) -> str:
+        """Retrieve relevant long-term records and return them as a context string.
+
+        Called by the framework every turn. Returning "" contributes nothing to context.
+        Retrieval failures are swallowed (logged) so a transient memory issue never breaks
+        the agent — it simply proceeds without historical context this turn.
+        """
+        query = self._latest_user_text(messages)
+        if not query:
+            return ""
+
+        try:
+            records = await _asyncio.to_thread(
+                self._session_manager().search_long_term_memories,
+                query=query,
+                namespace_prefix=self.namespace,  # SAME namespace we write to
+                top_k=self.retrieval_top_k,
+            )
+        except ClientError as exc:
+            logger.warning("⚠️  Long-term retrieval failed (%s) — proceeding without it.", exc)
+            return ""
+
+        texts: List[str] = []
+        for record in records:
+            # MemoryRecord wraps the service shape {"content": {"text": "..."}, ...}.
+            content = record.get("content", {}) if hasattr(record, "get") else {}
+            text = content.get("text", "").strip() if isinstance(content, dict) else ""
+            if text:
+                texts.append(text)
+
+        if not texts:
+            return ""
+
+        logger.info("🔎 Retrieved %d long-term record(s) for the agent.", len(texts))
+        bullets = "\n".join(f"- {t}" for t in texts)
+        return f"What you remember about this user from previous sessions:\n{bullets}"
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        """Persist short-term messages ejected from the FIFO to AgentCore.
+
+        Only user/assistant messages with text content are written — empty tool-call
+        envelopes are skipped (they can't be reconstructed and add no semantic value).
+        """
+        to_store: List[ConversationalMessage] = []
+        for message in messages:
+            if message.role == MessageRole.USER and message.content:
+                to_store.append(ConversationalMessage(str(message.content), ACMessageRole.USER))
+            elif message.role == MessageRole.ASSISTANT and message.content:
+                to_store.append(ConversationalMessage(str(message.content), ACMessageRole.ASSISTANT))
+
+        if not to_store:
+            return
+
+        try:
+            await _asyncio.to_thread(
+                self._session_manager().add_turns,
+                actor_id=self.actor_id,
+                session_id=self.session_id,
+                messages=to_store,
+            )
+            logger.info("🧠 Persisted %d flushed message(s) to AgentCore (queued for extraction).", len(to_store))
+        except ClientError as exc:
+            # Never crash the agent because a memory write failed; log and continue.
+            logger.error("❌ Failed to persist flushed messages: %s", exc)
+
+    async def atruncate(self, content: str, tokens_to_truncate: int) -> Optional[str]:
+        """Trim retrieved context if assembled memory exceeds the token budget.
+
+        We drop whole bullet lines from the end until we're roughly under budget. Returning
+        "" would drop the block entirely; returning None (base default) does the same.
+        """
+        if tokens_to_truncate <= 0 or not content:
+            return content
+        lines = content.splitlines()
+        # ~4 chars/token is a coarse but standard estimate for trimming display text.
+        approx_chars_to_cut = tokens_to_truncate * 4
+        cut = 0
+        while lines and cut < approx_chars_to_cut:
+            cut += len(lines[-1]) + 1
+            lines.pop()
+        return "\n".join(lines)
+
+
+# ## Step 4: A small domain tool (so the agent is a realistic FunctionAgent)
+#
+# The memory block handles persistence and recall automatically — the agent does NOT need a
+# "remember this" tool. We give it one lightweight domain tool so it behaves like a normal
+# task agent while memory works invisibly underneath.
+
+
+def note_interest(topic: str, detail: str) -> str:
+    """Record that the user is interested in a topic, with a short detail."""
+    logger.info("📝 Noted interest: %s — %s", topic, detail)
+    return f"Noted your interest in {topic}: {detail}"
+
+
+# ## Step 5: Wiring the block into the LlamaIndex `Memory` class
+#
+# `Memory.from_defaults` builds the short-term FIFO and attaches our long-term block.
+# `priority=0` means the block is NEVER truncated away (it's our durable recall surface).
+# We use a small `token_limit` so the FIFO flushes during this short demo, exercising the
+# `_aput` persistence path deterministically.
+
+
+def build_memory(memory_id: str, session_id: str) -> Memory:
+    """Construct a LlamaIndex Memory backed by our AgentCore block for a given session."""
+    agentcore_block = AgentCoreMemoryBlock(
+        name="agentcore_longterm",  # required by BaseMemoryBlock
+        memory_id=memory_id,
+        actor_id=ACTOR_ID,
+        session_id=session_id,
+        namespace=RESOLVED_NAMESPACE,
+        region=REGION,
+        retrieval_top_k=5,
+        priority=0,  # 0 = never truncate this block out of context
+    )
+    return Memory.from_defaults(
+        session_id=session_id,
+        token_limit=800,  # SMALL on purpose so the FIFO flushes within the demo
+        chat_history_token_ratio=0.5,  # flush when short-term exceeds ~400 tokens
+        token_flush_size=120,  # flush ~120 tokens at a time to the block
+        memory_blocks=[agentcore_block],
+        insert_method=InsertMethod.SYSTEM,  # inject recalled memory into the system message
+    )
+
+
+def build_agent(llm: BedrockConverse) -> FunctionAgent:
+    """Create the FunctionAgent. Memory is passed per-run, not bound to the agent."""
+    return FunctionAgent(
+        tools=[FunctionTool.from_defaults(fn=note_interest)],
+        llm=llm,
+        system_prompt=(
+            "You are a Personal Knowledge Assistant. You build up durable knowledge about "
+            "the user over time. When the system context includes 'What you remember about "
+            "this user', treat it as established fact and use it to personalise your answer. "
+            "Be concise and concrete."
+        ),
+    )
+
+
+# ## Step 6: Create the shared memory resource (one built-in Semantic strategy)
+
+
+def get_or_create_memory(memory_client: MemoryClient) -> str:
+    """Create the memory with a built-in Semantic strategy, or reuse it if it exists."""
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "PersonalFacts",
+                "description": "Durable facts about the user, extracted from conversation.",
+                # The strategy writes records under this template. We retrieve from the
+                # SAME template (resolved) — no namespace drift.
+                "namespaces": [NAMESPACE_TEMPLATE],
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=MEMORY_NAME,
+            strategies=strategies,
+            description="LlamaIndex built-in memory block tutorial — semantic LTM",
+            event_expiry_days=30,
+            # NOTE: built-in strategies need NO memory_execution_role_arn.
+        )
+        memory_id = memory["id"]
+        logger.info("✅ Created memory with built-in Semantic strategy: %s", memory_id)
+        return memory_id
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ValidationException" and "already exists" in str(exc):
+            logger.info("Memory '%s' already exists — reusing it.", MEMORY_NAME)
+            existing = next((m["id"] for m in memory_client.list_memories() if m.get("name") == MEMORY_NAME), None)
+            if not existing:
+                raise RuntimeError(f"Memory '{MEMORY_NAME}' reported as existing but not found")
+            logger.info("✅ Reusing existing memory: %s", existing)
+            return existing
+        raise
+
+
+# ## Step 7: Drive the demo — build knowledge in one session, recall it in another
+#
+# Session 1 teaches the assistant facts about the user; the small token budget flushes those
+# turns into AgentCore, where the Semantic strategy extracts them. After the extraction wait,
+# Session 2 (a brand-new Memory, so an empty short-term FIFO) asks the assistant to recall —
+# the only way it can answer is via the block's `_aget` reading AgentCore long-term memory.
+
+
+async def main() -> None:
+    memory_client = MemoryClient(region_name=REGION)
+    memory_id: Optional[str] = None
+    llm = BedrockConverse(model=MODEL_ID, region_name=REGION)
+    agent = build_agent(llm)
+
+    try:
+        memory_id = get_or_create_memory(memory_client)
+        # Brief data-plane propagation pause after the resource goes ACTIVE.
+        time.sleep(10)
+
+        # ---- Session 1: build up knowledge -------------------------------------
+        print("\n=== Session 1: building long-term knowledge ===")
+        session1 = build_memory(memory_id, session_id=f"session-1-{datetime.now().strftime('%Y%m%d%H%M%S')}")
+
+        session1_turns = [
+            "Hi! I'm Dana, a backend engineer. I mostly work in Rust and I'm allergic to peanuts.",
+            "I'm planning a team offsite in Lisbon next quarter and I prefer vegetarian restaurants.",
+            "For my reading list, note my interest in distributed systems, especially consensus protocols.",
+            "I also play classical guitar on weekends and I'm learning Portuguese for the trip.",
+        ]
+        for turn in session1_turns:
+            response = await agent.run(turn, memory=session1)
+            print(f"\n👤 {turn}\n🤖 {response}")
+
+        # Flushing is driven by the PUT path: each agent.run() puts messages, and when the
+        # short-term FIFO exceeds chat_history_token_ratio * token_limit, the OLDEST messages
+        # are ejected to the block's _aput (verified in llama_index/core/memory/memory.py —
+        # aget() is read-only and does NOT flush). With our small token_limit the early
+        # fact-bearing turns flush during the conversation above. To make sure the LAST
+        # fact-bearing turns are pushed out too, we send a couple of short "wind-down" turns
+        # that grow the queue past the flush threshold before we wait for extraction.
+        for closing in ("Thanks, that's really helpful!", "That's everything for today."):
+            await agent.run(closing, memory=session1)
+
+        # ---- Wait for asynchronous semantic extraction -------------------------
+        print(f"\n⏳ Waiting ~{EXTRACTION_WAIT_SECONDS}s for AgentCore to extract semantic records...")
+        await _asyncio.sleep(EXTRACTION_WAIT_SECONDS)
+        print("✅ Extraction window elapsed — long-term records should be searchable.")
+
+        # ---- Session 2: a fresh Memory; recall depends entirely on AgentCore ---
+        print("\n=== Session 2: fresh session, recall from long-term memory ===")
+        session2 = build_memory(memory_id, session_id=f"session-2-{datetime.now().strftime('%Y%m%d%H%M%S')}")
+
+        recall_prompts = [
+            "What do you remember about my programming language preferences and any allergies?",
+            "I'm booking dinner for my upcoming offsite — what should you keep in mind about location and food?",
+            "Suggest a weekend activity that fits my hobbies.",
+        ]
+        for prompt in recall_prompts:
+            response = await agent.run(prompt, memory=session2)
+            print(f"\n👤 {prompt}\n🤖 {response}")
+
+        print(
+            "\n✅ Expected: the assistant recalls Rust + peanut allergy, Lisbon + vegetarian, "
+            "and classical guitar — none of which were said in Session 2."
+        )
+
+    finally:
+        # ## Cleanup
+        #
+        # AgentCore Memory resources are billable. We delete the resource even if a step
+        # raised. Comment out this block to keep the memory between runs (get_or_create
+        # will reuse it).
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info("✅ Deleted memory: %s", memory_id)
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask the real error
+                logger.error("Failed to delete memory %s: %s", memory_id, exc)
+
+
+if __name__ == "__main__":
+    _asyncio.run(main())

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/llamaindex-ltm-built-in-memory-block.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/llamaindex-ltm-built-in-memory-block.py
@@ -102,7 +102,6 @@ import time
 from datetime import datetime
 from typing import Any, List, Optional
 
-import boto3
 from botocore.exceptions import ClientError
 
 # AgentCore Memory: control-plane client (create/delete) + data-plane session manager
@@ -402,26 +401,18 @@ def get_or_create_memory(memory_client: MemoryClient) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=MEMORY_NAME,
-            strategies=strategies,
-            description="LlamaIndex built-in memory block tutorial — semantic LTM",
-            event_expiry_days=30,
-            # NOTE: built-in strategies need NO memory_execution_role_arn.
-        )
-        memory_id = memory["id"]
-        logger.info("✅ Created memory with built-in Semantic strategy: %s", memory_id)
-        return memory_id
-    except ClientError as exc:
-        if exc.response["Error"]["Code"] == "ValidationException" and "already exists" in str(exc):
-            logger.info("Memory '%s' already exists — reusing it.", MEMORY_NAME)
-            existing = next((m["id"] for m in memory_client.list_memories() if m.get("name") == MEMORY_NAME), None)
-            if not existing:
-                raise RuntimeError(f"Memory '{MEMORY_NAME}' reported as existing but not found")
-            logger.info("✅ Reusing existing memory: %s", existing)
-            return existing
-        raise
+    # create_or_get_memory creates the resource, or returns the existing one on a name
+    # clash — no manual already-exists scan needed. Built-in strategies need NO
+    # memory_execution_role_arn.
+    memory = memory_client.create_or_get_memory(
+        name=MEMORY_NAME,
+        strategies=strategies,
+        description="LlamaIndex built-in memory block tutorial — semantic LTM",
+        event_expiry_days=30,
+    )
+    memory_id = memory["id"]
+    logger.info("✅ Memory with built-in Semantic strategy ready: %s", memory_id)
+    return memory_id
 
 
 # ## Step 7: Drive the demo — build knowledge in one session, recall it in another

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/01-built-in-memory-block/requirements.txt
@@ -1,0 +1,7 @@
+# The Memory class + BaseMemoryBlock API (replacing the deprecated ChatMemoryBuffer) is in
+# modern llama-index-core. Pinned to a known-good floor; latest 0.14.x verified.
+llama-index-core>=0.12.0
+llama-index-llms-bedrock-converse>=0.3.0
+bedrock-agentcore>=0.1.6
+boto3>=1.34.0
+pydantic>=2.0.0

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/README.md
@@ -1,0 +1,134 @@
+# LlamaIndex + AgentCore memory — custom memory block (self-managed extraction)
+
+A more sophisticated custom `BaseMemoryBlock` than
+[`../01-built-in-memory-block/`](../01-built-in-memory-block/): this one **owns its
+extraction logic**. It decides *what* is worth storing, distills it before writing, and
+score-filters what it reads back — the "self-managed" philosophy applied **at the block
+level**, in-process, with no extra infrastructure.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term, single-agent |
+| Agent usecase | Customer Support Assistant (durable customer profile across contacts) |
+| Framework | LlamaIndex (`Memory` + custom `BaseMemoryBlock`, `FunctionAgent`) |
+| LLM model | Claude Sonnet 4.6 — `global.anthropic.claude-sonnet-4-6` (via Amazon Bedrock) |
+| Strategies | Semantic (facts) — **built-in**; extraction *gated* by the block |
+| Memory components | Conditional `_aput` (LLM-judged), score-filtered `_aget`, client-side distillation |
+| Complexity | Advanced |
+
+> ### ⚠️ LlamaIndex API note — `Memory` + `BaseMemoryBlock` (NOT `ChatMemoryBuffer`)
+> `ChatMemoryBuffer` is **deprecated**. This block subclasses `BaseMemoryBlock[str]` and
+> implements `_aget` (retrieve, every turn) and `_aput` (persist, on short-term flush).
+> Verified against `llama-index-core` 0.14.x.
+
+## What makes this block "sophisticated"
+
+1. **Conditional storage.** On flush, the block asks an in-process extractor LLM to judge
+   whether the snippet contains a stable, reusable fact. Greetings and chit-chat are
+   dropped; only durable facts are written.
+2. **Client-side distillation (self-managed extraction).** It writes the *distilled* fact —
+   one clean sentence — not the raw turns. You own the "what to extract" step.
+3. **Score-filtered retrieval.** On read it keeps only records whose AgentCore relevance
+   `score` clears `MIN_RELEVANCE_SCORE` (0.3), so weak matches never reach the LLM.
+4. **Fail-safe parsing.** The extractor must return strict JSON; any unparseable output
+   means *store nothing* rather than guess.
+
+## 🛠️ "Self-managed" — two levels, and where this sits
+
+AgentCore offers a **server-side** self-managed strategy (`customMemoryStrategy` +
+`selfManagedConfiguration`): AgentCore drops conversation payloads to **your S3 bucket**,
+notifies **your SNS topic**, and **your** Lambda writes records back via
+`BatchCreateMemoryRecords`. That needs standing infrastructure and an execution role — it's
+documented at [`../../../../03-self-managed-strategy/`](../../../../03-self-managed-strategy/).
+
+This tutorial shows the **client-side / in-process** form: the LlamaIndex block runs the
+extraction itself, synchronously, with zero extra infra. Use it when your extraction logic
+is light enough to run in the agent process. Reach for the server-side strategy when
+extraction is heavy, must use external context (CRM/EHR), or has to run out-of-band.
+
+## Architecture
+
+```
+                         LlamaIndex FunctionAgent
+                                   │
+                    agent.run(msg, memory=Memory)
+                                   │
+              ┌────────────────────┴─────────────────────┐
+              │             LlamaIndex Memory             │
+              │   short-term FIFO (token-bounded queue)   │
+              │                   │ flush (over budget)   │
+              │                   ▼                       │
+              │   SelfManagedMemoryBlock (BaseMemoryBlock)│
+              │     _aput:  LLM distill ─▶ worth storing? ─┼─ no ─▶ drop
+              │                              │ yes          │
+              │     _aget:  search ─▶ score ≥ threshold?   │
+              └───────────┬───────────────────┬───────────┘
+                 search    │                   │  create_event
+           (filter by score)                  (distilled fact only)
+                          ▼                    ▼
+            ┌─────────────────────────────────────────────┐
+            │         AgentCore Memory (one memory_id)      │
+            │   Semantic strategy →                         │
+            │     /support/{actorId}/profile/               │  ◀── write AND read here
+            └─────────────────────────────────────────────┘
+```
+
+## ✅ Namespace correctness
+
+As in the built-in block, the strategy's write namespace and the block's read namespace are
+the **same resolved template** — `/support/{actorId}/profile/`. This avoids the drift bug in
+the older memory-as-tool tutorials (which searched a hard-coded `/strategies/` prefix that
+didn't match the write target, so retrieval returned nothing). **Read from where you write.**
+
+## What it does
+
+[`llamaindex-ltm-custom-memory-block.py`](./llamaindex-ltm-custom-memory-block.py):
+
+1. Creates (or reuses) one memory with a built-in Semantic strategy on
+   `/support/{actorId}/profile/`.
+2. **Session 1** mixes memory-worthy facts (plan, billing rules, recurring issue) with
+   throwaway chit-chat. The block stores the former and drops the latter.
+3. Waits ~90s for asynchronous extraction.
+4. **Session 2** (fresh `Memory`) verifies recall, with only score-clearing facts surfacing.
+5. Deletes the memory resource in a `finally` block.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with **both** AgentCore Memory permissions and Amazon Bedrock model access
+- IAM permissions: `bedrock-agentcore:CreateMemory`, `:DeleteMemory`, `:GetMemory`,
+  `:CreateEvent`, `:RetrieveMemoryRecords`
+- Amazon Bedrock model access for **Claude Sonnet 4.6** in your region
+- **No IAM execution role required** — the gating/distillation runs in-process.
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+export AWS_REGION=us-west-2   # optional; defaults to us-west-2
+python llamaindex-ltm-custom-memory-block.py
+```
+
+Expected output: Session 1 prints `🧠 Stored distilled fact` for the plan/billing/issue
+turns and `🚫 Nothing memory-worthy … skipping write` for the chit-chat; Session 2 recalls
+the stored facts (Enterprise + SSO, EUR invoices, the Monday export issue) and not the
+weather/greeting talk.
+
+## Key implementation notes
+
+- **Two LLMs, distinct roles.** One drives the conversation; a second (`bind_extractor`)
+  runs the distillation/gating step. They can be the same model id but are separate calls.
+- **Fail-safe extraction.** Unparseable extractor output → store nothing. Memory writes
+  never fabricate.
+- **Score filtering uses the `score` field** AgentCore returns on each retrieved record
+  (a Double, higher = more relevant; missing score is treated as 0.0 → conservative).
+- **`priority=0`** keeps the profile block from being truncated out of context.
+- **Cleanup runs in `finally`.** Comment out the delete block to keep the memory.
+
+## Where to go next
+
+- The simpler built-in block: [`../01-built-in-memory-block/`](../01-built-in-memory-block/)
+- Memory-as-tool pattern: [`../03-memory-tool/`](../03-memory-tool/)
+- Full server-side self-managed strategy (SNS + S3 + Lambda):
+  [`../../../../03-self-managed-strategy/`](../../../../03-self-managed-strategy/)
+- Long-term memory overview: [`../../../../README.md`](../../../../README.md)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/llamaindex-ltm-custom-memory-block.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/llamaindex-ltm-custom-memory-block.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python
+
+# # LlamaIndex with AgentCore Memory - Custom Memory Block (Self-managed extraction)
+#
+# ## Introduction
+#
+# This tutorial builds on the built-in memory block (`../01-built-in-memory-block/`) with a
+# **more sophisticated** custom `BaseMemoryBlock` that owns its extraction logic — the
+# "self-managed" philosophy applied at the **block level**. Where the built-in block wrote
+# raw flushed turns and let AgentCore's Semantic strategy decide what to keep, this block:
+#
+#   1. **Decides what to store (conditional logic).** Before writing anything, it asks the
+#      LLM to distill the flushed turns into a single durable fact AND to judge whether the
+#      content is memory-worthy. Greetings, chit-chat, and transient questions are dropped;
+#      only stable, reusable facts are persisted.
+#   2. **Distills before writing (self-managed extraction).** It writes the *distilled* fact
+#      — not the raw conversation — so the stored record is clean and high-signal. You own
+#      the "what to extract" step instead of delegating it entirely to the service.
+#   3. **Filters retrieval by score.** On read it runs a semantic search and keeps only
+#      records whose relevance `score` clears a threshold, so weak matches never pollute the
+#      agent's context.
+#
+# > ### ⚠️ LlamaIndex API note — `Memory` + `BaseMemoryBlock` (NOT `ChatMemoryBuffer`)
+# > `ChatMemoryBuffer` is **deprecated**. This block subclasses `BaseMemoryBlock[str]` and
+# > implements `_aget` (retrieve, every turn) and `_aput` (persist, on short-term flush),
+# > exactly as the built-in tutorial. Verified against `llama-index-core` 0.14.x.
+#
+# > ### 🛠️ "Self-managed" — two levels, and where this sits
+# > AgentCore has a *server-side* self-managed strategy (`customMemoryStrategy` +
+# > `selfManagedConfiguration`) where AgentCore drops conversation payloads to **your S3
+# > bucket**, notifies **your SNS topic**, and **your** Lambda writes records back via
+# > `BatchCreateMemoryRecords`. That requires standing infrastructure and is documented at
+# > [`../../../../03-self-managed-strategy/`](../../../../03-self-managed-strategy/).
+# >
+# > THIS tutorial shows the **client-side / in-process** form of self-managed extraction:
+# > the LlamaIndex block runs the extraction itself, synchronously, with no extra infra, and
+# > stores the distilled result. It's the right pattern when your extraction logic is light
+# > enough to run in the agent process and you want zero operational overhead.
+#
+# ### Tutorial Details
+#
+# | Information         | Details                                                                          |
+# |:--------------------|:---------------------------------------------------------------------------------|
+# | Tutorial type       | Long-term, single-agent                                                          |
+# | Agent usecase       | Customer Support Assistant (durable customer profile across contacts)            |
+# | Agentic Framework   | LlamaIndex (`Memory` + custom `BaseMemoryBlock`, `FunctionAgent`)                |
+# | LLM model           | Anthropic Claude Sonnet 4.6 (via Amazon Bedrock)                                 |
+# | Strategies          | Semantic (facts) — **built-in** strategy; extraction *gated* by the block        |
+# | Memory components    | Conditional `_aput` (LLM-judged), score-filtered `_aget`, client-side distillation |
+# | Example complexity  | Advanced                                                                         |
+#
+# You'll learn to:
+# - Add conditional storage to a memory block (don't persist low-value turns)
+# - Run a client-side extraction/distillation step before writing (self-managed)
+# - Score-filter retrieved records so only strong matches reach the LLM
+# - Keep the write namespace and read namespace identical (avoid the classic drift bug)
+#
+# ## Architecture
+#
+# ```
+#                          LlamaIndex FunctionAgent
+#                                    │
+#                     agent.run(msg, memory=Memory)
+#                                    │
+#               ┌────────────────────┴─────────────────────┐
+#               │             LlamaIndex Memory             │
+#               │   short-term FIFO (token-bounded queue)   │
+#               │                   │ flush (over budget)   │
+#               │                   ▼                       │
+#               │   SelfManagedMemoryBlock (BaseMemoryBlock)│
+#               │     _aput:  LLM distill ─▶ worth storing? ─┼─ no ─▶ drop
+#               │                              │ yes          │
+#               │     _aget:  search ─▶ score ≥ threshold?   │
+#               └───────────┬───────────────────┬───────────┘
+#                  search    │                   │  create_event
+#            (filter by score)                  (distilled fact only)
+#                           ▼                    ▼
+#             ┌─────────────────────────────────────────────┐
+#             │         AgentCore Memory (one memory_id)      │
+#             │   Semantic strategy →                         │
+#             │     /support/{actorId}/profile/               │  ◀── write AND read here
+#             └─────────────────────────────────────────────┘
+# ```
+#
+# ## Prerequisites
+#
+# - Python 3.10+
+# - AWS credentials with AgentCore Memory permissions AND Amazon Bedrock model access
+# - IAM permissions: `bedrock-agentcore:CreateMemory`, `:DeleteMemory`, `:GetMemory`,
+#   `:CreateEvent`, `:RetrieveMemoryRecords`
+# - Amazon Bedrock model access for Claude Sonnet 4.6 in your region
+# - No IAM execution role required — we use a **built-in** Semantic strategy; the extra
+#   logic (gating + distillation) runs in-process.
+# - `pip install -r requirements.txt`
+
+# ## Step 1: Setup and Imports
+
+
+import asyncio as _asyncio
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any, List, Optional
+
+from botocore.exceptions import ClientError
+
+from bedrock_agentcore.memory import MemoryClient
+from bedrock_agentcore.memory.constants import StrategyType
+from bedrock_agentcore.memory.session import MemorySessionManager
+from bedrock_agentcore.memory.constants import ConversationalMessage, MessageRole as ACMessageRole
+
+from llama_index.core.memory import Memory, BaseMemoryBlock, InsertMethod
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.bedrock_converse import BedrockConverse as _BedrockConverseBase
+from pydantic import Field, PrivateAttr
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("llamaindex-custom-memory-block")
+
+# ---- Configuration --------------------------------------------------------------
+REGION = os.getenv("AWS_REGION", "us-west-2")
+MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+MEMORY_NAME = "LlamaIndexCustomMemoryBlock"
+ACTOR_ID = "customer-7741"  # the customer whose durable profile we build
+
+# Namespace template for the Semantic strategy. Resolved ONCE and used for BOTH the
+# strategy's write target and the block's read query — no drift between write and read.
+NAMESPACE_TEMPLATE = "/support/{actorId}/profile/"
+RESOLVED_NAMESPACE = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
+
+EXTRACTION_WAIT_SECONDS = 90
+
+# Retrieval: only records at or above this relevance score reach the agent. AgentCore
+# returns a `score` (0-1, higher = more relevant) on each record from RetrieveMemoryRecords.
+MIN_RELEVANCE_SCORE = 0.3
+
+
+# ## Step 2: A Bedrock LLM safe to call from async code
+#
+# Same sync-on-thread wrapper as the sibling tutorials: avoids the aiobotocore Python 3.13
+# credential-loading issue by running synchronous `chat` on a worker thread.
+
+
+class BedrockConverse(_BedrockConverseBase):
+    """Sync-on-thread wrapper to avoid the aiobotocore Python 3.13 credential issue."""
+
+    async def achat(self, messages, **kwargs):
+        return await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+    async def astream_chat(self, messages, **kwargs):
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, messages, **kwargs)
+
+        return _gen()
+
+    async def astream_chat_with_tools(
+        self,
+        tools,
+        user_msg=None,
+        chat_history=None,
+        verbose=False,
+        allow_parallel_tool_calls=False,
+        tool_required=False,
+        **kwargs,
+    ):
+        chat_kwargs = self._prepare_chat_with_tools_compat(
+            tools,
+            user_msg=user_msg,
+            chat_history=chat_history,
+            verbose=verbose,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+            tool_required=tool_required,
+            **kwargs,
+        )
+
+        async def _gen():
+            yield await _asyncio.to_thread(self.chat, **chat_kwargs)
+
+        return _gen()
+
+
+# ## Step 3: The self-managed custom memory block
+#
+# The block holds its OWN reference to an LLM (`_extractor_llm`) used purely for the
+# extraction/gating step — separate from the agent's conversation LLM. On flush it distills,
+# decides, and conditionally writes; on retrieval it searches and score-filters.
+
+
+# Prompt the block uses to distill + gate flushed turns. We ask for strict JSON so parsing
+# is deterministic; on any parse failure we fail SAFE (store nothing) rather than guess.
+_EXTRACTION_PROMPT = """You maintain a durable customer-support profile. Given the recent \
+conversation snippet below, extract ONLY stable, reusable facts about the customer \
+(identity, account, preferences, recurring issues, entitlements). Ignore greetings, \
+pleasantries, one-off questions, and anything transient.
+
+Respond with STRICT JSON and nothing else:
+{{"worth_storing": <true|false>, "fact": "<one concise sentence, or empty string>"}}
+
+Conversation snippet:
+{snippet}
+"""
+
+
+class SelfManagedMemoryBlock(BaseMemoryBlock[str]):
+    """A custom memory block that owns its extraction: conditional, distilled writes and
+    score-filtered reads, backed by Amazon Bedrock AgentCore long-term memory."""
+
+    # --- pydantic fields ---------------------------------------------------------
+    memory_id: str = Field(description="AgentCore Memory resource id.")
+    actor_id: str = Field(description="WHO the profile belongs to.")
+    session_id: str = Field(description="Session events are grouped under.")
+    namespace: str = Field(description="Fully-resolved namespace for BOTH read and write.")
+    region: str = Field(default="us-west-2", description="AWS region for AgentCore.")
+    retrieval_top_k: int = Field(default=8, description="Candidates to fetch before score-filtering.")
+    min_score: float = Field(default=0.3, description="Drop retrieved records below this relevance score.")
+
+    # Non-pydantic runtime collaborators (lazy / injected) kept as private attrs.
+    _manager: Optional[MemorySessionManager] = PrivateAttr(default=None)
+    _extractor_llm: Any = PrivateAttr(default=None)
+
+    def bind_extractor(self, llm: Any) -> "SelfManagedMemoryBlock":
+        """Inject the LLM used for the distillation/gating step. Returns self for chaining."""
+        self._extractor_llm = llm
+        return self
+
+    def _session_manager(self) -> MemorySessionManager:
+        if self._manager is None:
+            self._manager = MemorySessionManager(memory_id=self.memory_id, region_name=self.region)
+        return self._manager
+
+    @staticmethod
+    def _latest_user_text(messages: Optional[List[ChatMessage]]) -> str:
+        if not messages:
+            return ""
+        for message in reversed(messages):
+            if message.role == MessageRole.USER and message.content:
+                return str(message.content)
+        return ""
+
+    # ---- RETRIEVAL: search + score filter ---------------------------------------
+    async def _aget(self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any) -> str:
+        """Retrieve relevant profile facts, keeping only those above the score threshold."""
+        query = self._latest_user_text(messages)
+        if not query:
+            return ""
+
+        try:
+            records = await _asyncio.to_thread(
+                self._session_manager().search_long_term_memories,
+                query=query,
+                namespace_prefix=self.namespace,  # SAME namespace we write to
+                top_k=self.retrieval_top_k,
+            )
+        except ClientError as exc:
+            logger.warning("⚠️  Retrieval failed (%s) — proceeding without profile context.", exc)
+            return ""
+
+        kept: List[str] = []
+        dropped = 0
+        for record in records:
+            # `score` is an optional Double on each MemoryRecordSummary (verified in the
+            # bedrock-agentcore service model). Treat a missing score as 0.0 → conservative.
+            score = record.get("score", 0.0) if hasattr(record, "get") else 0.0
+            content = record.get("content", {}) if hasattr(record, "get") else {}
+            text = content.get("text", "").strip() if isinstance(content, dict) else ""
+            if not text:
+                continue
+            if score is not None and score >= self.min_score:
+                kept.append(text)
+            else:
+                dropped += 1
+
+        logger.info("🔎 Retrieval: kept %d record(s), dropped %d below score %.2f.", len(kept), dropped, self.min_score)
+        if not kept:
+            return ""
+        bullets = "\n".join(f"- {t}" for t in kept)
+        return f"Known facts about this customer (high-confidence):\n{bullets}"
+
+    # ---- PERSISTENCE: distill + gate + conditional write ------------------------
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        """Distill flushed turns into one durable fact and store it ONLY if worth keeping."""
+        snippet = self._format_snippet(messages)
+        if not snippet:
+            return
+
+        decision = await self._extract_fact(snippet)
+        if not decision.get("worth_storing") or not decision.get("fact"):
+            logger.info("🚫 Nothing memory-worthy in flushed turns — skipping write.")
+            return
+
+        fact = str(decision["fact"]).strip()
+        try:
+            # Write the DISTILLED fact (not the raw turns). It's stored as a USER message so
+            # the Semantic strategy extracts/embeds it; retrieval then finds it by meaning.
+            await _asyncio.to_thread(
+                self._session_manager().add_turns,
+                actor_id=self.actor_id,
+                session_id=self.session_id,
+                messages=[ConversationalMessage(fact, ACMessageRole.USER)],
+            )
+            logger.info("🧠 Stored distilled fact: %r", fact)
+        except ClientError as exc:
+            logger.error("❌ Failed to store distilled fact: %s", exc)
+
+    @staticmethod
+    def _format_snippet(messages: List[ChatMessage]) -> str:
+        """Render flushed messages into a compact transcript for the extractor."""
+        lines: List[str] = []
+        for message in messages:
+            if message.role in (MessageRole.USER, MessageRole.ASSISTANT) and message.content:
+                who = "Customer" if message.role == MessageRole.USER else "Agent"
+                lines.append(f"{who}: {message.content}")
+        return "\n".join(lines)
+
+    async def _extract_fact(self, snippet: str) -> dict:
+        """Run the in-process extractor LLM and parse its strict-JSON verdict.
+
+        Fails SAFE: any error or unparseable output → store nothing. We never fabricate a
+        fact or guess intent when the extractor's output is malformed.
+        """
+        if self._extractor_llm is None:
+            logger.warning("No extractor LLM bound — skipping extraction. Call bind_extractor().")
+            return {"worth_storing": False, "fact": ""}
+
+        prompt = _EXTRACTION_PROMPT.format(snippet=snippet)
+        try:
+            response = await self._extractor_llm.achat([ChatMessage(role=MessageRole.USER, content=prompt)])
+            raw = str(response.message.content).strip()
+            # Be tolerant of fenced code blocks the model might wrap JSON in.
+            if raw.startswith("```"):
+                raw = raw.strip("`")
+                raw = raw[raw.find("{") : raw.rfind("}") + 1]
+            parsed = json.loads(raw)
+            return {
+                "worth_storing": bool(parsed.get("worth_storing", False)),
+                "fact": str(parsed.get("fact", "")),
+            }
+        except (json.JSONDecodeError, AttributeError, KeyError, ValueError) as exc:
+            logger.warning("⚠️  Could not parse extractor output (%s) — failing safe (no write).", exc)
+            return {"worth_storing": False, "fact": ""}
+
+    async def atruncate(self, content: str, tokens_to_truncate: int) -> Optional[str]:
+        """Trim retrieved context from the end if the assembled memory is over budget."""
+        if tokens_to_truncate <= 0 or not content:
+            return content
+        lines = content.splitlines()
+        approx_chars_to_cut = tokens_to_truncate * 4  # ~4 chars/token coarse estimate
+        cut = 0
+        while lines and cut < approx_chars_to_cut:
+            cut += len(lines[-1]) + 1
+            lines.pop()
+        return "\n".join(lines)
+
+
+# ## Step 4: A domain tool (so the agent is a realistic support FunctionAgent)
+
+
+def open_ticket(summary: str, priority: str) -> str:
+    """Open a support ticket with a short summary and a priority (low|medium|high)."""
+    logger.info("🎫 Opened %s-priority ticket: %s", priority, summary)
+    return f"Opened a {priority}-priority ticket: {summary}"
+
+
+# ## Step 5: Wire the block into the LlamaIndex Memory class
+
+
+def build_memory(memory_id: str, session_id: str, extractor_llm: BedrockConverse) -> Memory:
+    """Construct a Memory backed by the self-managed block for a given session."""
+    block = SelfManagedMemoryBlock(
+        name="self_managed_profile",  # required by BaseMemoryBlock
+        memory_id=memory_id,
+        actor_id=ACTOR_ID,
+        session_id=session_id,
+        namespace=RESOLVED_NAMESPACE,
+        region=REGION,
+        retrieval_top_k=8,
+        min_score=MIN_RELEVANCE_SCORE,
+        priority=0,  # never truncate the profile block out of context
+    ).bind_extractor(extractor_llm)
+
+    return Memory.from_defaults(
+        session_id=session_id,
+        token_limit=800,  # small on purpose so the FIFO flushes within the demo
+        chat_history_token_ratio=0.5,
+        token_flush_size=120,
+        memory_blocks=[block],
+        insert_method=InsertMethod.SYSTEM,
+    )
+
+
+def build_agent(llm: BedrockConverse) -> FunctionAgent:
+    return FunctionAgent(
+        tools=[FunctionTool.from_defaults(fn=open_ticket)],
+        llm=llm,
+        system_prompt=(
+            "You are a Customer Support Assistant. When the system context lists 'Known facts "
+            "about this customer', use them to personalise and speed up support. Be concise, "
+            "empathetic, and proactive. Open a ticket when an issue needs follow-up."
+        ),
+    )
+
+
+# ## Step 6: Create the shared memory resource (built-in Semantic strategy)
+
+
+def get_or_create_memory(memory_client: MemoryClient) -> str:
+    strategies = [
+        {
+            StrategyType.SEMANTIC.value: {
+                "name": "CustomerProfile",
+                "description": "Durable, distilled facts about the customer.",
+                "namespaces": [NAMESPACE_TEMPLATE],  # write target == read target
+            }
+        }
+    ]
+    try:
+        memory = memory_client.create_memory_and_wait(
+            name=MEMORY_NAME,
+            strategies=strategies,
+            description="LlamaIndex custom (self-managed) memory block tutorial",
+            event_expiry_days=30,
+        )
+        memory_id = memory["id"]
+        logger.info("✅ Created memory with built-in Semantic strategy: %s", memory_id)
+        return memory_id
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ValidationException" and "already exists" in str(exc):
+            logger.info("Memory '%s' already exists — reusing it.", MEMORY_NAME)
+            existing = next((m["id"] for m in memory_client.list_memories() if m.get("name") == MEMORY_NAME), None)
+            if not existing:
+                raise RuntimeError(f"Memory '{MEMORY_NAME}' reported as existing but not found")
+            return existing
+        raise
+
+
+# ## Step 7: Drive the demo
+#
+# Session 1 mixes memory-worthy facts with throwaway chit-chat — the block should store the
+# former and drop the latter. After extraction, Session 2 (fresh Memory) verifies recall and
+# that only the high-value, score-clearing facts surface.
+
+
+async def main() -> None:
+    memory_client = MemoryClient(region_name=REGION)
+    memory_id: Optional[str] = None
+    conversation_llm = BedrockConverse(model=MODEL_ID, region_name=REGION)
+    extractor_llm = BedrockConverse(model=MODEL_ID, region_name=REGION)
+    agent = build_agent(conversation_llm)
+
+    try:
+        memory_id = get_or_create_memory(memory_client)
+        time.sleep(10)  # brief data-plane propagation after ACTIVE
+
+        # ---- Session 1: mixed signal --------------------------------------------
+        print("\n=== Session 1: build profile (block gates what gets stored) ===")
+        session1 = build_memory(memory_id, f"s1-{datetime.now().strftime('%Y%m%d%H%M%S')}", extractor_llm)
+
+        session1_turns = [
+            "Hey, good morning! Hope you're doing well today.",  # chit-chat → should be dropped
+            "I'm Priya Nair, account #AC-7741. I'm on the Enterprise plan with the SSO add-on.",  # store
+            "By the way, nice weather we're having.",  # chit-chat → drop
+            "Heads up: I always need invoices in EUR and sent to billing@nair-corp.eu.",  # store
+            "I keep hitting a rate-limit error on the bulk-export endpoint every Monday morning.",  # store
+            "Thanks, that's all for now!",  # chit-chat → drop
+        ]
+        for turn in session1_turns:
+            response = await agent.run(turn, memory=session1)
+            print(f"\n👤 {turn}\n🤖 {response}")
+
+        # Flushing happens on the PUT path: as agent.run() puts messages and the short-term
+        # FIFO exceeds chat_history_token_ratio * token_limit, the OLDEST messages are
+        # ejected to the block's _aput (verified in llama_index/core/memory/memory.py —
+        # aget() is read-only and does NOT flush). A couple of short wind-down turns grow the
+        # queue past the threshold so the last fact-bearing turns are flushed too. The block
+        # then GATES each flushed snippet — these closers should be judged not memory-worthy.
+        for closing in ("Thanks, appreciate the help!", "That's all for now."):
+            await agent.run(closing, memory=session1)
+
+        print(f"\n⏳ Waiting ~{EXTRACTION_WAIT_SECONDS}s for semantic extraction...")
+        await _asyncio.sleep(EXTRACTION_WAIT_SECONDS)
+        print("✅ Extraction window elapsed.")
+
+        # ---- Session 2: recall, score-filtered ----------------------------------
+        print("\n=== Session 2: fresh session, score-filtered recall ===")
+        session2 = build_memory(memory_id, f"s2-{datetime.now().strftime('%Y%m%d%H%M%S')}", extractor_llm)
+
+        recall_prompts = [
+            "Remind me which plan and add-ons this account has.",
+            "I need a new invoice — what are the billing requirements on file?",
+            "I'm seeing that recurring export problem again. Can you open a ticket with the context you have?",
+        ]
+        for prompt in recall_prompts:
+            response = await agent.run(prompt, memory=session2)
+            print(f"\n👤 {prompt}\n🤖 {response}")
+
+        print(
+            "\n✅ Expected: Enterprise + SSO, EUR invoices to billing@nair-corp.eu, and the "
+            "Monday bulk-export rate-limit issue are recalled; the weather/greeting chit-chat is not."
+        )
+
+    finally:
+        # ## Cleanup — resources are billable; delete even if a step raised.
+        if memory_id:
+            try:
+                memory_client.delete_memory_and_wait(memory_id=memory_id)
+                logger.info("✅ Deleted memory: %s", memory_id)
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask the real error
+                logger.error("Failed to delete memory %s: %s", memory_id, exc)
+
+
+if __name__ == "__main__":
+    _asyncio.run(main())

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/llamaindex-ltm-custom-memory-block.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/llamaindex-ltm-custom-memory-block.py
@@ -418,24 +418,17 @@ def get_or_create_memory(memory_client: MemoryClient) -> str:
             }
         }
     ]
-    try:
-        memory = memory_client.create_memory_and_wait(
-            name=MEMORY_NAME,
-            strategies=strategies,
-            description="LlamaIndex custom (self-managed) memory block tutorial",
-            event_expiry_days=30,
-        )
-        memory_id = memory["id"]
-        logger.info("✅ Created memory with built-in Semantic strategy: %s", memory_id)
-        return memory_id
-    except ClientError as exc:
-        if exc.response["Error"]["Code"] == "ValidationException" and "already exists" in str(exc):
-            logger.info("Memory '%s' already exists — reusing it.", MEMORY_NAME)
-            existing = next((m["id"] for m in memory_client.list_memories() if m.get("name") == MEMORY_NAME), None)
-            if not existing:
-                raise RuntimeError(f"Memory '{MEMORY_NAME}' reported as existing but not found")
-            return existing
-        raise
+    # create_or_get_memory creates the memory on first run and, on a name clash, returns the
+    # existing memory dict instead of erroring — so reruns reuse the same resource.
+    memory = memory_client.create_or_get_memory(
+        name=MEMORY_NAME,
+        strategies=strategies,
+        description="LlamaIndex custom (self-managed) memory block tutorial",
+        event_expiry_days=30,
+    )
+    memory_id = memory["id"]
+    logger.info("✅ Memory with built-in Semantic strategy ready: %s", memory_id)
+    return memory_id
 
 
 # ## Step 7: Drive the demo

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/02-custom-memory-block/requirements.txt
@@ -1,0 +1,7 @@
+# The Memory class + BaseMemoryBlock API (replacing the deprecated ChatMemoryBuffer) is in
+# modern llama-index-core. Pinned to a known-good floor; latest 0.14.x verified.
+llama-index-core>=0.12.0
+llama-index-llms-bedrock-converse>=0.3.0
+bedrock-agentcore>=0.1.6
+boto3>=1.34.0
+pydantic>=2.0.0

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-llamaindex-agent/README.md
@@ -4,24 +4,40 @@ Three integration patterns matching the LlamaIndex model.
 
 | Pattern | Folder | Notes |
 |---|---|---|
-| **Built-in memory block** — LlamaIndex's AgentCore memory block on the default chat-engine lifecycle | [`01-built-in-memory-block/`](./01-built-in-memory-block/) | Placeholder — content to be authored |
-| **Custom memory block** — subclass the memory block for bespoke extraction/retrieval | [`02-custom-memory-block/`](./02-custom-memory-block/) | Placeholder — content to be authored |
+| **Built-in memory block** — a custom `BaseMemoryBlock` wired into the `Memory` class; the framework calls it automatically (retrieve every turn, persist on flush) | [`01-built-in-memory-block/`](./01-built-in-memory-block/) | Personal Knowledge Assistant — recall user facts across sessions |
+| **Custom memory block** — a sophisticated block that owns its extraction: conditional storage, client-side distillation, score-filtered retrieval | [`02-custom-memory-block/`](./02-custom-memory-block/) | Customer Support Assistant — self-managed extraction in-process |
 | **memory-as-tool** — memory ops exposed as LlamaIndex tools the LLM invokes | [`03-memory-tool/`](./03-memory-tool/) | Four domain examples: academic research, investment advisor, legal doc analyzer, medical knowledge |
+
+> **API note:** the block-based patterns (01, 02) use LlamaIndex's current `Memory` +
+> `BaseMemoryBlock` API. `ChatMemoryBuffer` is **deprecated** and not used. Each block
+> implements `_aget` (retrieve, every turn) and `_aput` (persist, on short-term flush).
 
 See the [long-term memory README](../../../README.md) for the underlying strategies and APIs.
 
 ## Running the Python Scripts
 
-Navigate into each sub-folder and run the scripts:
+Navigate into each sub-folder, install its requirements, and run the script:
 
 ```bash
-pip install -r requirements.txt  # if present
+# 01-built-in-memory-block/
+cd 01-built-in-memory-block
+pip install -r requirements.txt
+python llamaindex-ltm-built-in-memory-block.py
+```
+
+```bash
+# 02-custom-memory-block/
+cd 02-custom-memory-block
+pip install -r requirements.txt
+python llamaindex-ltm-custom-memory-block.py
 ```
 
 ```bash
 # 03-memory-tool/
-python 03-memory-tool/academic-research-assistant-long-term-memory-tutorial.py
-python 03-memory-tool/investment-portfolio-advisor-long-term-memory-tutorial.py
-python 03-memory-tool/medical-knowledge-assistant-long-term-memory-tutorial.py
+cd 03-memory-tool
+pip install -r requirements.txt
+python academic-research-assistant-long-term-memory-tutorial.py
+python investment-portfolio-advisor-long-term-memory-tutorial.py
+python medical-knowledge-assistant-long-term-memory-tutorial.py
 ```
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/01-built-in-hook/customer-support/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/01-built-in-hook/customer-support/README.md
@@ -1,0 +1,36 @@
+# Long-term memory — Strands customer support (built-in strategies)
+
+A customer-support agent built with **Strands Agents** that uses AgentCore's **built-in** Semantic and User Preference strategies via memory hooks. The agent remembers order history, preferences, and past issues across conversations, and includes a web-search tool for up-to-date product info. Built-in strategies need **no IAM execution role**.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Customer Support |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | Semantic + User Preference (built-in — no IAM role) |
+| Memory components | `MemoryManager` / `MemorySessionManager`, memory hooks, web search |
+| Complexity | Intermediate |
+
+## What it does
+
+[`customer-support-inbuilt-strategy.py`](./customer-support-inbuilt-strategy.py):
+
+1. Creates memory with built-in Semantic + User Preference strategies (no IAM role).
+2. Registers hooks that store each turn and retrieve relevant history automatically.
+3. Resolves customer issues with full context from previous interactions.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Amazon Bedrock AgentCore SDK with `MemoryManager` support
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python customer-support-inbuilt-strategy.py
+```
+
+For the custom-model-override version of this same use case, see [`../../02-custom-hook/customer-support/`](../../02-custom-hook/customer-support/). See the [Strands single-agent README](../../README.md) for all three patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/01-built-in-hook/simple-math-assistant/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/01-built-in-hook/simple-math-assistant/README.md
@@ -1,0 +1,37 @@
+# Long-term memory — Strands math assistant (Summary strategy)
+
+A math tutor built with **Strands Agents** that stores **conversation summaries** as long-term memory via hooks. It demonstrates the Summary strategy alongside a calculator tool, conversation branching for alternative teaching paths, and event metadata for tracking student progress.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Math Assistant |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | Summary |
+| Memory components | Summary strategy, memory hooks, calculator tool, branching, event metadata |
+| Complexity | Intermediate |
+
+## What it does
+
+[`math-assistant.py`](./math-assistant.py):
+
+1. Creates memory with a Summary strategy; hooks store and retrieve summaries automatically.
+2. Answers math questions using a calculator tool, informed by summarized history.
+3. Uses branching to explore alternative difficulty levels and teaching approaches.
+4. Tags events with metadata (difficulty, performance, learning milestones).
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Amazon Bedrock AgentCore SDK
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python math-assistant.py
+```
+
+See the [Strands single-agent README](../../README.md) for the other long-term patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/02-custom-hook/culinary-assistant-self-managed-strategy/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/02-custom-hook/culinary-assistant-self-managed-strategy/README.md
@@ -1,0 +1,34 @@
+# Long-term memory — Strands self-managed strategy
+
+A culinary assistant demonstrating AgentCore's **self-managed memory strategy** — you replace AgentCore's built-in extraction with your own pipeline. Trigger conditions (message count, idle timeout, token count) publish to SNS → SQS → your Lambda, which downloads the conversation payload from S3, runs custom extraction, and writes records back via `BatchCreateMemoryRecords`.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Culinary Assistant |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude (Bedrock) |
+| Strategies | Self-managed (custom extraction pipeline) |
+| Components | SNS, SQS, Lambda, S3, `BatchCreateMemoryRecords` |
+| Complexity | Advanced |
+
+## What it does
+
+- [`agentcore_self_managed_memory_demo.py`](./agentcore_self_managed_memory_demo.py) — provisions the infrastructure (S3, SNS, SQS, Lambda, IAM), creates the self-managed memory, fires test events through the pipeline, and shows an agent retrieving the stored records.
+- [`lambda_function.py`](./lambda_function.py) — the extraction handler: downloads the S3 payload, extracts memories, and stores them.
+- [`aws_utils.py`](./aws_utils.py) — helpers for creating and tearing down the AWS infrastructure.
+
+## Prerequisites
+
+- Python 3.11+
+- AWS credentials with access to Lambda, S3, SNS, SQS, and Bedrock
+- Amazon Bedrock model access (Claude)
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python agentcore_self_managed_memory_demo.py
+```
+
+For the variant that adds citation/data-lineage metadata, see [`../culinary-assistant-self-managed-strategy-with-citations/`](../culinary-assistant-self-managed-strategy-with-citations/). See the [Strands single-agent README](../../README.md) for context.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/02-custom-hook/customer-support/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/02-custom-hook/customer-support/README.md
@@ -1,0 +1,38 @@
+# Long-term memory — Strands customer support (custom strategy override)
+
+The same customer-support agent as the [built-in version](../../01-built-in-hook/customer-support/), but using **custom-override** Semantic and User Preference strategies. Custom strategies let you specify your own Bedrock models for extraction and consolidation — at the cost of **requiring an IAM execution role**.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Customer Support |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | Semantic + User Preference (**custom override** — requires IAM role) |
+| Memory components | `MemoryManager` / `MemorySessionManager`, custom extraction/consolidation models, memory hooks, web search |
+| Complexity | Advanced |
+
+## What it does
+
+[`customer-support-override-strategy.py`](./customer-support-override-strategy.py):
+
+1. Creates an IAM execution role for custom-strategy model invocation.
+2. Configures custom Bedrock models for extraction and consolidation.
+3. Registers hooks that store and retrieve memory automatically.
+4. Resolves customer issues with context from previous interactions.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- An IAM execution role for custom-strategy model invocation
+- Amazon Bedrock AgentCore SDK with `MemoryManager` support
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python customer-support-override-strategy.py
+```
+
+For the no-IAM-role built-in version, see [`../../01-built-in-hook/customer-support/`](../../01-built-in-hook/customer-support/). See the [Strands single-agent README](../../README.md) for all three patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/03-memory-tool/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/03-memory-tool/README.md
@@ -1,0 +1,40 @@
+# Long-term memory — Strands, memory as a tool
+
+Long-term memory exposed as **tools the agent decides to call**. Instead of hooks that save/recall on the lifecycle, the Strands agent itself chooses when to store a durable fact and when to search its past knowledge.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Long-term conversational |
+| Agent type | Culinary Assistant |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | User Preference |
+| Memory components | Memory tool (`store`/`retrieve`), extraction strategy |
+| Complexity | Beginner |
+
+## What it does
+
+[`culinary-assistant.py`](./culinary-assistant.py):
+
+1. Configures memory with a User Preference extraction strategy.
+2. Integrates the AgentCore memory tool so the agent stores/retrieves on its own.
+3. Hydrates past conversation history and delivers personalized restaurant recommendations across sessions.
+
+## Also here
+
+- [`debugging-agent/`](./debugging-agent/) — a debugging assistant using **episodic** memory with reflections.
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Amazon Bedrock AgentCore SDK
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python culinary-assistant.py
+```
+
+See the [Strands single-agent README](../README.md) for the hook-based patterns.

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/03-memory-tool/debugging-agent/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/single-agent/with-strands-agent/03-memory-tool/debugging-agent/README.md
@@ -1,0 +1,39 @@
+# Long-term memory — Strands debugging assistant (episodic)
+
+A debugging assistant built with **Strands Agents** that uses **episodic memory with reflections**. It captures complete debugging sessions — problem statement, actions taken, and outcome — then learns across them: reflections surface recurring issues, successful strategies, and common pitfalls to guide future debugging.
+
+| Information | Details |
+|---|---|
+| Tutorial type | Episodic memory with reflections |
+| Agent type | Debugging Assistant |
+| Framework | Strands Agents |
+| LLM model | Anthropic Claude Haiku 4.5 |
+| Strategies | Episodic (with reflection configuration) |
+| Memory components | Episodic memory tool, cross-episode reflections |
+| Complexity | Intermediate |
+
+## What it does
+
+[`debugging_assistant_episodic_memory.py`](./debugging_assistant_episodic_memory.py):
+
+1. Creates memory with an episodic strategy and reflection configuration.
+2. Stores each debugging session as a full episode at `debugging/{actorId}/sessions/{sessionId}`.
+3. Generates reflections at `debugging/{actorId}` — synthesized knowledge across episodes.
+4. Recalls past episodes and reflections to provide context-aware guidance ("how did I solve X last time?").
+
+Sample debugging data lives in [`data/`](./data/).
+
+## Prerequisites
+
+- Python 3.10+
+- AWS credentials with AgentCore Memory permissions
+- Access to AgentCore services
+
+## How to run
+
+```bash
+pip install -r requirements.txt
+python debugging_assistant_episodic_memory.py
+```
+
+See the [memory-tool README](../README.md) for the preference-based culinary example.

--- a/01-features/04-manage-context-of-your-agent/memory/03-integrations/04-memory-browser/backend/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/03-integrations/04-memory-browser/backend/README.md
@@ -1,0 +1,29 @@
+# Memory Browser — backend
+
+The **FastAPI** backend for the [AgentCore Memory Dashboard](../README.md). It wraps `MemoryClient` and exposes REST endpoints the React frontend calls to browse short-term events/turns and query long-term records by namespace. AWS error messages are scrubbed of ARNs and account IDs before being returned.
+
+| Information | Details |
+|---|---|
+| Component | REST API backend |
+| Framework | FastAPI + `bedrock_agentcore.memory.MemoryClient` |
+| Endpoints | List events, conversation turns, and long-term records by namespace |
+| IAM permissions | `bedrock-agentcore:ListMemoryRecords`, `ListEvents`, `GetLastKTurns`, `RetrieveMemories`, `GetMemoryStrategies` |
+
+## Prerequisites
+
+- Python 3.8+
+- AWS credentials configured
+- The IAM permissions listed above
+
+## How to run
+
+Normally started together with the frontend via `npm run dev` from the [parent folder](../README.md). To run the backend on its own:
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # edit for a non-default AWS profile or region
+uvicorn app:app --host 127.0.0.1 --port 8000
+```
+
+See the [Memory Dashboard README](../README.md) for full setup and the frontend.

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/01-error-handling.md
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/01-error-handling.md
@@ -1,0 +1,164 @@
+# Error handling
+
+AgentCore Memory has two API surfaces, and they raise **different exceptions**. Getting this right matters because the retry decision depends on the exact error.
+
+- **Data plane** — `bedrock-agentcore` (boto3) / `MemoryClient` (SDK): `CreateEvent`, `RetrieveMemoryRecords`, `ListEvents`, `BatchCreate/Update/DeleteMemoryRecords`, …
+- **Control plane** — `bedrock-agentcore-control`: `CreateMemory`, `UpdateMemory`, `DeleteMemory`, …
+
+All errors arrive in boto3 as `botocore.exceptions.ClientError`; the modeled name is in `e.response["Error"]["Code"]` and the HTTP status in `e.response["ResponseMetadata"]["HTTPStatusCode"]`.
+
+## The exceptions, by surface
+
+### Data-plane errors
+
+Sourced from the API reference for [`CreateEvent`](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_CreateEvent.html), [`RetrieveMemoryRecords`](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_RetrieveMemoryRecords.html), and [`BatchCreateMemoryRecords`](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_BatchCreateMemoryRecords.html).
+
+| Exception | HTTP | Retry-able? | What it means / what to do |
+|---|---|---|---|
+| `ThrottledException` | 429 | **Yes** | Request rate exceeded. Back off exponentially with jitter. If sustained, you've hit an account quota — request an increase. |
+| `RetryableConflictException` | 409 | **Yes** | Temporary conflict (e.g. concurrent writes to the same session). The API reference explicitly recommends exponential-backoff retry. **Only `CreateEvent` raises this** — not retrieve/batch. |
+| `ServiceException` | 500 | **Yes** | Internal service error. Transient; retry with backoff. If it persists, open a support case. |
+| `ServiceQuotaExceededException` | 402 | **No** (not by blind retry) | A quota would be exceeded. Retrying the same request won't help — reduce the request or request a quota increase. |
+| `ValidationException` | 400 | **No** | Input violates a service constraint (bad namespace, oversized metadata, malformed payload). Fix the input; never retry as-is. |
+| `InvalidInputException` | 400 | **No** | Input failed AgentCore-side validation. Same as above — fix, don't retry. |
+| `ResourceNotFoundException` | 404 | **No** | Memory, strategy, or namespace doesn't exist (or was deleted). Retrying won't conjure it. Check the id / that the resource is `ACTIVE`. |
+| `AccessDeniedException` | 403 | **No** | IAM/KMS denied the call. Fix the policy or key state. A retry storms your own logs. |
+
+### Control-plane errors
+
+Sourced from the [`CreateMemory`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateMemory.html) API reference. Same retry-ability logic; two differences from the data plane:
+
+| Exception | HTTP | Retry-able? | Notes |
+|---|---|---|---|
+| `ThrottledException` | 429 | **Yes** | Same as data plane. |
+| `ConflictException` | 409 | **No** | A conflicting operation (e.g. creating a memory whose name already exists, or mutating a resource mid-update). Not the same as the data plane's `RetryableConflictException` — resolve the conflict, don't blindly retry. |
+| `ServiceException` | 500 | **Yes** | Transient. |
+| `ServiceQuotaExceededException` | 402 | **No** | Quota; request an increase. |
+| `ValidationException` | 400 | **No** | Bad input — e.g. `eventExpiryDuration` outside 3–365, or a name that doesn't match `[a-zA-Z][a-zA-Z0-9_]{0,47}`. |
+| `ResourceNotFoundException` | 404 | **No** | Resource doesn't exist. |
+| `AccessDeniedException` | 403 | **No** | Permissions. |
+
+> **Naming gotcha.** The modeled throttling exception is `ThrottledException`. That's distinct from the string `ThrottlingException` you may see inside an **extraction job's** `failureReason` — that one is the *Bedrock model* throttling the async extraction, not the Memory API throttling your call. See [`../02-long-term-memory/08-redrive/`](../02-long-term-memory/08-redrive/) for redriving those. Match on the code you actually observe rather than hard-coding one spelling.
+
+## The one rule
+
+> **Retry transient failures. Fix deterministic ones.**
+
+Throttling, retryable conflicts, and 500s are transient — they may succeed on the next attempt. Validation, not-found, access-denied, and quota-exceeded are deterministic — the *same request* will fail the *same way* every time, so retrying just burns latency, tokens, and log volume. The `_is_retryable` helper in [`production-patterns.py`](./production-patterns.py) encodes exactly this split.
+
+## Exponential backoff with jitter
+
+Never retry in a tight loop, and never retry on a fixed delay — fixed delays cause **retry storms** where every throttled client retries in lockstep and re-throttles the service. Use exponential backoff with **full jitter**:
+
+```
+delay = random_uniform(0, min(cap, base * 2 ** attempt))
+```
+
+```python
+import random
+import time
+from botocore.exceptions import ClientError
+
+# Codes worth retrying. Everything else is deterministic — fix it, don't retry.
+RETRYABLE = {
+    "ThrottledException",
+    "RetryableConflictException",
+    "ServiceException",
+}
+
+def call_with_backoff(fn, *args, max_attempts=5, base=0.5, cap=20.0, **kwargs):
+    """Call `fn`, retrying only transient errors with full-jitter backoff."""
+    for attempt in range(max_attempts):
+        try:
+            return fn(*args, **kwargs)
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code not in RETRYABLE or attempt == max_attempts - 1:
+                raise  # deterministic, or out of attempts — let it surface
+            delay = random.uniform(0, min(cap, base * (2 ** attempt)))
+            time.sleep(delay)
+```
+
+### You're not starting from zero: botocore already retries
+
+boto3's default (`standard`) retry mode **already** retries throttling and transient errors with exponential backoff — up to 3 attempts. You can raise that, or switch to `adaptive` mode (client-side rate limiting that backs off proactively), via the client config:
+
+```python
+import boto3
+from botocore.config import Config
+
+data = boto3.client(
+    "bedrock-agentcore",
+    config=Config(retries={"max_attempts": 5, "mode": "adaptive"}),
+)
+```
+
+> The `bedrock_agentcore` `MemoryClient` builds its own boto3 clients internally. As of the SDK version inspected for this guide (1.12.0), it sets a `user_agent_extra` on the client config but does **not** raise `max_attempts` or set `adaptive` mode — so you get botocore's default `standard`/3-attempts behaviour. Treat the application-level backoff above as a deliberate layer on top of (not instead of) botocore's, especially for batch and bulk paths where you want a higher attempt ceiling.
+
+The application-level `call_with_backoff` is still worth keeping because it lets you:
+- decide retry-ability per *modeled exception name* (botocore retries by category, not by your business rules),
+- bound attempts differently for interactive vs. batch paths,
+- emit your own metrics/logs on each retry.
+
+## Graceful degradation
+
+**Memory is an enhancement, not a hard dependency on the response path.** If retrieval is throttled or the service is briefly down, the agent should still answer — just without the remembered context — rather than fail the user's turn.
+
+```python
+def recall(client, memory_id, **kwargs):
+    """Retrieve memories, but never let a memory failure break the turn."""
+    try:
+        return call_with_backoff(client.retrieve_memories, memory_id=memory_id, **kwargs)
+    except ClientError as e:
+        # Degrade: log, emit a metric, and continue with empty context.
+        logger.warning("Memory recall failed (%s); continuing without it",
+                       e.response["Error"]["Code"])
+        return []
+```
+
+Two asymmetries to respect:
+
+- **Reads** (`RetrieveMemoryRecords`, `ListEvents`) degrade cleanly to "no context" — the user gets a slightly less personalized answer. The SDK's own `retrieve_memories` already swallows `ResourceNotFoundException`/`ValidationException`/`ServiceException` and returns `[]` for exactly this reason.
+- **Writes** (`CreateEvent`) are different: dropping a write silently loses conversation history. Prefer to **buffer-and-retry** writes (in-memory queue, or persist to a durable buffer) rather than discard them. Only drop a write as a last resort, and emit a metric when you do.
+
+## Partial failure on batch calls
+
+`BatchCreate/Update/DeleteMemoryRecords` return **HTTP 200/201 even when individual records fail**. The per-record outcome is in `successfulRecords` / `failedRecords` — the top-level call succeeding tells you nothing about the records. Always inspect both:
+
+```python
+resp = call_with_backoff(data.batch_create_memory_records, memoryId=mid, records=batch)
+failed = resp.get("failedRecords", [])
+if failed:
+    for r in failed:
+        logger.error("record %s failed: %s %s",
+                     r.get("requestIdentifier"), r.get("errorCode"), r.get("errorMessage"))
+    # Decide per errorCode whether the failed subset is worth re-submitting.
+```
+
+Cap each batch at **100 records** (the documented maximum for `records`); split larger workloads into chunks. See [`../02-long-term-memory/07-batch-apis/`](../02-long-term-memory/07-batch-apis/).
+
+## try / finally cleanup
+
+Anything you create in a request path or a test must be released even when the body raises. The classic leak is a memory resource (and its ongoing storage cost) orphaned by an exception between create and delete.
+
+```python
+memory_id = None
+try:
+    memory_id = control.create_memory(name=name, eventExpiryDuration=30)["memory"]["id"]
+    # ... use the memory ...
+finally:
+    if memory_id:
+        try:
+            control.delete_memory(memoryId=memory_id, clientToken=str(uuid.uuid4()))
+        except ClientError as e:
+            # Don't let cleanup failure mask the original error; log and move on.
+            logger.error("cleanup of %s failed: %s", memory_id, e.response["Error"]["Code"])
+```
+
+Key points:
+- The cleanup itself is wrapped — a failing `delete_memory` must not replace the real exception from the `try` block.
+- `delete_memory` takes a `clientToken` for idempotency; pass a fresh UUID.
+- For long-lived production resources you do **not** delete per request — see the teardown guidance in [`03-production-checklist.md`](./03-production-checklist.md#resource-cleanup-on-teardown).
+
+See [`production-patterns.py`](./production-patterns.py) for all of these composed into one reference module.
+</content>

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/02-cost-optimization.md
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/02-cost-optimization.md
@@ -1,0 +1,96 @@
+# Cost optimization
+
+AgentCore Memory cost comes from a few distinct levers, and they pull in different directions. This document is about the levers you control — what each one does, and the trade-off you're making when you turn it.
+
+> **On exact prices.** Per-unit pricing (storage, events, extraction) is set on the [Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/) and changes over time — we don't reproduce dollar figures here. What's durable, and what this doc covers, is *which actions cost money* and *how your configuration multiplies them*. **Bedrock model invocations for built-in strategies bill against your account separately** from any Memory charge — that's the cost that surprises people, and it scales with strategy count and event volume.
+
+## The cost model in one picture
+
+```
+                      stored for `eventExpiryDuration` days
+  CreateEvent ──► short-term events ──────────────────────────► (storage cost)
+                          │
+                          │  if strategies are configured, each event triggers...
+                          ▼
+              ┌──────────────────────────────┐
+              │  async extraction pipeline    │   one job PER strategy,
+              │  (Bedrock model invocation)   │   each a billed Bedrock call
+              └──────────────────────────────┘
+                          │
+                          ▼
+              long-term memory records ───────────────────────► (storage cost,
+                                                                  lives with the resource)
+```
+
+Two storage buckets, plus a compute (Bedrock) cost that fires on the way from one to the other. Optimize each.
+
+## 1. Event expiry tuning (`eventExpiryDuration`)
+
+Short-term events are retained for `eventExpiryDuration` days, then expire automatically. **Valid range: 3–365 days** (integer; required on `CreateMemory`) — confirmed in the [`CreateMemory` API reference](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateMemory.html). The longer the window, the more raw events you store and pay for.
+
+| Setting | Good fit |
+|---|---|
+| **Short (3–7 days)** | Real-time assistants where long-term records (not raw events) carry the durable value. The tutorials in this repo use 7–30. Streaming and identity samples use 7. |
+| **Medium (30–90 days)** | Default working range; 90 is the SDK's `create_memory` default. Enough history to redrive a failed extraction or debug a session. |
+| **Long (up to 365)** | Compliance/audit needs to retain raw conversation, or slow extraction cadences that must reach back weeks. |
+
+Guidance:
+- **Set it deliberately.** It's a *required* field — don't copy `30` from a sample without thinking about your retention need.
+- **Decouple it from long-term value.** If your durable value lives in extracted *records*, a short event window is fine — records persist with the resource regardless of event expiry.
+- **Don't over-retain "just in case."** Raw events are the cheaper-to-regenerate, higher-volume bucket. A 365-day window on a high-traffic agent is a large standing cost for data you rarely read.
+
+## 2. Strategy selection — every strategy is a separate extraction job
+
+This is the biggest hidden multiplier. Each configured strategy runs its **own** extraction (and consolidation, and for episodic, reflection) over your events — and each of those steps is a **Bedrock model invocation billed to your account** (built-in strategies require a `memoryExecutionRoleArn` precisely because the model runs as you).
+
+So: **N strategies ≈ N× the extraction model cost** over the same event stream.
+
+| Lever | Effect |
+|---|---|
+| **Fewer strategies** | Each one you remove eliminates a full extraction job per qualifying event. Configure only the strategies whose records you actually retrieve. |
+| **Right strategy for the need** | `SEMANTIC` (facts), `SUMMARIZATION` (running summary), `USER_PREFERENCE` (preferences), `EPISODIC` (events + cross-episode reflection). Episodic does the most model work — use it only when you need cross-session episode reasoning. |
+| **Overrides over redundancy** | If a built-in *almost* fits, override its extraction/consolidation prompt (see [`../02-long-term-memory/02-strategy-overrides/`](../02-long-term-memory/02-strategy-overrides/)) rather than stacking a second strategy. |
+| **Self-managed for control** | A self-managed strategy lets you choose the model and trigger cadence — and *batch* extraction so you're not invoking a model per event. Trade-off: you operate it. See [`../02-long-term-memory/03-self-managed-strategy/`](../02-long-term-memory/03-self-managed-strategy/). |
+
+Audit prompt: **for each strategy, name the retrieval that reads its records.** If you can't, that strategy is paying extraction cost for records nobody queries — remove it.
+
+## 3. Namespace and record lifecycle
+
+Long-term records persist for the life of the memory resource — there's no automatic TTL on a record the way there is on an event. Left alone, record storage grows monotonically.
+
+- **Prune stale records.** Use `BatchDeleteMemoryRecords` (by `memoryRecordId`) to remove records that are no longer useful — superseded preferences, expired facts, or per-compliance deletions. See [`../02-long-term-memory/07-batch-apis/`](../02-long-term-memory/07-batch-apis/).
+- **List then delete by namespace.** `list_memory_records(namespace=...)` enumerates a namespace; pair it with batch-delete to clean a whole branch (e.g. a churned tenant's `/users/{actorId}/`).
+- **Namespaces are organization, not access control.** Design them hierarchically (trailing `/`) so a single prefix scan finds everything you need to clean up. (Security boundary is IAM — see [`../05-security/`](../05-security/).)
+- **Delete the resource for whole-tenant offboarding.** If an actor/tenant maps to its own memory resource, deleting that resource releases both events and records in one call. See [`03-production-checklist.md`](./03-production-checklist.md#resource-cleanup-on-teardown).
+
+## 4. Batch-API economics
+
+When you write or delete records yourself (self-managed extraction, back-fills, migrations, pruning), the batch APIs are dramatically cheaper per record than one call each:
+
+- **Up to 100 records per call** (documented max for the `records` array). Fewer API calls = less request overhead and less throttling exposure.
+- **Chunk large workloads at 100** and parallelize the chunks (mind your throttle ceiling — see [`01-error-handling.md`](./01-error-handling.md)).
+- **Inspect `failedRecords`** so you only re-submit the subset that failed, not the whole batch.
+- Batch CRUD **bypasses extraction** — no Bedrock model cost. That's the cheap path when *you've already done the extraction*. Don't use `CreateEvent`-with-a-strategy if all you want is to write a record you already have.
+
+## 5. STM-only vs. LTM strategies
+
+The single highest-leverage decision: **do you need extraction at all?**
+
+| Use **STM-only** (no strategies) when… | Reach for **LTM strategies** when… |
+|---|---|
+| Context only needs to live within a session or a few days | You need recall *across* sessions (preferences, facts, history) |
+| You just need the conversation transcript (`ListEvents` / `get_last_k_turns`) | You want *structured insight* (a summary, a preference set) rather than raw turns |
+| You're cost- or latency-sensitive and raw history is enough | The value of better personalization clearly exceeds per-event extraction cost |
+
+A memory with **no strategies configured runs no extraction pipeline** — you pay only event storage, and you've eliminated the entire Bedrock-invocation cost line. Many "remember the last few turns" use cases are STM-only and people reach for strategies reflexively. Start STM-only; add a strategy when a concrete retrieval need justifies it.
+
+## Quick wins checklist
+
+- [ ] `eventExpiryDuration` set to your actual retention need, not a copied default
+- [ ] Every configured strategy maps to a retrieval that reads its records
+- [ ] Episodic used only where cross-episode reasoning is needed
+- [ ] STM-only for "recent context" use cases; strategies added only when recall-across-sessions pays off
+- [ ] Stale long-term records pruned (no record auto-TTL)
+- [ ] Self-managed writes/back-fills go through batch APIs (100/call), not per-record `CreateEvent`
+- [ ] Whole-tenant offboarding deletes the resource, not record-by-record
+</content>

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/03-production-checklist.md
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/03-production-checklist.md
@@ -1,0 +1,137 @@
+# Production deployment checklist
+
+Work top to bottom before you put an AgentCore Memory–backed agent in front of users. Each section is actionable; the deep-dives live under [`../05-security/`](../05-security/) and [`../04-observability/`](../04-observability/).
+
+## 1. IAM least-privilege
+
+Grant the runtime role only the data-plane actions it actually calls, and scope them with conditions. Two distinct principals to get right:
+
+- **Your runtime/agent role** — calls the *data plane* (`bedrock-agentcore:*` on events and records).
+- **The memory execution role** (`memoryExecutionRoleArn` on the resource) — assumed by the *service* to invoke Bedrock for built-in strategy extraction. Required for built-in strategies because the model bills to your account.
+
+### Runtime role — scoped data-plane policy
+
+Grant only the operations the agent uses. A read-mostly agent that records turns and retrieves records needs roughly:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "MemoryDataPlaneScopedToActor",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:us-east-1:111122223333:memory/mem-abc123",
+      "Condition": {
+        "StringEquals": { "bedrock-agentcore:actorId": "${aws:PrincipalTag/actorId}" }
+      }
+    }
+  ]
+}
+```
+
+Principles:
+- **Enumerate actions; never `bedrock-agentcore:*`.** Add batch CRUD only if the agent actually does self-managed writes/pruning. Keep control-plane actions (`CreateMemory`, `DeleteMemory`) out of the runtime role entirely — provision and tear down memories from a separate, privileged path.
+- **Scope `Resource` to the specific memory ARN(s).** Wildcards across all memories defeat tenant isolation.
+- **Condition on `actorId`** (and namespace where supported) so one user's credentials can't read another's memory. This is the actual access boundary — namespaces are organization, not security. The condition-key patterns are demonstrated in [`../05-security/01-iam-scoped-access/`](../05-security/01-iam-scoped-access/).
+- **Prefer federated, short-lived credentials** for user-facing paths (Cognito → STS `AssumeRoleWithWebIdentity`) over a long-lived shared role. See [`../05-security/02-cognito-federated-identity/`](../05-security/02-cognito-federated-identity/).
+
+### Memory execution role
+
+- Trust policy lets the AgentCore Memory service assume it.
+- Permissions: `bedrock:InvokeModel` for the model(s) your strategies use, plus (for self-managed) `s3:PutObject` to the payload bucket and `sns:Publish` to the topic.
+- If the resource uses a CMK, this role and the service need `kms:Decrypt`/`kms:GenerateDataKey` on that key.
+
+## 2. KMS encryption
+
+Memory data is encrypted at rest by default with an AWS-owned key. For sensitive or contractually-controlled workloads, supply a **customer-managed key** via `encryptionKeyArn` on `CreateMemory` (see [`../05-security/03-kms-encryption/`](../05-security/03-kms-encryption/)).
+
+- **When to use a CMK:** you need key rotation you control, auditable `kms:Decrypt` in CloudTrail, or the ability to revoke access by disabling the key. One CMK per tenant when a contract demands customer-controlled revocation.
+- **Key policy must grant the memory service** (and the execution role) `kms:Decrypt` and `kms:GenerateDataKey` — otherwise creates/reads fail with `AccessDeniedException` and you'll see `StreamUserError` on the streaming path.
+- **`encryptionKeyArn` is set at create time.** Decide before you create the resource.
+- **Don't put sensitive data in event metadata** regardless of CMK — metadata is more exposed across the API surface than payload content.
+- **Disabling the key is a kill switch, not a quiet config change** — every data-plane call against that memory starts failing. That's the intended behavior for revocation; just know it's immediate and total.
+
+## 3. Observability
+
+Wire these up *before* launch — the first time you need them is during an incident. Full metric list and CLI in [`../04-observability/`](../04-observability/).
+
+| Signal | Metric / source | Alarm guidance |
+|---|---|---|
+| API errors | `Errors` (per data-plane op, namespace `AWS/Bedrock-AgentCore`) | Alarm on a spike — usually a deleted strategy or renamed namespace. |
+| Throttling | `Errors` on `CreateEvent`/`RetrieveMemoryRecords` correlated with 429s | Sustained throttling = you've outgrown your quota; request an increase. |
+| Stream delivery | `StreamPublishingFailure`, `StreamUserError` | Alarm on **any** `StreamUserError` (page-worthy: broken IAM/KMS); alarm on `StreamPublishingFailure > 0`. |
+| Ingestion health | `NumberOfMemoryRecords` per strategy | Alarm on a sudden drop — the canary for an extraction regression. |
+| Ingestion errors | Log group `/aws/bedrock-agentcore/memory/<memoryId>` | **Enable log delivery in production** — without it, ingestion failures are invisible. |
+
+- **Pair every alarm with a runbook.** Streaming failures usually want a redrive ([`../02-long-term-memory/08-redrive/`](../02-long-term-memory/08-redrive/)); user errors want an IAM/KMS fix.
+- **Audit `bedrock-agentcore:actorId` and `kms:Decrypt` in CloudTrail** — the two signals that tell you who read what.
+
+## 4. Rate limits and quotas
+
+> **These are account- and region-specific, adjustable, and change over time — verify current values; do not hard-code numbers from any tutorial.**
+
+- **CreateEvent is explicitly rate-limited** ("This operation is subject to request rate limiting" — API reference). Expect `ThrottledException` (429) under load and handle it per [`01-error-handling.md`](./01-error-handling.md).
+- **Check the Service Quotas console** (search "Bedrock AgentCore") for your per-API, per-account limits, and request increases **before** a launch or load test — quota increases are not instantaneous.
+
+  ```bash
+  # Discover the service code, then list default quotas.
+  aws service-quotas list-services \
+    --query "Services[?contains(ServiceName, 'AgentCore')]"
+
+  aws service-quotas list-aws-default-service-quotas \
+    --service-code <service-code-from-above> \
+    --query "Quotas[].{Name:QuotaName,Value:Value}" --output table
+  ```
+
+**Field constraints that *are* fixed** (from the API references — safe to rely on):
+
+| Constraint | Value | Source |
+|---|---|---|
+| `eventExpiryDuration` | 3–365 (integer days) | `CreateMemory` |
+| `records` per batch call | 0–100 | `BatchCreateMemoryRecords` |
+| `payload` items per `CreateEvent` | 0–100 | `CreateEvent` |
+| Event `metadata` entries | 0–15 (key 1–128 chars) | `CreateEvent` |
+| `RetrieveMemoryRecords` `maxResults` | 1–100 (default 20) | `RetrieveMemoryRecords` |
+| `metadataFilters` per retrieve | ≤ 5 (SDK-enforced `ValueError`) | SDK `retrieve_memories` |
+| `indexedKeys` per memory | 1–10 items | `CreateMemory` |
+| Memory `name` | `[a-zA-Z][a-zA-Z0-9_]{0,47}`, unique per account | `CreateMemory` |
+| Tags per memory | 0–50 | `CreateMemory` |
+
+## 5. Multi-region
+
+AgentCore Memory is regional — a memory resource and its data live in one region. Decide your posture explicitly:
+
+- **Single-region (default):** simplest. Pin your runtime and memory to the same region; make the region an explicit config value, not a default buried in code.
+- **Active-passive / DR:** there is no built-in cross-region replication of a memory resource. If you need a warm standby, you own the replication — e.g. fan `CreateEvent` writes to a second region, or periodically export records (`list_memory_records`) and `BatchCreateMemoryRecords` into the standby. Budget for the duplicate extraction cost if both regions run strategies.
+- **Data residency:** if records must stay in-region for compliance, make `actorId`/namespace and the resource region-aware so a user is always routed to the compliant region.
+- **Verify regional availability** of AgentCore Memory before committing an architecture to a given region.
+
+## 6. Resource cleanup on teardown
+
+Orphaned memory resources keep costing money (event + record storage). Make teardown deliberate.
+
+- **Per-request resources** (tests, ephemeral sessions): wrap create/use/delete in `try/finally` so an exception can't leak the resource. Pattern in [`01-error-handling.md`](./01-error-handling.md#try--finally-cleanup) and [`production-patterns.py`](./production-patterns.py).
+- **Per-tenant resources:** on offboarding, `delete_memory` releases events *and* records in one call — cheaper and more complete than record-by-record deletion.
+- **Shared resource, per-user cleanup:** if many actors share one memory, delete a churned user's data with `list_memory_records(namespace="/users/{actorId}/")` → `BatchDeleteMemoryRecords`. (See [`02-cost-optimization.md`](./02-cost-optimization.md#3-namespace-and-record-lifecycle).)
+- **`delete_memory` takes a `clientToken`** for idempotent retries — pass a fresh UUID, and wrap the delete so a cleanup failure is logged rather than masking the real error.
+- **Don't delete long-lived production memories on a per-request path.** Cleanup-on-teardown is for ephemeral resources and offboarding, not steady-state traffic.
+
+---
+
+### Final pre-launch gate
+
+- [ ] Runtime role enumerates only the data-plane actions used, scoped to the memory ARN and `actorId`
+- [ ] Control-plane actions kept off the runtime role
+- [ ] Memory execution role can `bedrock:InvokeModel` (+ S3/SNS/KMS as needed)
+- [ ] CMK configured for sensitive workloads, key policy grants the service `kms:Decrypt`/`kms:GenerateDataKey`
+- [ ] Alarms live on `Errors`, throttles, `StreamPublishingFailure`, `StreamUserError`, `NumberOfMemoryRecords`
+- [ ] Ingestion log delivery enabled
+- [ ] Current quotas checked in Service Quotas; increases requested ahead of launch
+- [ ] Region pinned explicitly; multi-region/DR posture decided
+- [ ] Teardown path deletes ephemeral/offboarded resources; long-lived ones excluded
+</content>

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/README.md
@@ -1,0 +1,53 @@
+# Production patterns
+
+Most tutorials in this tree show the **happy path** — create a memory, write an event, retrieve a record, and assume every call succeeds. That's the right shape for learning a primitive, but it's not what you ship. In production the service throttles you, a strategy gets deleted out from under a running agent, a KMS key is disabled, a transient `ServiceException` lands in the middle of a conversation, and a teardown that doesn't clean up leaks resources and cost.
+
+This section collects the patterns that turn the happy-path samples into something you can run in front of users.
+
+## What's inside
+
+| Document | Covers |
+|---|---|
+| [`01-error-handling.md`](./01-error-handling.md) | The exceptions AgentCore Memory raises, which are retry-able, exponential backoff with jitter, graceful degradation, and `try/finally` cleanup |
+| [`02-cost-optimization.md`](./02-cost-optimization.md) | Event-expiry tuning, the per-strategy cost of extraction, namespace/record lifecycle, batch-API economics, and STM-only vs. LTM |
+| [`03-production-checklist.md`](./03-production-checklist.md) | Least-privilege IAM, KMS encryption, observability, quotas, multi-region, and resource cleanup |
+| [`production-patterns.py`](./production-patterns.py) | A reference implementation of every pattern — copy-paste, not a runnable demo |
+
+## Production readiness checklist
+
+Use this as the index; each row links to the section that explains the *why* and shows the *how*.
+
+| Area | You've done it when… | Where |
+|---|---|---|
+| **Error handling** | Every data-plane call is wrapped; retry-able vs. terminal errors are distinguished, not blanket-retried | [`01`](./01-error-handling.md) |
+| **Retry/backoff** | Retries use exponential backoff **with jitter** and a capped attempt count | [`01`](./01-error-handling.md) |
+| **Graceful degradation** | The agent still answers if memory is unavailable — memory is an enhancement, not a hard dependency on the response path | [`01`](./01-error-handling.md) |
+| **Partial-failure handling** | Batch calls inspect `failedRecords`, not just the HTTP status | [`01`](./01-error-handling.md) |
+| **Event expiry** | `eventExpiryDuration` is set deliberately (3–365 days) to bound storage, not left at a default | [`02`](./02-cost-optimization.md) |
+| **Strategy count** | Each configured strategy is justified — every strategy is a separate extraction job that bills Bedrock | [`02`](./02-cost-optimization.md) |
+| **STM vs. LTM** | You use STM-only where you don't need extracted insight, and reach for strategies only where recall across sessions pays for itself | [`02`](./02-cost-optimization.md) |
+| **IAM least-privilege** | The runtime role grants only the data-plane actions it uses, scoped by `actorId`/namespace conditions | [`03`](./03-production-checklist.md) |
+| **KMS** | Sensitive workloads use a customer-managed key via `encryptionKeyArn`, with the key policy granting the memory service | [`03`](./03-production-checklist.md) |
+| **Observability** | CloudWatch alarms on `Errors`, throttles, and `StreamPublishingFailure`; ingestion log delivery enabled | [`03`](./03-production-checklist.md) and [`../04-observability/`](../04-observability/) |
+| **Quotas** | You've checked the current per-account/per-API quotas in Service Quotas and requested increases before launch | [`03`](./03-production-checklist.md) |
+| **Multi-region** | You've decided whether memory is single-region or replicated, and made the actor/namespace scheme region-aware if replicated | [`03`](./03-production-checklist.md) |
+| **Cleanup** | Agent/tenant teardown deletes the memory resource (or its records) so you don't pay for orphaned data | [`03`](./03-production-checklist.md) |
+
+## A note on what's verified here
+
+Everything in this section is grounded in one of three sources, and we say which:
+
+- **API Reference** — the per-operation error lists and field constraints (e.g. `eventExpiryDuration` range 3–365) come from the [AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/) and [AgentCore Control](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/) API references.
+- **SDK source** — retry/limit behaviour of the `bedrock_agentcore` Python SDK (`MemoryClient`) is read from the installed package.
+- **AWS docs** — conceptual guidance from the [AgentCore Memory dev guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html).
+
+**Per-API request-rate quotas (TPS) are account- and region-specific and are not reproduced here** — they change and are adjustable. Check the **Service Quotas console** (search "Bedrock AgentCore") before capacity planning. See [`03-production-checklist.md`](./03-production-checklist.md#rate-limits-and-quotas).
+
+## See also
+
+- [`../04-observability/`](../04-observability/) — the metrics and alarms this section's checklist refers to
+- [`../05-security/`](../05-security/) — the IAM/Cognito/KMS deep-dives this section summarizes
+- [`../02-long-term-memory/07-batch-apis/`](../02-long-term-memory/07-batch-apis/) — partial-failure handling on batch calls
+- [`../02-long-term-memory/08-redrive/`](../02-long-term-memory/08-redrive/) — recovering failed async extractions
+</content>
+</invoke>

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/production-patterns.py
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/production-patterns.py
@@ -26,7 +26,7 @@ import logging
 import random
 import time
 import uuid
-from typing import Any, Callable, Iterable, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -35,12 +35,12 @@ logger = logging.getLogger("agentcore.memory.production")
 
 # --- Fixed service constraints (from the API references) ------------------
 # Safe to rely on; these are modeled field limits, not adjustable quotas.
-MAX_RECORDS_PER_BATCH = 100        # BatchCreate/Update/DeleteMemoryRecords `records`
+MAX_RECORDS_PER_BATCH = 100  # BatchCreate/Update/DeleteMemoryRecords `records`
 MAX_PAYLOAD_ITEMS_PER_EVENT = 100  # CreateEvent `payload`
-MAX_EVENT_METADATA_ENTRIES = 15    # CreateEvent `metadata`
-MAX_METADATA_FILTERS = 5           # RetrieveMemoryRecords (SDK-enforced)
-MIN_EVENT_EXPIRY_DAYS = 3          # CreateMemory `eventExpiryDuration`
-MAX_EVENT_EXPIRY_DAYS = 365        # CreateMemory `eventExpiryDuration`
+MAX_EVENT_METADATA_ENTRIES = 15  # CreateEvent `metadata`
+MAX_METADATA_FILTERS = 5  # RetrieveMemoryRecords (SDK-enforced)
+MIN_EVENT_EXPIRY_DAYS = 3  # CreateMemory `eventExpiryDuration`
+MAX_EVENT_EXPIRY_DAYS = 365  # CreateMemory `eventExpiryDuration`
 
 # --- Retry classification -------------------------------------------------
 # ONLY these transient data-plane errors are worth retrying. Everything else
@@ -53,9 +53,9 @@ MAX_EVENT_EXPIRY_DAYS = 365        # CreateMemory `eventExpiryDuration`
 # retry-able (e.g. duplicate name) — so it is intentionally absent here.
 RETRYABLE_DATAPLANE = frozenset(
     {
-        "ThrottledException",          # 429 — rate exceeded; back off
+        "ThrottledException",  # 429 — rate exceeded; back off
         "RetryableConflictException",  # 409 — transient write conflict (CreateEvent)
-        "ServiceException",            # 500 — internal/transient
+        "ServiceException",  # 500 — internal/transient
     }
 )
 
@@ -97,10 +97,14 @@ def call_with_backoff(
             if not _is_retryable(e) or attempt == max_attempts - 1:
                 # Deterministic failure, or we're out of attempts. Surface it.
                 raise
-            delay = random.uniform(0, min(cap, base * (2 ** attempt)))
+            delay = random.uniform(0, min(cap, base * (2**attempt)))
             logger.warning(
                 "transient error %s on %s (attempt %d/%d); retrying in %.2fs",
-                code, getattr(fn, "__name__", "call"), attempt + 1, max_attempts, delay,
+                code,
+                getattr(fn, "__name__", "call"),
+                attempt + 1,
+                max_attempts,
+                delay,
             )
             time.sleep(delay)
 
@@ -177,8 +181,7 @@ def record_turn_durably(
             f"payload has {len(messages)} items; CreateEvent allows "
             f"{MAX_PAYLOAD_ITEMS_PER_EVENT}. Split into multiple events."
         )
-    payload = [{"conversational": {"role": role, "content": {"text": text}}}
-               for text, role in messages]
+    payload = [{"conversational": {"role": role, "content": {"text": text}}} for text, role in messages]
     try:
         call_with_backoff(
             data_client.create_event,
@@ -194,17 +197,21 @@ def record_turn_durably(
         logger.error("create_event failed permanently (%s); dead-lettering", code)
         _emit_metric("MemoryWriteDeadLettered", 1)
         if dead_letter is not None:
-            dead_letter({
-                "memoryId": memory_id, "actorId": actor_id,
-                "sessionId": session_id, "messages": messages,
-            })
+            dead_letter(
+                {
+                    "memoryId": memory_id,
+                    "actorId": actor_id,
+                    "sessionId": session_id,
+                    "messages": messages,
+                }
+            )
         return False
 
 
 # --- Pattern 4: batch writes with partial-failure handling ----------------
 def _chunked(items: list, size: int) -> Iterator[list]:
     for i in range(0, len(items), size):
-        yield items[i:i + size]
+        yield items[i : i + size]
 
 
 def batch_create_with_partial_handling(
@@ -234,7 +241,9 @@ def batch_create_with_partial_handling(
         for r in failed:
             logger.error(
                 "record %s failed: code=%s msg=%s",
-                r.get("requestIdentifier"), r.get("errorCode"), r.get("errorMessage"),
+                r.get("requestIdentifier"),
+                r.get("errorCode"),
+                r.get("errorMessage"),
             )
     if all_failed:
         _emit_metric("MemoryBatchRecordFailures", len(all_failed))
@@ -257,8 +266,7 @@ class MemoryResource:
     def __init__(self, control_client: Any, name: str, event_expiry_days: int = 30):
         if not (MIN_EVENT_EXPIRY_DAYS <= event_expiry_days <= MAX_EVENT_EXPIRY_DAYS):
             raise ValueError(
-                f"event_expiry_days must be {MIN_EVENT_EXPIRY_DAYS}-"
-                f"{MAX_EVENT_EXPIRY_DAYS}; got {event_expiry_days}"
+                f"event_expiry_days must be {MIN_EVENT_EXPIRY_DAYS}-{MAX_EVENT_EXPIRY_DAYS}; got {event_expiry_days}"
             )
         self._control = control_client
         self._name = name
@@ -281,15 +289,14 @@ class MemoryResource:
         if not self.memory_id:
             return False
         try:
-            self._control.delete_memory(
-                memoryId=self.memory_id, clientToken=str(uuid.uuid4())
-            )
+            self._control.delete_memory(memoryId=self.memory_id, clientToken=str(uuid.uuid4()))
             logger.info("deleted ephemeral memory %s", self.memory_id)
         except ClientError as e:
             # Log; do NOT raise — a cleanup failure must not replace the real error.
             logger.error(
                 "cleanup of %s failed (%s); may need manual deletion",
-                self.memory_id, e.response["Error"]["Code"],
+                self.memory_id,
+                e.response["Error"]["Code"],
             )
         return False
 

--- a/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/production-patterns.py
+++ b/01-features/04-manage-context-of-your-agent/memory/06-production-patterns/production-patterns.py
@@ -1,0 +1,325 @@
+"""Production patterns for AgentCore Memory — reference, not a demo.
+
+This module is meant to be *read and copy-pasted*, not run. It deliberately
+has no conversation, no `__main__` flow, and no live API calls. Each function
+is a self-contained pattern you can lift into your own agent:
+
+    - _is_retryable / RETRYABLE_DATAPLANE  : classify errors correctly
+    - call_with_backoff                    : exponential backoff WITH JITTER
+    - recall_with_degradation              : memory failures never break a turn
+    - record_turn_durably                  : writes buffer-and-retry, not drop
+    - batch_create_with_partial_handling   : inspect failedRecords, chunk at 100
+    - MemoryResource (context manager)      : try/finally cleanup that can't leak
+    - health_check                          : cheap readiness probe
+
+Every constant and error name below is grounded in the AgentCore /
+AgentCore-Control API references and the `bedrock_agentcore` SDK source.
+See ./01-error-handling.md for the reasoning behind each retry decision.
+
+Prerequisites (if you adapt this into something runnable):
+    pip install boto3 bedrock-agentcore
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+import uuid
+from typing import Any, Callable, Iterable, Iterator, Optional
+
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger("agentcore.memory.production")
+
+# --- Fixed service constraints (from the API references) ------------------
+# Safe to rely on; these are modeled field limits, not adjustable quotas.
+MAX_RECORDS_PER_BATCH = 100        # BatchCreate/Update/DeleteMemoryRecords `records`
+MAX_PAYLOAD_ITEMS_PER_EVENT = 100  # CreateEvent `payload`
+MAX_EVENT_METADATA_ENTRIES = 15    # CreateEvent `metadata`
+MAX_METADATA_FILTERS = 5           # RetrieveMemoryRecords (SDK-enforced)
+MIN_EVENT_EXPIRY_DAYS = 3          # CreateMemory `eventExpiryDuration`
+MAX_EVENT_EXPIRY_DAYS = 365        # CreateMemory `eventExpiryDuration`
+
+# --- Retry classification -------------------------------------------------
+# ONLY these transient data-plane errors are worth retrying. Everything else
+# (ValidationException, InvalidInputException, ResourceNotFoundException,
+# AccessDeniedException, ServiceQuotaExceededException) is deterministic:
+# the same request fails the same way, so retrying just burns latency.
+#
+# Note: `RetryableConflictException` is raised by CreateEvent only.
+# The control plane raises `ConflictException` instead, which is NOT
+# retry-able (e.g. duplicate name) — so it is intentionally absent here.
+RETRYABLE_DATAPLANE = frozenset(
+    {
+        "ThrottledException",          # 429 — rate exceeded; back off
+        "RetryableConflictException",  # 409 — transient write conflict (CreateEvent)
+        "ServiceException",            # 500 — internal/transient
+    }
+)
+
+
+def _is_retryable(error: ClientError) -> bool:
+    """Return True only for transient errors that a retry might fix."""
+    return error.response["Error"]["Code"] in RETRYABLE_DATAPLANE
+
+
+# --- Pattern 1: exponential backoff with full jitter ----------------------
+def call_with_backoff(
+    fn: Callable[..., Any],
+    *args: Any,
+    max_attempts: int = 5,
+    base: float = 0.5,
+    cap: float = 20.0,
+    **kwargs: Any,
+) -> Any:
+    """Invoke `fn(*args, **kwargs)`, retrying only transient errors.
+
+    Uses FULL JITTER: delay = uniform(0, min(cap, base * 2**attempt)).
+    Full jitter prevents retry storms where every throttled client retries
+    in lockstep and re-throttles the service. A fixed or non-jittered delay
+    is the classic way to turn a brief throttle into an outage.
+
+    Deterministic errors (validation, not-found, access-denied, quota) are
+    re-raised immediately — retrying them is pure waste. The final attempt
+    always re-raises so the caller can decide how to degrade.
+
+    This is an application-level layer ON TOP OF botocore's own retries
+    (see configured_clients below); it lets you decide retry-ability per
+    modeled exception and emit your own per-retry metrics.
+    """
+    for attempt in range(max_attempts):
+        try:
+            return fn(*args, **kwargs)
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if not _is_retryable(e) or attempt == max_attempts - 1:
+                # Deterministic failure, or we're out of attempts. Surface it.
+                raise
+            delay = random.uniform(0, min(cap, base * (2 ** attempt)))
+            logger.warning(
+                "transient error %s on %s (attempt %d/%d); retrying in %.2fs",
+                code, getattr(fn, "__name__", "call"), attempt + 1, max_attempts, delay,
+            )
+            time.sleep(delay)
+
+
+def configured_clients(region: str) -> tuple[Any, Any]:
+    """Build data- and control-plane clients with a sensible retry config.
+
+    botocore's `standard` mode already retries throttling/5xx ~3 times with
+    backoff; `adaptive` adds client-side rate limiting that pre-emptively
+    slows down when it sees throttling. We raise max_attempts for bulk paths.
+
+    NOTE: the `bedrock_agentcore` MemoryClient builds its own clients and does
+    NOT raise these defaults — if you use the SDK and want this behaviour,
+    keep the application-level `call_with_backoff` above as your retry layer.
+    """
+    import boto3
+
+    cfg = Config(retries={"max_attempts": 5, "mode": "adaptive"})
+    data = boto3.client("bedrock-agentcore", region_name=region, config=cfg)
+    control = boto3.client("bedrock-agentcore-control", region_name=region, config=cfg)
+    return data, control
+
+
+# --- Pattern 2: graceful degradation on reads ----------------------------
+def recall_with_degradation(
+    data_client: Any,
+    memory_id: str,
+    namespace: str,
+    query: str,
+    top_k: int = 10,
+) -> list[dict]:
+    """Retrieve memories, but NEVER let a memory failure break the turn.
+
+    Memory is an enhancement, not a hard dependency on the response path.
+    If retrieval throttles or the service is briefly down, we log, emit a
+    metric (placeholder), and return [] so the agent still answers — just
+    without remembered context.
+    """
+    try:
+        resp = call_with_backoff(
+            data_client.retrieve_memory_records,
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": query, "topK": top_k},
+        )
+        return resp.get("memoryRecordSummaries", [])
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        # Degrade gracefully: the user gets a less personalized answer,
+        # not an error. Emit a metric so the degradation is visible.
+        logger.warning("recall failed (%s); continuing without memory context", code)
+        _emit_metric("MemoryRecallDegraded", 1)
+        return []
+
+
+# --- Pattern 3: durable writes (buffer-and-retry, don't drop) -------------
+def record_turn_durably(
+    data_client: Any,
+    memory_id: str,
+    actor_id: str,
+    session_id: str,
+    messages: list[tuple[str, str]],
+    dead_letter: Optional[Callable[[dict], None]] = None,
+) -> bool:
+    """Persist a conversation turn. Returns True on success.
+
+    Writes are asymmetric to reads: silently dropping a write LOSES history.
+    So we retry transient errors, and on final failure we hand the payload to
+    a dead-letter sink (a queue, a file, a DynamoDB row) for later replay
+    rather than discarding it. Only give up after that safety net.
+    """
+    if len(messages) > MAX_PAYLOAD_ITEMS_PER_EVENT:
+        raise ValueError(
+            f"payload has {len(messages)} items; CreateEvent allows "
+            f"{MAX_PAYLOAD_ITEMS_PER_EVENT}. Split into multiple events."
+        )
+    payload = [{"conversational": {"role": role, "content": {"text": text}}}
+               for text, role in messages]
+    try:
+        call_with_backoff(
+            data_client.create_event,
+            memoryId=memory_id,
+            actorId=actor_id,
+            sessionId=session_id,
+            payload=payload,
+            clientToken=str(uuid.uuid4()),  # idempotent retries
+        )
+        return True
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        logger.error("create_event failed permanently (%s); dead-lettering", code)
+        _emit_metric("MemoryWriteDeadLettered", 1)
+        if dead_letter is not None:
+            dead_letter({
+                "memoryId": memory_id, "actorId": actor_id,
+                "sessionId": session_id, "messages": messages,
+            })
+        return False
+
+
+# --- Pattern 4: batch writes with partial-failure handling ----------------
+def _chunked(items: list, size: int) -> Iterator[list]:
+    for i in range(0, len(items), size):
+        yield items[i:i + size]
+
+
+def batch_create_with_partial_handling(
+    data_client: Any,
+    memory_id: str,
+    records: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Create records in chunks of 100, inspecting per-record outcomes.
+
+    Batch calls return HTTP 200/201 EVEN WHEN individual records fail — the
+    top-level success tells you nothing. You must read failedRecords. We
+    chunk at the documented 100-record max and aggregate outcomes so the
+    caller can re-submit only the failed subset.
+    """
+    all_ok: list[dict] = []
+    all_failed: list[dict] = []
+    for chunk in _chunked(records, MAX_RECORDS_PER_BATCH):
+        resp = call_with_backoff(
+            data_client.batch_create_memory_records,
+            memoryId=memory_id,
+            records=chunk,
+        )
+        ok = resp.get("successfulRecords", [])
+        failed = resp.get("failedRecords", [])
+        all_ok.extend(ok)
+        all_failed.extend(failed)
+        for r in failed:
+            logger.error(
+                "record %s failed: code=%s msg=%s",
+                r.get("requestIdentifier"), r.get("errorCode"), r.get("errorMessage"),
+            )
+    if all_failed:
+        _emit_metric("MemoryBatchRecordFailures", len(all_failed))
+    return all_ok, all_failed
+
+
+# --- Pattern 5: try/finally cleanup that can't leak -----------------------
+class MemoryResource:
+    """Context manager for an EPHEMERAL memory resource (tests, short jobs).
+
+    Guarantees the resource is deleted even if the body raises — the classic
+    leak is a memory orphaned (and billed) by an exception between create and
+    delete. The cleanup is itself wrapped so a delete failure can't mask the
+    original error.
+
+    DO NOT use this for long-lived production memories — those are provisioned
+    once out-of-band, not per request. See 03-production-checklist.md.
+    """
+
+    def __init__(self, control_client: Any, name: str, event_expiry_days: int = 30):
+        if not (MIN_EVENT_EXPIRY_DAYS <= event_expiry_days <= MAX_EVENT_EXPIRY_DAYS):
+            raise ValueError(
+                f"event_expiry_days must be {MIN_EVENT_EXPIRY_DAYS}-"
+                f"{MAX_EVENT_EXPIRY_DAYS}; got {event_expiry_days}"
+            )
+        self._control = control_client
+        self._name = name
+        self._expiry = event_expiry_days
+        self.memory_id: Optional[str] = None
+
+    def __enter__(self) -> "MemoryResource":
+        resp = call_with_backoff(
+            self._control.create_memory,
+            name=self._name,
+            eventExpiryDuration=self._expiry,
+            clientToken=str(uuid.uuid4()),
+        )
+        self.memory_id = resp["memory"]["id"]
+        logger.info("created ephemeral memory %s", self.memory_id)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        # Returns False: never suppress the body's exception.
+        if not self.memory_id:
+            return False
+        try:
+            self._control.delete_memory(
+                memoryId=self.memory_id, clientToken=str(uuid.uuid4())
+            )
+            logger.info("deleted ephemeral memory %s", self.memory_id)
+        except ClientError as e:
+            # Log; do NOT raise — a cleanup failure must not replace the real error.
+            logger.error(
+                "cleanup of %s failed (%s); may need manual deletion",
+                self.memory_id, e.response["Error"]["Code"],
+            )
+        return False
+
+
+# --- Pattern 6: cheap health check ----------------------------------------
+def health_check(control_client: Any, memory_id: str) -> bool:
+    """Readiness probe: is the memory resource present and ACTIVE?
+
+    Cheap, control-plane-only, and safe to call from a health endpoint. A
+    ResourceNotFoundException or a non-ACTIVE status means do not route
+    memory-dependent traffic here yet. Wrapped so a transient blip reads as
+    'not ready' rather than crashing the probe.
+    """
+    try:
+        resp = call_with_backoff(control_client.get_memory, memoryId=memory_id)
+        status = resp["memory"]["status"]
+        if status != "ACTIVE":
+            logger.warning("memory %s status=%s (not ACTIVE)", memory_id, status)
+            return False
+        return True
+    except ClientError as e:
+        logger.warning("health check failed (%s)", e.response["Error"]["Code"])
+        return False
+
+
+# --- Placeholder so the patterns are self-contained -----------------------
+def _emit_metric(name: str, value: float) -> None:
+    """Stand-in for your metrics pipeline (EMF, CloudWatch PutMetricData…).
+
+    Replace with your telemetry. Kept trivial here so the patterns above read
+    cleanly; the point is that every degradation/failure path is observable.
+    """
+    logger.debug("metric %s=%s", name, value)

--- a/01-features/04-manage-context-of-your-agent/memory/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/README.md
@@ -18,6 +18,7 @@ New to AgentCore Memory? → [`00-getting-started/`](./00-getting-started/). You
 | [`03-integrations/`](./03-integrations/) | Runtime, identity, Guardrails, memory-browser |
 | [`04-observability/`](./04-observability/) | CloudWatch metrics, alarms, ingestion logs |
 | [`05-security/`](./05-security/) | IAM scoping, Cognito federation, KMS encryption |
+| [`06-production-patterns/`](./06-production-patterns/) | Error handling & retries, cost optimization, deploy-to-prod checklist |
 
 ## How this tree is organised
 


### PR DESCRIPTION
## What

Adds single- and multi-agent memory tutorials for the `01-features/04-manage-context-of-your-agent/memory` feature across three agent frameworks, plus a production-patterns reference module and supporting navigation READMEs.

**Tutorials added (13 runnable + 1 reference module):**

| Framework | Tutorials |
|---|---|
| **Claude SDK** (Anthropic Bedrock) | short-term conversation · long-term semantic · custom strategy override · memory-as-tool · **episodic** · multi-agent shared memory |
| **LangGraph v1** | built-in callback (checkpointer + store) · memory-as-tool · multi-agent shared memory |
| **LlamaIndex** | built-in memory block · custom memory block · multi-agent shared memory |
| **Production patterns** | retry/backoff, graceful degradation, durable writes, batch partial-failure handling, ephemeral-resource cleanup (reference module, no live calls) |

## Review updates

Two changes since the first revision:

**1. Use the SDK's `create_or_get_memory` instead of a hand-rolled helper.** Per review, every tutorial had its own `get_or_create_memory` that called `create_memory_and_wait`, caught the "already exists" `ValidationException`, and scanned `list_memories` to reuse the id. `MemoryClient.create_or_get_memory` already does exactly that, so all 12 tutorials now delegate to it (−155 lines of duplicated try/except). Verified live that create + reuse return the same id, with strategies attached correctly.

**2. Fixed the LlamaIndex multi-agent extraction wait.** The sequential handoff polled for async extraction between agents but capped the wait at 120s. On a live run, extraction into the shared namespace took longer, so downstream agents read an empty blackboard. Raised the cap to 300s (the code already polled and returns as soon as records appear, so fast runs are unaffected). Re-ran live: the shared namespace returned records and the handoff worked.

## Validation

All runnable tutorials were executed **verbatim against a live AgentCore Memory account** (`us-west-2`, model `global.anthropic.claude-sonnet-4-6`). Each:

- exits `0` and demonstrates its advertised pattern (store → async extraction → cross-session/cross-agent recall), and
- deletes the memory resource it creates in a `finally` block — verified zero residual resources after each run.

The production-patterns module passed 14/14 unit tests (mocked, no AWS). Static checks (compile, import resolution against current SDKs, all relative markdown links resolve) also pass.

### End-to-end results

Full live runs after the `create_or_get_memory` refactor (us-west-2, `global.anthropic.claude-sonnet-4-6`). All self-cleaned; no residual memories afterward (only the 3 unrelated baseline resources remained).

| # | Framework | Tutorial | Result |
|---|---|---|---|
| 1 | Claude SDK | short-term conversation | ✅ recalled name + destination in a new process |
| 2 | Claude SDK | long-term semantic | ✅ retrieved 2 facts + 1 preference |
| 3 | Claude SDK | memory-as-tool | ✅ recall tool returned 3 records in session 2 |
| 4 | Claude SDK | custom strategy override | ✅ 5 clinical-fact records via the override strategy |
| 5 | Claude SDK | multi-agent shared memory | ✅ agent-to-agent handoff via shared memory |
| 6 | Claude SDK | **episodic** | ✅ episode extracted ~14.9 min after seeding; closing-turn conclusion confirmed |
| 7 | LangGraph v1 | built-in callback | ✅ session 2 auto-recalled the user's facts |
| 8 | LangGraph v1 | memory-as-tool | ✅ 5 records recalled in a new session |
| 9 | LangGraph v1 | multi-agent shared memory | ✅ shared-memory recall across agents |
| 10 | LlamaIndex | built-in memory block | ✅ session 2 recalled facts never stated in that session |
| 11 | LlamaIndex | custom memory block | ✅ recalled customer profile, opened a ticket from memory |
| 12 | LlamaIndex | multi-agent shared memory | ✅ after the wait-cap fix, shared blackboard populated and handoff worked |

### Episodic tutorial — validated end-to-end

The Claude SDK **episodic** tutorial (`04-episodic-memory`) was held back from the first revision until its asynchronous Episodic pipeline (Extraction → Consolidation → Reflection) was verified to actually produce records. It now passes: an episode/reflection record surfaced ~15 min after seeding, and a follow-up session recalled it. It demonstrates the Episodic-strategy specifics:
- `reflectionConfiguration` with a namespace that is the same as / a prefix of the episode namespace (required by `CreateMemory`).
- Each episode ends with a clear conclusion **and a following turn**, so AgentCore detects "episode completion".
- A 20-minute extraction-wait cap, since episodic extraction is slower than semantic.

## Notes

- LangGraph tutorials use the v1 `create_agent` + middleware API with `langgraph-checkpoint-aws` savers; only a non-fatal `.text()` deprecation warning was observed.
- Credentials are sourced solely from the standard AWS provider chain; no secrets in code.
