### PR TITLE
fix(payments): document Non-custodial Manage scope for CDP API key

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/.env.coinbase.sample
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/.env.coinbase.sample
@@ -29,9 +29,11 @@ AWS_REGION=us-west-2
 # TUTORIAL ONLY: For local testing, store credentials in .env (git-ignored).
 # DEPLOYED WORKLOADS: Use AWS Secrets Manager or Systems Manager Parameter Store.
 # See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
-# Get these from portal.cdp.coinbase.com (see providers/coinbase_cdp_account_setup.ipynb)
+# Get these from portal.cdp.coinbase.com (see providers/coinbase_cdp_account_setup.py)
 # API Key ID + Secret: from project API key creation
 # Wallet Secret: from Wallet → ServerWallet
+# When creating the API key, enable Non-custodial: Manage under Advanced
+# settings — CreatePaymentInstrument returns AccessDenied without it.
 COINBASE_API_KEY_ID=<your-coinbase-api-key-id>
 COINBASE_API_KEY_SECRET=<your-coinbase-api-key-secret>
 COINBASE_WALLET_SECRET=<your-coinbase-wallet-secret>

--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
@@ -167,6 +167,10 @@ Before the agent can produce x402 payments, two things must happen:
 
 A Manager with the same name already exists. Either use `idempotent_create()` (already done in the script) or delete the existing Manager first. The script appends a UUID suffix to ensure uniqueness on fresh runs.
 
+### CreatePaymentInstrument returns AccessDeniedException
+
+The error message is `The payment connector credentials are not authorized for this operation`. The CDP API key is missing the `Non-custodial: Manage` scope, which sits under Advanced settings when you create the key at [portal.cdp.coinbase.com](https://portal.cdp.coinbase.com/api-keys/secret). Create a new key with that scope enabled, update `.env`, and re-run `setup_agentcore_payments.py`.
+
 ### Instrument status stays CREATING
 
 `EMBEDDED_CRYPTO_WALLET` provisioning is asynchronous. The script uses `wait_for_status()` which polls every 5 seconds for up to 5 minutes. If it times out, check the Coinbase CDP or Privy dashboard for errors. Make sure `LINKED_EMAIL` is a real email address.

--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/providers/coinbase_cdp_account_setup.py
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/providers/coinbase_cdp_account_setup.py
@@ -64,8 +64,11 @@ Step 3a — Create an API Key
   1. In the CDP Portal, navigate to your project.
   2. Choose Create API key (or New key).
   3. Enter a descriptive name (e.g. agentcore-payments-tutorial).
-  4. Choose Create or Save.
-  5. Download the keys when prompted.
+  4. Under Advanced settings, enable Non-custodial: Manage.
+     Without this scope, Tutorial 00 fails at CreatePaymentInstrument
+     with AccessDenied.
+  5. Choose Create or Save.
+  6. Download the keys when prompted.
   → Gives you: API Key ID  →  COINBASE_API_KEY_ID
                 API Key Secret  →  COINBASE_API_KEY_SECRET
 


### PR DESCRIPTION
## Issue

Tutorial 00 Step 7 calls `CreatePaymentInstrument`, which fails with `AccessDeniedException` (`The payment connector credentials are not authorized for this operation`) when the CDP API key was created without the `Non-custodial: Manage` scope. The scope sits under **Advanced settings** at [portal.cdp.coinbase.com/api-keys/secret](https://portal.cdp.coinbase.com/api-keys/secret) and is off by default.

Until now, neither the Tutorial 00 README nor the CDP setup walkthrough mentioned it, so a fresh user hits an opaque AccessDenied at Step 7 with no clue what's wrong. Reproduced on 2026-06-12 against `us-west-2`.

## Changes

- `providers/coinbase_cdp_account_setup.py` — add the scope step to the on-screen API key creation walkthrough (Step 3a), with a one-line note about the failure mode.
- `.env.coinbase.sample` — note the scope above the `COINBASE_API_KEY_ID=` line, where the operator pastes the key.
- `README.md` Troubleshooting — add a `CreatePaymentInstrument returns AccessDeniedException` entry with the verbatim error string so a user who hits it can grep the README and find the fix.

Docs-only. No code semantics change.

## Verification

Re-read the cited file:line at upstream HEAD `3a8d5352`:
- `setup_agentcore_payments.py:323` is the `dp_client.create_payment_instrument` call that errors.
- grep across the upstream `00-setup-agentcore-payments/` tree for "Non-custodial", "Manage", "wallet:create", "scope" → 0 hits before this PR.
- AWS official docs at [`payments-getting-started.html`](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-getting-started.html) Step 1 also omit the scope, so even users following the docs hit it.