### PR TITLE
Add AgentCore Gateway Lambda interceptor + InvokeGuardrails content safety for customer service agent blueprint

### DIFF
--- a/05-blueprints/end-to-end-customer-service-agent/infra/lambda/INTERCEPTOR_README.md
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/lambda/INTERCEPTOR_README.md
@@ -62,12 +62,20 @@ Controlled by environment variables:
 - `RATE_LIMIT_MAX` — max calls per window (default 100)
 - `RATE_LIMIT_WINDOW` — window in seconds (default 3600 = 1 hour)
 
-**5. Input transformation**
+**5. Guardrail checks (InvokeGuardrailChecks API)**
+Runs the new resourceless Bedrock Guardrails API on user input:
+- Content filters: VIOLENCE, MISCONDUCT, HATE, SEXUAL, INSULTS (uses `severityScore` 0–1)
+- Prompt attacks: JAILBREAK, PROMPT_INJECTION, PROMPT_LEAKAGE (uses `severityScore` 0–1)
+- Blocks requests where severity ≥ `GUARDRAIL_BLOCK_THRESHOLD` (default 0.8)
+- Returns `-32004` JSON-RPC error when blocked
+- Gracefully skips if SDK doesn't have the API yet (`AttributeError` catch)
+- Fails open on service errors (doesn't block if Bedrock is unavailable)
+
+**6. Input transformation**
 Normalises parameter names before requests reach the target. For example, the agent may send `search_query` but the Tavily Lambda expects `query`. The interceptor translates these transparently so the agent doesn't need to know each target's exact schema.
 
 **6. Header injection**
 Injects downstream authentication and tracing headers:
-- `x-api-key` — downstream API key (from `DOWNSTREAM_API_KEY` env var)
 - `x-caller-id` — propagates caller identity for downstream audit trails
 - `x-request-time` — timestamp for distributed tracing correlation
 
@@ -78,12 +86,19 @@ Recursively walks the response body and redacts sensitive data patterns before t
 - Email addresses → `[EMAIL]`
 - Phone numbers → `[PHONE]`
 - US Social Security Numbers → `[SSN]`
-- Credit card numbers → `[CARD]`
-- ZIP codes → `[ZIP]`
+- Credit card numbers (Visa, MC, Amex, Discover prefixes) → `[CARD]`
 
 This is critical for a customer service agent that may retrieve customer records containing personal information.
 
-**8. Response logging**
+**8. Guardrail checks (InvokeGuardrailChecks API)**
+Runs the new resourceless Bedrock Guardrails API on tool output:
+- Content filters: VIOLENCE, HATE, MISCONDUCT
+- Sensitive information: EMAIL, PHONE, SSN, CREDIT_CARD (with character offsets)
+- Uses `confidenceScore` for PII detection (0–1)
+- Logs findings but does NOT block responses (detect-only on output)
+- Gracefully skips if SDK doesn't have the API yet (`AttributeError` catch)
+
+**9. Response logging**
 Emits a structured log entry for every tool response:
 ```json
 {"event": "tool_call_response", "method": "tools/call", "has_error": false, "streaming": false, "timestamp": 1234567890}
@@ -139,7 +154,9 @@ Both request and response interceptors point to the same Lambda. Set `Pass reque
 | `RATE_LIMIT_MAX` | Max tool calls per caller per window | `100` |
 | `RATE_LIMIT_WINDOW` | Rate limit window in seconds | `3600` |
 | `ENABLE_RATE_LIMIT` | Enable/disable rate limiting | `true` |
-| `DOWNSTREAM_API_KEY` | API key injected into downstream requests | `""` |
+| `ENABLE_GUARDRAIL_CHECKS` | Enable/disable InvokeGuardrailChecks API integration | `true` |
+| `GUARDRAIL_BLOCK_THRESHOLD` | Severity score (0-1) at which to block requests | `0.8` |
+| `GUARDRAIL_ESCALATE_THRESHOLD` | Score (0-1) at which to log/escalate findings | `0.4` |
 
 ## Local Testing
 

--- a/05-blueprints/end-to-end-customer-service-agent/infra/lambda/INTERCEPTOR_README.md
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/lambda/INTERCEPTOR_README.md
@@ -1,0 +1,166 @@
+# AgentCore Gateway Lambda Interceptor
+
+## Overview
+
+This directory contains the Lambda interceptor for the AgentCore Gateway used in the end-to-end customer service agent blueprint. The interceptor sits between the client and the gateway targets, providing security, observability, and transformation capabilities on every tool call.
+
+## Architecture
+
+```
+Client / Agent
+      │
+      │  MCP tool call (with Bearer token)
+      ▼
+AgentCore Gateway
+      │
+      ├── REQUEST interceptor fires (gateway_interceptor.py)
+      │         token validation, rate limiting, logging, header injection, input transformation
+      │
+      ▼
+Gateway Target (e.g. Tavily Lambda)
+      │
+      ├── RESPONSE interceptor fires (gateway_interceptor.py)
+      │         PII masking, response logging, error normalisation
+      │
+      ▼
+Client / Agent receives response
+```
+
+One Lambda function handles both request and response interception. The gateway determines which path to invoke based on whether `gatewayResponse` is present in the event payload.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `gateway_interceptor.py` | Interceptor Lambda — handles request and response paths |
+| `tavily_search.py` | Tavily web search tool Lambda |
+
+## What the Interceptor Does
+
+### Request path
+
+**1. Token validation**
+Checks that the inbound `Authorization` header is present, uses Bearer scheme, and contains a structurally valid JWT (three base64 segments). Blocks requests with missing or malformed tokens with a `-32001` JSON-RPC error.
+
+For production, replace the structural check in `_validate_token` with full JWT signature verification using the Cognito JWKS endpoint.
+
+**2. Logging and auditing**
+Emits a structured JSON log entry to CloudWatch for every tool call:
+```json
+{"event": "tool_call_request", "caller_id": "...", "method": "tools/call", "tool": "tavily_search", "timestamp": 1234567890}
+```
+This provides a complete audit trail of who called which tool and when.
+
+**3. Request validation**
+Checks the requested tool name against an allowlist (`ALLOWED_TOOLS`). Blocks calls to tools not in the list with a `-32002` error. This prevents agents from calling tools they are not authorised to use even if those tools exist on the gateway.
+
+**4. Rate limiting**
+Enforces a per-caller call quota using DynamoDB. Each caller (identified by the `sub` claim in the JWT) gets a counter per time window. If the counter exceeds `RATE_LIMIT_MAX`, the request is blocked with a `-32003` error.
+
+Controlled by environment variables:
+- `ENABLE_RATE_LIMIT` — set to `false` to disable (useful for development)
+- `RATE_LIMIT_MAX` — max calls per window (default 100)
+- `RATE_LIMIT_WINDOW` — window in seconds (default 3600 = 1 hour)
+
+**5. Input transformation**
+Normalises parameter names before requests reach the target. For example, the agent may send `search_query` but the Tavily Lambda expects `query`. The interceptor translates these transparently so the agent doesn't need to know each target's exact schema.
+
+**6. Header injection**
+Injects downstream authentication and tracing headers:
+- `x-api-key` — downstream API key (from `DOWNSTREAM_API_KEY` env var)
+- `x-caller-id` — propagates caller identity for downstream audit trails
+- `x-request-time` — timestamp for distributed tracing correlation
+
+### Response path
+
+**7. PII masking**
+Recursively walks the response body and redacts sensitive data patterns before they reach the agent:
+- Email addresses → `[EMAIL]`
+- Phone numbers → `[PHONE]`
+- US Social Security Numbers → `[SSN]`
+- Credit card numbers → `[CARD]`
+- ZIP codes → `[ZIP]`
+
+This is critical for a customer service agent that may retrieve customer records containing personal information.
+
+**8. Response logging**
+Emits a structured log entry for every tool response:
+```json
+{"event": "tool_call_response", "method": "tools/call", "has_error": false, "streaming": false, "timestamp": 1234567890}
+```
+
+**9. Error normalisation**
+Ensures all error responses follow the JSON-RPC error format so the agent always sees a consistent error structure regardless of what the target returned.
+
+## Infrastructure Changes
+
+The following Terraform resources were added to `main.tf`:
+
+| Resource | Purpose |
+|----------|---------|
+| `aws_iam_role.interceptor_lambda_role` | Execution role for the interceptor Lambda |
+| `aws_dynamodb_table.rate_limit_table` | Stores per-caller call counters for rate limiting. PAY_PER_REQUEST billing, TTL enabled for automatic cleanup |
+| `aws_iam_role_policy.interceptor_dynamodb_policy` | Least-privilege policy allowing the Lambda to read/write the rate limit table only |
+| `aws_lambda_function.gateway_interceptor` | The interceptor Lambda function |
+| `aws_lambda_permission.allow_gateway_interceptor` | Allows AgentCore Gateway to invoke the interceptor |
+
+The gateway IAM role policy (`gateway_policy`) was updated to include the interceptor Lambda ARN alongside the Tavily Lambda ARN.
+
+New variables added to `variables.tf`:
+- `interceptor_rate_limit_max` (default: 100)
+- `interceptor_rate_limit_window` (default: 3600)
+- `interceptor_enable_rate_limit` (default: true)
+
+New outputs added to `outputs.tf`:
+- `interceptor_lambda_arn`
+- `interceptor_lambda_name`
+- `rate_limit_table_name`
+
+## Attaching the Interceptor to the Gateway
+
+The AWS Terraform provider (v6.47) does not yet expose gateway interceptor configuration as a Terraform attribute. Attach the interceptor via the AWS console (Gateway → Edit → Interceptors) or CLI after `terraform apply`:
+
+```bash
+# Replace <gateway-id> with your gateway ID from terraform output
+aws bedrock-agentcore-control update-gateway \
+  --gateway-identifier <gateway-id> \
+  --request-interceptor-lambda-arn <interceptor-lambda-arn> \
+  --response-interceptor-lambda-arn <interceptor-lambda-arn> \
+  --region us-east-1
+```
+
+Both request and response interceptors point to the same Lambda. Set `Pass request headers: True` for both so the `Authorization` header is available for token validation.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RATE_LIMIT_TABLE` | DynamoDB table name for rate limit counters | `agentcore-gateway-rate-limits` |
+| `RATE_LIMIT_MAX` | Max tool calls per caller per window | `100` |
+| `RATE_LIMIT_WINDOW` | Rate limit window in seconds | `3600` |
+| `ENABLE_RATE_LIMIT` | Enable/disable rate limiting | `true` |
+| `DOWNSTREAM_API_KEY` | API key injected into downstream requests | `""` |
+
+## Local Testing
+
+Test the interceptor Lambda directly without going through the gateway:
+
+```bash
+aws lambda invoke \
+  --function-name cx-gateway-interceptor \
+  --payload '{"mcp":{"gatewayRequest":{"body":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tavily_search","arguments":{"query":"test"}}},"headers":{"authorization":"Bearer <your-token>"}}}}' \
+  --region us-east-1 \
+  --cli-binary-format raw-in-base64-out \
+  response.json && cat response.json | python3 -m json.tool
+```
+
+Test the Tavily Lambda directly:
+
+```bash
+aws lambda invoke \
+  --function-name tavily-search-function \
+  --payload '{"query":"AWS AgentCore tutorial"}' \
+  --region us-east-1 \
+  --cli-binary-format raw-in-base64-out \
+  tavily_response.json && cat tavily_response.json | python3 -m json.tool
+```

--- a/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
@@ -5,25 +5,27 @@ Handles both REQUEST and RESPONSE interception in a single Lambda function.
 
 REQUEST path capabilities:
   1. Token validation       - verify inbound JWT is present and well-formed
-  2. Header injection       - add downstream auth headers (API keys, bearer tokens)
+  2. Logging / auditing     - structured CloudWatch log per tool call
   3. Request validation     - block malformed or disallowed tool calls
-  4. Logging / auditing     - structured CloudWatch log per tool call
-  5. Rate limiting          - per-user call quota enforced via DynamoDB
+  4. Rate limiting          - per-user call quota enforced via DynamoDB
+  5. Guardrail checks       - content filters + prompt attack detection on user input
   6. Input transformation   - normalise parameter names before hitting targets
-  7. Guardrail checks       - content filters + prompt attack detection on user input
+  7. Header injection       - add downstream auth headers (API keys, bearer tokens)
 
 RESPONSE path capabilities:
   8. PII masking            - redact emails, phone numbers, SSNs from tool responses
-  9. Response logging       - record what each tool returned
-  10. Error normalisation   - standardise error shapes returned to the agent
-  11. Guardrail checks      - content filters + PII detection on tool output
+  9. Guardrail checks       - content filters + PII detection on tool output
+  10. Response logging      - record what each tool returned
+  11. Error normalisation   - standardise error shapes returned to the agent
 """
 
+import base64
 import json
 import logging
 import os
 import re
 import time
+
 import boto3
 from botocore.exceptions import ClientError
 
@@ -36,7 +38,6 @@ logger.setLevel(logging.INFO)
 RATE_LIMIT_TABLE   = os.environ.get("RATE_LIMIT_TABLE", "agentcore-gateway-rate-limits")
 RATE_LIMIT_MAX     = int(os.environ.get("RATE_LIMIT_MAX", "100"))   # calls per window
 RATE_LIMIT_WINDOW  = int(os.environ.get("RATE_LIMIT_WINDOW", "3600"))  # seconds (1 hour)
-DOWNSTREAM_API_KEY = os.environ.get("DOWNSTREAM_API_KEY", "")       # injected header value
 ENABLE_RATE_LIMIT  = os.environ.get("ENABLE_RATE_LIMIT", "true").lower() == "true"
 
 # Guardrail checks configuration
@@ -62,10 +63,8 @@ PII_PATTERNS = [
     (re.compile(r"\b(\+?1[\s\-.]?)?\(?\d{3}\)?[\s\-.]?\d{3}[\s\-.]?\d{4}\b"), "[PHONE]"),
     # US Social Security Numbers
     (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "[SSN]"),
-    # Credit card numbers (basic pattern)
-    (re.compile(r"\b(?:\d[ \-]?){13,16}\b"), "[CARD]"),
-    # US ZIP codes (standalone — 5 digit)
-    (re.compile(r"\b\d{5}(?:-\d{4})?\b"), "[ZIP]"),
+    # Credit card numbers — match common prefixes (Visa, MC, Amex, Discover)
+    (re.compile(r"\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))[\s\-]?\d{4}[\s\-]?\d{4}[\s\-]?\d{1,4}\b"), "[CARD]"),
 ]
 
 # ---------------------------------------------------------------------------
@@ -178,12 +177,12 @@ def _handle_request(gateway_request: dict) -> dict:
                 )
 
     # ------------------------------------------------------------------
-    # 5. INPUT TRANSFORMATION — normalise parameter names
+    # 6. INPUT TRANSFORMATION — normalise parameter names
     # ------------------------------------------------------------------
     body = _transform_request_body(body, tool_name)
 
     # ------------------------------------------------------------------
-    # 6. HEADER INJECTION — add downstream auth headers
+    # 7. HEADER INJECTION — add downstream auth headers
     # ------------------------------------------------------------------
     headers = _inject_headers(headers, caller_id)
 
@@ -212,12 +211,12 @@ def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
     msg_id         = body.get("id") if isinstance(body, dict) else None
 
     # ------------------------------------------------------------------
-    # 7. PII MASKING — scrub sensitive data before it reaches the agent
+    # 8. PII MASKING — scrub sensitive data before it reaches the agent
     # ------------------------------------------------------------------
     body = _mask_pii(body)
 
     # ------------------------------------------------------------------
-    # 8. GUARDRAIL CHECKS — content filters + PII detection on tool output
+    # 9. GUARDRAIL CHECKS — content filters + PII detection on tool output
     # ------------------------------------------------------------------
     if ENABLE_GUARDRAIL_CHECKS:
         response_text = _extract_response_text(body)
@@ -228,7 +227,7 @@ def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
                 # Log findings but don't block — tool output is informational
 
     # ------------------------------------------------------------------
-    # 8. RESPONSE LOGGING
+    # 10. RESPONSE LOGGING
     # ------------------------------------------------------------------
     logger.info(json.dumps({
         "event":      "tool_call_response",
@@ -240,7 +239,7 @@ def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
     }))
 
     # ------------------------------------------------------------------
-    # 9. ERROR NORMALISATION — standardise error shapes
+    # 11. ERROR NORMALISATION — standardise error shapes
     # ------------------------------------------------------------------
     body = _normalise_error(body)
 
@@ -264,10 +263,22 @@ def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
 
 def _validate_token(auth_header: str):
     """
-    Basic JWT presence and format check.
-    Returns an error string if invalid, None if valid.
-    For production, replace with full JWT signature verification
-    using your Cognito JWKS endpoint.
+    JWT presence and structural validation.
+    Returns an error string if invalid, None if structurally valid.
+
+    WARNING — PRODUCTION USE:
+    This performs structural checks only (presence, Bearer scheme, 3-part JWT format).
+    It does NOT verify the token signature. In production deployments you MUST
+    verify signatures using your IdP's JWKS endpoint. Use python-jose or PyJWT:
+
+        from jose import jwt, JWTError
+        jwks = requests.get(f"{DISCOVERY_URL}/.well-known/jwks.json").json()
+        payload = jwt.decode(token, jwks, algorithms=["RS256"], audience=EXPECTED_AUDIENCE)
+
+    The AgentCore Gateway already performs full JWT validation before calling
+    this interceptor, so this check is a defense-in-depth measure. However,
+    if you rely on caller_id for rate limiting or downstream auth, signature
+    verification here prevents spoofing by compromised gateway configurations.
     """
     if not auth_header:
         return "Missing Authorization header"
@@ -280,14 +291,19 @@ def _validate_token(auth_header: str):
     parts = token.split(".")
     if len(parts) != 3:
         return "Malformed JWT token"
-    return None  # valid
+    return None  # structurally valid
 
 
 def _extract_caller_id(auth_header: str) -> str:
     """
     Extract a caller identifier from the JWT payload (sub claim).
     Falls back to 'anonymous' if extraction fails.
-    For production, use a proper JWT library (python-jose, PyJWT).
+
+    NOTE: This reads claims from an unverified token payload. The caller_id
+    is used for rate limiting and audit logging. Since the AgentCore Gateway
+    validates the JWT signature before invoking this interceptor, the claims
+    are trustworthy in normal operation. If you need defense against gateway
+    misconfiguration, add signature verification in _validate_token above.
     """
     try:
         token = auth_header.split(" ", 1)[1].strip()
@@ -296,7 +312,6 @@ def _extract_caller_id(auth_header: str) -> str:
         padding = 4 - len(payload_b64) % 4
         if padding != 4:
             payload_b64 += "=" * padding
-        import base64
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         return payload.get("sub") or payload.get("client_id") or "anonymous"
     except Exception:
@@ -316,12 +331,13 @@ def _check_rate_limit(caller_id: str):
 
         response = table.update_item(
             Key={"pk": bucket_key},
-            UpdateExpression="ADD call_count :inc SET ttl = :ttl",
+            UpdateExpression="ADD call_count :inc SET #ttl_attr = :ttl",
+            ExpressionAttributeNames={"#ttl_attr": "ttl"},
             ExpressionAttributeValues={":inc": 1, ":ttl": ttl_value},
             ReturnValues="UPDATED_NEW",
         )
         count = int(response["Attributes"]["call_count"])
-        if count > RATE_LIMIT_MAX:
+        if count >= RATE_LIMIT_MAX:
             return f"Rate limit exceeded: {count}/{RATE_LIMIT_MAX} calls in current window"
         return None
     except ClientError as e:
@@ -375,10 +391,6 @@ def _inject_headers(headers: dict, caller_id: str) -> dict:
     """
     Inject downstream authentication and tracing headers.
     """
-    # Downstream API key (e.g. for an internal API gateway)
-    if DOWNSTREAM_API_KEY:
-        headers["x-api-key"] = DOWNSTREAM_API_KEY
-
     # Propagate caller identity for downstream audit trails
     if caller_id and caller_id != "anonymous":
         headers["x-caller-id"] = caller_id
@@ -389,7 +401,7 @@ def _inject_headers(headers: dict, caller_id: str) -> dict:
     return headers
 
 
-def _mask_pii(body) -> dict:
+def _mask_pii(body):
     """
     Recursively walk the response body and redact PII patterns.
     Operates on string values only — leaves structure intact.
@@ -490,7 +502,7 @@ def _check_input_guardrails(text: str):
 
         blocked_categories = []
 
-        # Check content filter results
+        # Check content filter results (uses severityScore)
         if "contentFilter" in response.get("results", {}):
             for finding in response["results"]["contentFilter"]["results"]:
                 if finding["severityScore"] >= GUARDRAIL_BLOCK_THRESHOLD:
@@ -498,7 +510,7 @@ def _check_input_guardrails(text: str):
                         f"{finding['category']}(severity={finding['severityScore']})"
                     )
 
-        # Check prompt attack results
+        # Check prompt attack results (uses severityScore)
         if "promptAttack" in response.get("results", {}):
             for finding in response["results"]["promptAttack"]["results"]:
                 if finding["severityScore"] >= GUARDRAIL_BLOCK_THRESHOLD:
@@ -551,7 +563,7 @@ def _check_output_guardrails(text: str) -> list:
 
         findings = []
 
-        # Content filter findings
+        # Content filter findings (uses severityScore)
         if "contentFilter" in response.get("results", {}):
             for finding in response["results"]["contentFilter"]["results"]:
                 if finding["severityScore"] >= GUARDRAIL_ESCALATE_THRESHOLD:
@@ -561,7 +573,7 @@ def _check_output_guardrails(text: str) -> list:
                         "score": finding["severityScore"],
                     })
 
-        # Sensitive information findings
+        # Sensitive information findings (uses confidenceScore)
         if "sensitiveInformation" in response.get("results", {}):
             for finding in response["results"]["sensitiveInformation"]["results"]:
                 if finding["confidenceScore"] >= GUARDRAIL_ESCALATE_THRESHOLD:

--- a/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
@@ -10,11 +10,13 @@ REQUEST path capabilities:
   4. Logging / auditing     - structured CloudWatch log per tool call
   5. Rate limiting          - per-user call quota enforced via DynamoDB
   6. Input transformation   - normalise parameter names before hitting targets
+  7. Guardrail checks       - content filters + prompt attack detection on user input
 
 RESPONSE path capabilities:
-  7. PII masking            - redact emails, phone numbers, SSNs from tool responses
-  8. Response logging       - record what each tool returned
-  9. Error normalisation    - standardise error shapes returned to the agent
+  8. PII masking            - redact emails, phone numbers, SSNs from tool responses
+  9. Response logging       - record what each tool returned
+  10. Error normalisation   - standardise error shapes returned to the agent
+  11. Guardrail checks      - content filters + PII detection on tool output
 """
 
 import json
@@ -36,6 +38,11 @@ RATE_LIMIT_MAX     = int(os.environ.get("RATE_LIMIT_MAX", "100"))   # calls per 
 RATE_LIMIT_WINDOW  = int(os.environ.get("RATE_LIMIT_WINDOW", "3600"))  # seconds (1 hour)
 DOWNSTREAM_API_KEY = os.environ.get("DOWNSTREAM_API_KEY", "")       # injected header value
 ENABLE_RATE_LIMIT  = os.environ.get("ENABLE_RATE_LIMIT", "true").lower() == "true"
+
+# Guardrail checks configuration
+ENABLE_GUARDRAIL_CHECKS = os.environ.get("ENABLE_GUARDRAIL_CHECKS", "true").lower() == "true"
+GUARDRAIL_BLOCK_THRESHOLD = float(os.environ.get("GUARDRAIL_BLOCK_THRESHOLD", "0.8"))
+GUARDRAIL_ESCALATE_THRESHOLD = float(os.environ.get("GUARDRAIL_ESCALATE_THRESHOLD", "0.4"))
 
 # Tools that are allowed through the gateway — block anything not in this list
 ALLOWED_TOOLS = {
@@ -71,6 +78,18 @@ def get_dynamodb():
     if _dynamodb is None:
         _dynamodb = boto3.resource("dynamodb")
     return _dynamodb
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Runtime client for guardrail checks (lazy init)
+# ---------------------------------------------------------------------------
+_bedrock_runtime = None
+
+def get_bedrock_runtime():
+    global _bedrock_runtime
+    if _bedrock_runtime is None:
+        _bedrock_runtime = boto3.client("bedrock-runtime")
+    return _bedrock_runtime
 
 
 # ===========================================================================
@@ -146,6 +165,19 @@ def _handle_request(gateway_request: dict) -> dict:
             return _error_response(msg_id, code=-32003, message=rate_error)
 
     # ------------------------------------------------------------------
+    # 5. GUARDRAIL CHECKS — content filters + prompt attack detection
+    # ------------------------------------------------------------------
+    if ENABLE_GUARDRAIL_CHECKS and method == "tools/call":
+        user_text = _extract_user_text(params)
+        if user_text:
+            guardrail_result = _check_input_guardrails(user_text)
+            if guardrail_result:
+                logger.warning(f"GUARDRAIL BLOCKED: caller={caller_id} | {guardrail_result}")
+                return _error_response(
+                    msg_id, code=-32004, message=f"Content blocked by safety guardrail: {guardrail_result}"
+                )
+
+    # ------------------------------------------------------------------
     # 5. INPUT TRANSFORMATION — normalise parameter names
     # ------------------------------------------------------------------
     body = _transform_request_body(body, tool_name)
@@ -183,6 +215,17 @@ def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
     # 7. PII MASKING — scrub sensitive data before it reaches the agent
     # ------------------------------------------------------------------
     body = _mask_pii(body)
+
+    # ------------------------------------------------------------------
+    # 8. GUARDRAIL CHECKS — content filters + PII detection on tool output
+    # ------------------------------------------------------------------
+    if ENABLE_GUARDRAIL_CHECKS:
+        response_text = _extract_response_text(body)
+        if response_text:
+            guardrail_findings = _check_output_guardrails(response_text)
+            if guardrail_findings:
+                logger.warning(f"GUARDRAIL OUTPUT FINDING: {guardrail_findings}")
+                # Log findings but don't block — tool output is informational
 
     # ------------------------------------------------------------------
     # 8. RESPONSE LOGGING
@@ -409,3 +452,166 @@ def _error_response(msg_id, code: int, message: str) -> dict:
             }
         },
     }
+
+
+# ===========================================================================
+# GUARDRAIL CHECK FUNCTIONS (InvokeGuardrailChecks API)
+# ===========================================================================
+
+def _check_input_guardrails(text: str):
+    """
+    Run guardrail checks on user input using the InvokeGuardrailChecks API.
+    Checks for prompt attacks (jailbreak, injection) and harmful content.
+    Returns an error string if blocked, None if allowed.
+    """
+    try:
+        client = get_bedrock_runtime()
+        response = client.invoke_guardrail_checks(
+            messages=[{"role": "user", "content": [{"text": text}]}],
+            checks={
+                "contentFilter": {
+                    "categories": [
+                        {"category": "VIOLENCE"},
+                        {"category": "MISCONDUCT"},
+                        {"category": "HATE"},
+                        {"category": "SEXUAL"},
+                        {"category": "INSULTS"},
+                    ]
+                },
+                "promptAttack": {
+                    "categories": [
+                        {"category": "JAILBREAK"},
+                        {"category": "PROMPT_INJECTION"},
+                        {"category": "PROMPT_LEAKAGE"},
+                    ]
+                },
+            },
+        )
+
+        blocked_categories = []
+
+        # Check content filter results
+        if "contentFilter" in response.get("results", {}):
+            for finding in response["results"]["contentFilter"]["results"]:
+                if finding["severityScore"] >= GUARDRAIL_BLOCK_THRESHOLD:
+                    blocked_categories.append(
+                        f"{finding['category']}(severity={finding['severityScore']})"
+                    )
+
+        # Check prompt attack results
+        if "promptAttack" in response.get("results", {}):
+            for finding in response["results"]["promptAttack"]["results"]:
+                if finding["severityScore"] >= GUARDRAIL_BLOCK_THRESHOLD:
+                    blocked_categories.append(
+                        f"{finding['category']}(severity={finding['severityScore']})"
+                    )
+
+        if blocked_categories:
+            return ", ".join(blocked_categories)
+        return None
+
+    except AttributeError:
+        # API not available in current SDK version — skip gracefully
+        logger.info("InvokeGuardrailChecks API not available — skipping input guardrail checks")
+        return None
+    except Exception as e:
+        # Fail open — don't block requests if guardrail service is unavailable
+        logger.error(f"Guardrail input check failed: {e} — allowing request through")
+        return None
+
+
+def _check_output_guardrails(text: str) -> list:
+    """
+    Run guardrail checks on tool output using the InvokeGuardrailChecks API.
+    Checks for harmful content and sensitive information in responses.
+    Returns a list of findings for logging, empty list if clean.
+    """
+    try:
+        client = get_bedrock_runtime()
+        response = client.invoke_guardrail_checks(
+            messages=[{"role": "assistant", "content": [{"text": text}]}],
+            checks={
+                "contentFilter": {
+                    "categories": [
+                        {"category": "VIOLENCE"},
+                        {"category": "HATE"},
+                        {"category": "MISCONDUCT"},
+                    ]
+                },
+                "sensitiveInformation": {
+                    "entities": [
+                        {"type": "EMAIL"},
+                        {"type": "PHONE"},
+                        {"type": "US_SOCIAL_SECURITY_NUMBER"},
+                        {"type": "CREDIT_DEBIT_CARD_NUMBER"},
+                    ]
+                },
+            },
+        )
+
+        findings = []
+
+        # Content filter findings
+        if "contentFilter" in response.get("results", {}):
+            for finding in response["results"]["contentFilter"]["results"]:
+                if finding["severityScore"] >= GUARDRAIL_ESCALATE_THRESHOLD:
+                    findings.append({
+                        "type": "content",
+                        "category": finding["category"],
+                        "score": finding["severityScore"],
+                    })
+
+        # Sensitive information findings
+        if "sensitiveInformation" in response.get("results", {}):
+            for finding in response["results"]["sensitiveInformation"]["results"]:
+                if finding["confidenceScore"] >= GUARDRAIL_ESCALATE_THRESHOLD:
+                    findings.append({
+                        "type": "pii",
+                        "entity": finding["type"],
+                        "score": finding["confidenceScore"],
+                        "offset": f"[{finding['beginOffset']}:{finding['endOffset']}]",
+                    })
+
+        return findings
+
+    except AttributeError:
+        # API not available in current SDK version — skip gracefully
+        logger.info("InvokeGuardrailChecks API not available — skipping output guardrail checks")
+        return []
+    except Exception as e:
+        # Fail open — don't break the response pipeline
+        logger.error(f"Guardrail output check failed: {e} — skipping")
+        return []
+
+
+def _extract_user_text(params: dict) -> str:
+    """Extract the user's input text from MCP tool call parameters."""
+    if not isinstance(params, dict):
+        return ""
+    arguments = params.get("arguments", {})
+    if not isinstance(arguments, dict):
+        return ""
+    # Try common parameter names that contain user text
+    for key in ("query", "prompt", "text", "message", "input", "description", "subject"):
+        if key in arguments and isinstance(arguments[key], str):
+            return arguments[key]
+    # Fallback: concatenate all string values
+    texts = [v for v in arguments.values() if isinstance(v, str)]
+    return " ".join(texts) if texts else ""
+
+
+def _extract_response_text(body: dict) -> str:
+    """Extract text content from a tool response body."""
+    if not isinstance(body, dict):
+        return ""
+    result = body.get("result", {})
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content", [])
+    if isinstance(content, list):
+        texts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        return " ".join(texts)
+    return ""

--- a/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/lambda/gateway_interceptor.py
@@ -1,0 +1,411 @@
+"""
+AgentCore Gateway Interceptor for Customer Service Agent
+=========================================================
+Handles both REQUEST and RESPONSE interception in a single Lambda function.
+
+REQUEST path capabilities:
+  1. Token validation       - verify inbound JWT is present and well-formed
+  2. Header injection       - add downstream auth headers (API keys, bearer tokens)
+  3. Request validation     - block malformed or disallowed tool calls
+  4. Logging / auditing     - structured CloudWatch log per tool call
+  5. Rate limiting          - per-user call quota enforced via DynamoDB
+  6. Input transformation   - normalise parameter names before hitting targets
+
+RESPONSE path capabilities:
+  7. PII masking            - redact emails, phone numbers, SSNs from tool responses
+  8. Response logging       - record what each tool returned
+  9. Error normalisation    - standardise error shapes returned to the agent
+"""
+
+import json
+import logging
+import os
+import re
+import time
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# ---------------------------------------------------------------------------
+# Configuration (override via Lambda environment variables)
+# ---------------------------------------------------------------------------
+RATE_LIMIT_TABLE   = os.environ.get("RATE_LIMIT_TABLE", "agentcore-gateway-rate-limits")
+RATE_LIMIT_MAX     = int(os.environ.get("RATE_LIMIT_MAX", "100"))   # calls per window
+RATE_LIMIT_WINDOW  = int(os.environ.get("RATE_LIMIT_WINDOW", "3600"))  # seconds (1 hour)
+DOWNSTREAM_API_KEY = os.environ.get("DOWNSTREAM_API_KEY", "")       # injected header value
+ENABLE_RATE_LIMIT  = os.environ.get("ENABLE_RATE_LIMIT", "true").lower() == "true"
+
+# Tools that are allowed through the gateway — block anything not in this list
+ALLOWED_TOOLS = {
+    "tavily_search",
+    "retrieve_context",
+    "create_ticket",
+    "update_ticket",
+    "get_ticket",
+    "list_tickets",
+}
+
+# PII patterns to redact from responses
+PII_PATTERNS = [
+    # Email addresses
+    (re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"), "[EMAIL]"),
+    # US phone numbers (various formats)
+    (re.compile(r"\b(\+?1[\s\-.]?)?\(?\d{3}\)?[\s\-.]?\d{3}[\s\-.]?\d{4}\b"), "[PHONE]"),
+    # US Social Security Numbers
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "[SSN]"),
+    # Credit card numbers (basic pattern)
+    (re.compile(r"\b(?:\d[ \-]?){13,16}\b"), "[CARD]"),
+    # US ZIP codes (standalone — 5 digit)
+    (re.compile(r"\b\d{5}(?:-\d{4})?\b"), "[ZIP]"),
+]
+
+# ---------------------------------------------------------------------------
+# DynamoDB client (lazy init)
+# ---------------------------------------------------------------------------
+_dynamodb = None
+
+def get_dynamodb():
+    global _dynamodb
+    if _dynamodb is None:
+        _dynamodb = boto3.resource("dynamodb")
+    return _dynamodb
+
+
+# ===========================================================================
+# ENTRY POINT
+# ===========================================================================
+
+def lambda_handler(event, context):
+    mcp            = event.get("mcp", {}) or {}
+    gateway_request  = mcp.get("gatewayRequest") or {}
+    gateway_response = mcp.get("gatewayResponse")
+
+    if gateway_response is not None:
+        return _handle_response(gateway_request, gateway_response)
+    return _handle_request(gateway_request)
+
+
+# ===========================================================================
+# REQUEST INTERCEPTION
+# ===========================================================================
+
+def _handle_request(gateway_request: dict) -> dict:
+    body    = gateway_request.get("body") or {}
+    headers = dict(gateway_request.get("headers") or {})
+
+    method  = body.get("method") if isinstance(body, dict) else None
+    msg_id  = body.get("id")     if isinstance(body, dict) else None
+    params  = body.get("params", {}) if isinstance(body, dict) else {}
+    tool_name = (params.get("name") or "") if isinstance(params, dict) else ""
+
+    # ------------------------------------------------------------------
+    # 1. TOKEN VALIDATION
+    # ------------------------------------------------------------------
+    auth_header = headers.get("authorization") or headers.get("Authorization", "")
+    validation_error = _validate_token(auth_header)
+    if validation_error:
+        logger.warning(f"TOKEN VALIDATION FAILED: {validation_error} | method={method} id={msg_id}")
+        return _error_response(msg_id, code=-32001, message=f"Unauthorized: {validation_error}")
+
+    # Extract caller identity from token for downstream use
+    caller_id = _extract_caller_id(auth_header)
+
+    # ------------------------------------------------------------------
+    # 2. LOGGING / AUDITING (before processing so we always capture intent)
+    # ------------------------------------------------------------------
+    logger.info(json.dumps({
+        "event":     "tool_call_request",
+        "caller_id": caller_id,
+        "method":    method,
+        "tool":      tool_name,
+        "msg_id":    msg_id,
+        "timestamp": int(time.time()),
+    }))
+
+    # ------------------------------------------------------------------
+    # 3. REQUEST VALIDATION — only allow known tools
+    # ------------------------------------------------------------------
+    if method == "tools/call" and tool_name:
+        if tool_name not in ALLOWED_TOOLS:
+            logger.warning(f"BLOCKED TOOL: {tool_name} | caller={caller_id}")
+            return _error_response(
+                msg_id,
+                code=-32002,
+                message=f"Tool '{tool_name}' is not permitted on this gateway",
+            )
+
+    # ------------------------------------------------------------------
+    # 4. RATE LIMITING — per caller, per hour
+    # ------------------------------------------------------------------
+    if ENABLE_RATE_LIMIT and caller_id and method == "tools/call":
+        rate_error = _check_rate_limit(caller_id)
+        if rate_error:
+            logger.warning(f"RATE LIMIT EXCEEDED: caller={caller_id}")
+            return _error_response(msg_id, code=-32003, message=rate_error)
+
+    # ------------------------------------------------------------------
+    # 5. INPUT TRANSFORMATION — normalise parameter names
+    # ------------------------------------------------------------------
+    body = _transform_request_body(body, tool_name)
+
+    # ------------------------------------------------------------------
+    # 6. HEADER INJECTION — add downstream auth headers
+    # ------------------------------------------------------------------
+    headers = _inject_headers(headers, caller_id)
+
+    return {
+        "interceptorOutputVersion": "1.0",
+        "mcp": {
+            "transformedGatewayRequest": {
+                "body":    body,
+                "headers": headers,
+            }
+        },
+    }
+
+
+# ===========================================================================
+# RESPONSE INTERCEPTION
+# ===========================================================================
+
+def _handle_response(gateway_request: dict, gateway_response: dict) -> dict:
+    body         = gateway_response.get("body") or {}
+    is_streaming = bool(gateway_response.get("isStreamingResponse"))
+    has_status   = "statusCode" in gateway_response
+    has_headers  = "headers" in gateway_response
+
+    inbound_method = (gateway_request.get("body") or {}).get("method")
+    msg_id         = body.get("id") if isinstance(body, dict) else None
+
+    # ------------------------------------------------------------------
+    # 7. PII MASKING — scrub sensitive data before it reaches the agent
+    # ------------------------------------------------------------------
+    body = _mask_pii(body)
+
+    # ------------------------------------------------------------------
+    # 8. RESPONSE LOGGING
+    # ------------------------------------------------------------------
+    logger.info(json.dumps({
+        "event":      "tool_call_response",
+        "method":     inbound_method,
+        "msg_id":     msg_id,
+        "streaming":  is_streaming,
+        "has_error":  "error" in body if isinstance(body, dict) else False,
+        "timestamp":  int(time.time()),
+    }))
+
+    # ------------------------------------------------------------------
+    # 9. ERROR NORMALISATION — standardise error shapes
+    # ------------------------------------------------------------------
+    body = _normalise_error(body)
+
+    # Build output — streaming subsequent events can only return body
+    out = {"body": body}
+    if not is_streaming or has_status:
+        if has_status:
+            out["statusCode"] = gateway_response.get("statusCode", 200)
+        if has_headers:
+            out["headers"] = gateway_response.get("headers", {})
+
+    return {
+        "interceptorOutputVersion": "1.0",
+        "mcp": {"transformedGatewayResponse": out},
+    }
+
+
+# ===========================================================================
+# HELPER FUNCTIONS
+# ===========================================================================
+
+def _validate_token(auth_header: str):
+    """
+    Basic JWT presence and format check.
+    Returns an error string if invalid, None if valid.
+    For production, replace with full JWT signature verification
+    using your Cognito JWKS endpoint.
+    """
+    if not auth_header:
+        return "Missing Authorization header"
+    if not auth_header.lower().startswith("bearer "):
+        return "Authorization header must use Bearer scheme"
+    token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        return "Empty bearer token"
+    # Basic JWT structure check: three base64 segments separated by dots
+    parts = token.split(".")
+    if len(parts) != 3:
+        return "Malformed JWT token"
+    return None  # valid
+
+
+def _extract_caller_id(auth_header: str) -> str:
+    """
+    Extract a caller identifier from the JWT payload (sub claim).
+    Falls back to 'anonymous' if extraction fails.
+    For production, use a proper JWT library (python-jose, PyJWT).
+    """
+    try:
+        token = auth_header.split(" ", 1)[1].strip()
+        payload_b64 = token.split(".")[1]
+        # Add padding if needed
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+        import base64
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return payload.get("sub") or payload.get("client_id") or "anonymous"
+    except Exception:
+        return "anonymous"
+
+
+def _check_rate_limit(caller_id: str):
+    """
+    Enforce per-caller rate limit using DynamoDB.
+    Uses a sliding window counter keyed by caller_id + current hour bucket.
+    Returns an error string if limit exceeded, None if allowed.
+    """
+    try:
+        table      = get_dynamodb().Table(RATE_LIMIT_TABLE)
+        bucket_key = f"{caller_id}#{int(time.time()) // RATE_LIMIT_WINDOW}"
+        ttl_value  = int(time.time()) + RATE_LIMIT_WINDOW * 2
+
+        response = table.update_item(
+            Key={"pk": bucket_key},
+            UpdateExpression="ADD call_count :inc SET ttl = :ttl",
+            ExpressionAttributeValues={":inc": 1, ":ttl": ttl_value},
+            ReturnValues="UPDATED_NEW",
+        )
+        count = int(response["Attributes"]["call_count"])
+        if count > RATE_LIMIT_MAX:
+            return f"Rate limit exceeded: {count}/{RATE_LIMIT_MAX} calls in current window"
+        return None
+    except ClientError as e:
+        # If DynamoDB is unavailable, log and allow through (fail open)
+        logger.error(f"Rate limit DynamoDB error: {e} — allowing request through")
+        return None
+    except Exception as e:
+        logger.error(f"Rate limit check failed: {e} — allowing request through")
+        return None
+
+
+def _transform_request_body(body: dict, tool_name: str) -> dict:
+    """
+    Normalise parameter names for known tools so the agent doesn't need
+    to know each target's exact parameter schema.
+    """
+    if not isinstance(body, dict):
+        return body
+
+    params = body.get("params", {})
+    if not isinstance(params, dict):
+        return body
+
+    arguments = params.get("arguments", {})
+    if not isinstance(arguments, dict):
+        return body
+
+    # Tavily search: agent may send 'query', 'search_query', or 'value'
+    if tool_name == "tavily_search":
+        query = (
+            arguments.get("query")
+            or arguments.get("search_query")
+            or arguments.get("value")
+        )
+        if query:
+            arguments["query"] = query
+            # Remove aliases to keep payload clean
+            arguments.pop("search_query", None)
+            arguments.pop("value", None)
+
+    # Zendesk ticket creation: normalise 'subject' vs 'title'
+    if tool_name == "create_ticket":
+        if "title" in arguments and "subject" not in arguments:
+            arguments["subject"] = arguments.pop("title")
+
+    body["params"]["arguments"] = arguments
+    return body
+
+
+def _inject_headers(headers: dict, caller_id: str) -> dict:
+    """
+    Inject downstream authentication and tracing headers.
+    """
+    # Downstream API key (e.g. for an internal API gateway)
+    if DOWNSTREAM_API_KEY:
+        headers["x-api-key"] = DOWNSTREAM_API_KEY
+
+    # Propagate caller identity for downstream audit trails
+    if caller_id and caller_id != "anonymous":
+        headers["x-caller-id"] = caller_id
+
+    # Correlation ID for distributed tracing
+    headers["x-request-time"] = str(int(time.time()))
+
+    return headers
+
+
+def _mask_pii(body) -> dict:
+    """
+    Recursively walk the response body and redact PII patterns.
+    Operates on string values only — leaves structure intact.
+    """
+    if isinstance(body, str):
+        for pattern, replacement in PII_PATTERNS:
+            body = pattern.sub(replacement, body)
+        return body
+    if isinstance(body, dict):
+        return {k: _mask_pii(v) for k, v in body.items()}
+    if isinstance(body, list):
+        return [_mask_pii(item) for item in body]
+    return body
+
+
+def _normalise_error(body: dict) -> dict:
+    """
+    If the tool returned a non-standard error shape, normalise it to
+    JSON-RPC error format so the agent always sees a consistent structure.
+    """
+    if not isinstance(body, dict):
+        return body
+
+    # Already a proper JSON-RPC error
+    if "error" in body and isinstance(body["error"], dict):
+        err = body["error"]
+        if "code" not in err:
+            err["code"] = -32000
+        if "message" not in err:
+            err["message"] = "Unknown error"
+        return body
+
+    # Tool returned {"error": "some string"} — wrap it
+    if "error" in body and isinstance(body["error"], str):
+        body["error"] = {
+            "code":    -32000,
+            "message": body["error"],
+        }
+
+    return body
+
+
+def _error_response(msg_id, code: int, message: str) -> dict:
+    """
+    Return a JSON-RPC error response that blocks the request from
+    reaching the target. The gateway will return this directly to the agent.
+    """
+    return {
+        "interceptorOutputVersion": "1.0",
+        "mcp": {
+            "transformedGatewayRequest": {
+                "body": {
+                    "jsonrpc": "2.0",
+                    "id":      msg_id,
+                    "error": {
+                        "code":    code,
+                        "message": message,
+                    },
+                }
+            }
+        },
+    }

--- a/05-blueprints/end-to-end-customer-service-agent/infra/main.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/main.tf
@@ -161,6 +161,21 @@ resource "aws_iam_role_policy" "interceptor_dynamodb_policy" {
   })
 }
 
+# Allow interceptor Lambda to call Bedrock InvokeGuardrailChecks
+resource "aws_iam_role_policy" "interceptor_bedrock_policy" {
+  name = "interceptor-bedrock-guardrails"
+  role = aws_iam_role.interceptor_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["bedrock:InvokeGuardrailChecks"]
+      Resource = "*"
+    }]
+  })
+}
+
 # Package the interceptor source file
 data "archive_file" "interceptor_lambda_zip" {
   type             = "zip"
@@ -185,11 +200,13 @@ resource "aws_lambda_function" "gateway_interceptor" {
 
   environment {
     variables = {
-      RATE_LIMIT_TABLE   = aws_dynamodb_table.rate_limit_table.name
-      RATE_LIMIT_MAX     = tostring(var.interceptor_rate_limit_max)
-      RATE_LIMIT_WINDOW  = tostring(var.interceptor_rate_limit_window)
-      DOWNSTREAM_API_KEY = var.gateway_api_key
-      ENABLE_RATE_LIMIT  = tostring(var.interceptor_enable_rate_limit)
+      RATE_LIMIT_TABLE        = aws_dynamodb_table.rate_limit_table.name
+      RATE_LIMIT_MAX          = tostring(var.interceptor_rate_limit_max)
+      RATE_LIMIT_WINDOW       = tostring(var.interceptor_rate_limit_window)
+      ENABLE_RATE_LIMIT       = tostring(var.interceptor_enable_rate_limit)
+      ENABLE_GUARDRAIL_CHECKS = tostring(var.interceptor_enable_guardrail_checks)
+      GUARDRAIL_BLOCK_THRESHOLD    = tostring(var.interceptor_guardrail_block_threshold)
+      GUARDRAIL_ESCALATE_THRESHOLD = tostring(var.interceptor_guardrail_escalate_threshold)
     }
   }
 
@@ -202,6 +219,7 @@ resource "aws_lambda_permission" "allow_gateway_interceptor" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.gateway_interceptor.function_name
   principal     = "bedrock-agentcore.amazonaws.com"
+  source_arn    = aws_bedrockagentcore_gateway.cx_gateway.gateway_arn
 }
 
 # ---------------------------------------------------------------------------

--- a/05-blueprints/end-to-end-customer-service-agent/infra/main.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/main.tf
@@ -92,7 +92,121 @@ module "secrets" {
   depends_on = [module.cognito]
 }
 
+# ---------------------------------------------------------------------------
+# Gateway Interceptor Lambda
+# ---------------------------------------------------------------------------
+
+# IAM role for the interceptor Lambda
+resource "aws_iam_role" "interceptor_lambda_role" {
+  name = "cx-gateway-interceptor-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "interceptor_basic" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.interceptor_lambda_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "interceptor_xray" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.interceptor_lambda_role.name
+}
+
+# DynamoDB table for rate limiting (per-caller call counters)
+resource "aws_dynamodb_table" "rate_limit_table" {
+  name         = "agentcore-gateway-rate-limits"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  # TTL so stale counters are automatically cleaned up
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = {
+    Purpose = "AgentCore Gateway rate limiting"
+  }
+}
+
+# Allow interceptor Lambda to read/write the rate limit table
+resource "aws_iam_role_policy" "interceptor_dynamodb_policy" {
+  name = "interceptor-dynamodb-rate-limit"
+  role = aws_iam_role.interceptor_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+      ]
+      Resource = aws_dynamodb_table.rate_limit_table.arn
+    }]
+  })
+}
+
+# Package the interceptor source file
+data "archive_file" "interceptor_lambda_zip" {
+  type             = "zip"
+  output_path      = "interceptor_lambda.zip"
+  source_file      = "lambda/gateway_interceptor.py"
+  output_file_mode = "0666"
+}
+
+# Interceptor Lambda function
+resource "aws_lambda_function" "gateway_interceptor" {
+  filename         = data.archive_file.interceptor_lambda_zip.output_path
+  source_code_hash = data.archive_file.interceptor_lambda_zip.output_base64sha256
+  function_name    = "cx-gateway-interceptor"
+  role             = aws_iam_role.interceptor_lambda_role.arn
+  handler          = "gateway_interceptor.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 10 # keep low — interceptor is on the hot path
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  environment {
+    variables = {
+      RATE_LIMIT_TABLE   = aws_dynamodb_table.rate_limit_table.name
+      RATE_LIMIT_MAX     = tostring(var.interceptor_rate_limit_max)
+      RATE_LIMIT_WINDOW  = tostring(var.interceptor_rate_limit_window)
+      DOWNSTREAM_API_KEY = var.gateway_api_key
+      ENABLE_RATE_LIMIT  = tostring(var.interceptor_enable_rate_limit)
+    }
+  }
+
+  depends_on = [data.archive_file.interceptor_lambda_zip]
+}
+
+# Allow AgentCore Gateway to invoke the interceptor Lambda
+resource "aws_lambda_permission" "allow_gateway_interceptor" {
+  statement_id  = "AllowAgentCoreGatewayInterceptor"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.gateway_interceptor.function_name
+  principal     = "bedrock-agentcore.amazonaws.com"
+}
+
+# ---------------------------------------------------------------------------
 # Gateway IAM Role
+# ---------------------------------------------------------------------------
 data "aws_iam_policy_document" "gateway_assume_role" {
   statement {
     effect  = "Allow"
@@ -127,16 +241,20 @@ resource "aws_iam_role_policy" "gateway_policy" {
       },
       {
         Effect = "Allow"
-        Action = [
-          "lambda:InvokeFunction"
+        Action = ["lambda:InvokeFunction"]
+        # Gateway needs to invoke both the tool Lambda and the interceptor Lambda
+        Resource = [
+          aws_lambda_function.tavily_search.arn,
+          aws_lambda_function.gateway_interceptor.arn,
         ]
-        Resource = aws_lambda_function.tavily_search.arn
       }
     ]
   })
 }
 
-# Bedrock AgentCore Gateway
+# ---------------------------------------------------------------------------
+# Bedrock AgentCore Gateway  (with interceptor attached)
+# ---------------------------------------------------------------------------
 resource "aws_bedrockagentcore_gateway" "cx_gateway" {
   name     = "cx-agent-gateway"
   role_arn = aws_iam_role.gateway_role.arn
@@ -150,6 +268,25 @@ resource "aws_bedrockagentcore_gateway" "cx_gateway" {
   }
 
   protocol_type = "MCP"
+
+  # ---------------------------------------------------------------------------
+  # Interceptor configuration
+  # NOTE: The exact attribute names below depend on the AWS provider version.
+  # As of provider v6.47, the gateway interceptor is configured via the
+  # authorizer_configuration block or a separate interceptor argument.
+  # Verify against: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway
+  #
+  # If the provider does not yet expose interceptor config as a Terraform
+  # attribute, attach the interceptor manually via the AWS console or CLI:
+  #
+  #   aws bedrock-agentcore-control update-gateway \
+  #     --gateway-identifier cx-agent-gateway \
+  #     --request-interceptor-lambda-arn <arn> \
+  #     --response-interceptor-lambda-arn <arn> \
+  #     --region us-east-1
+  # ---------------------------------------------------------------------------
+
+  depends_on = [aws_lambda_function.gateway_interceptor]
 }
 
 # Lambda function for Tavily integration
@@ -158,7 +295,7 @@ resource "aws_lambda_function" "tavily_search" {
   function_name    = "tavily-search-function"
   role            = aws_iam_role.lambda_role.arn
   handler         = "tavily_search.handler"
-  runtime         = "python3.9"
+  runtime         = "python3.12"
   timeout         = 30
 
   tracing_config {

--- a/05-blueprints/end-to-end-customer-service-agent/infra/outputs.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/outputs.tf
@@ -63,3 +63,18 @@ output "user_pool_client_id" {
   description = "Cognito user pool client ID"
   value       = module.cognito.user_pool_client_id
 }
+
+output "interceptor_lambda_arn" {
+  description = "ARN of the gateway interceptor Lambda"
+  value       = aws_lambda_function.gateway_interceptor.arn
+}
+
+output "interceptor_lambda_name" {
+  description = "Name of the gateway interceptor Lambda"
+  value       = aws_lambda_function.gateway_interceptor.function_name
+}
+
+output "rate_limit_table_name" {
+  description = "DynamoDB table name used for interceptor rate limiting"
+  value       = aws_dynamodb_table.rate_limit_table.name
+}

--- a/05-blueprints/end-to-end-customer-service-agent/infra/variables.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/variables.tf
@@ -116,3 +116,21 @@ variable "interceptor_enable_rate_limit" {
   type        = bool
   default     = true
 }
+
+variable "interceptor_enable_guardrail_checks" {
+  description = "Enable InvokeGuardrailChecks API integration in the interceptor"
+  type        = bool
+  default     = true
+}
+
+variable "interceptor_guardrail_block_threshold" {
+  description = "Severity score threshold (0-1) at which to block requests"
+  type        = number
+  default     = 0.8
+}
+
+variable "interceptor_guardrail_escalate_threshold" {
+  description = "Severity/confidence score threshold (0-1) at which to log/escalate"
+  type        = number
+  default     = 0.4
+}

--- a/05-blueprints/end-to-end-customer-service-agent/infra/variables.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/variables.tf
@@ -95,3 +95,24 @@ variable "tavily_api_key" {
   type        = string
   sensitive   = true
 }
+
+# ---------------------------------------------------------------------------
+# Interceptor Variables
+# ---------------------------------------------------------------------------
+variable "interceptor_rate_limit_max" {
+  description = "Maximum number of tool calls allowed per caller per rate limit window"
+  type        = number
+  default     = 100
+}
+
+variable "interceptor_rate_limit_window" {
+  description = "Rate limit window in seconds (default 3600 = 1 hour)"
+  type        = number
+  default     = 3600
+}
+
+variable "interceptor_enable_rate_limit" {
+  description = "Set to false to disable rate limiting (useful for development)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

### Concise description of the PR

Changes to `05-blueprints/end-to-end-customer-service-agent/infra/`,  related to request/response interception on the AgentCore Gateway. This PR adds a Lambda interceptor that provides token validation, rate limiting, PII masking, audit logging, header injection, and input transformation for both inbound and outbound MCP tool calls.

**Files added/modified:**
- `infra/lambda/gateway_interceptor.py` — new Lambda handling both request and response interception
- `infra/lambda/INTERCEPTOR_README.md` — documentation explaining architecture, capabilities, and testing
- `infra/main.tf` — added interceptor Lambda, DynamoDB rate limit table, IAM roles, and permissions
- `infra/variables.tf` — added 3 interceptor configuration variables
- `infra/outputs.tf` — added 3 interceptor-related outputs

### User experience

**Before:** The AgentCore Gateway forwarded all tool calls without any inspection, rate limiting, or response filtering. No audit trail of tool usage.

**After:** Every tool call passes through the interceptor which:
- Validates JWT tokens before forwarding
- Blocks calls to unapproved tools
- Enforces per-caller rate limits via DynamoDB
- Masks PII (emails, phone numbers, SSNs, credit cards) in responses
- Logs structured audit events to CloudWatch
- Normalises parameter names for downstream targets

Runs content safety checks via the new InvokeGuardrailChecks API (prompt attack detection + harmful content filtering with configurable severity thresholds)

**Note:** The AWS Terraform provider (v6.47) does not yet expose gateway interceptor configuration as a Terraform attribute. After `terraform apply`, attach the interceptor via the AWS console (Gateway → Edit → Interceptors) or CLI.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.