### PR TITLE
fix(payments): point T01 signing error at the WalletHub per-wallet grant

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/01-agents-payments-and-limits/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/01-agents-payments-and-limits/README.md
@@ -122,7 +122,7 @@ python langgraph_payment_agent.py
 
 ### Agent gets 402 but payment fails
 
-Delegated signing is not configured. For Coinbase CDP: enable Delegated Signing in CDP Portal → Wallets → Embedded Wallet → Policies. For Stripe/Privy: open the Privy reference frontend at `http://localhost:3000`, log in as `LINKED_EMAIL`, and choose **Connect agent**.
+The error message is `Delegated signing grant is not active for the end user wallet. Please redirect end user to the WalletHub to grant the permissions`. Delegated signing has two layers and both must be granted. For Coinbase CDP: enable Delegated Signing in CDP Portal → Wallets → Embedded Wallet → Policies (project-level), then open the WalletHub `redirectUrl` from the `CreatePaymentInstrument` response, sign in as `LINKED_EMAIL`, and grant the per-wallet permission. For Stripe/Privy: open the Privy reference frontend at `http://localhost:3000`, log in as `LINKED_EMAIL`, and choose **Connect agent**.
 
 ### Session budget exceeded immediately
 


### PR DESCRIPTION
## Issue

The Tutorial 01 README troubleshooting entry titled \"Agent gets 402 but payment fails\" pointed only at enabling Delegated Signing in the CDP Portal. That toggle is project-level and necessary but not sufficient — Coinbase CDP also requires a per-wallet grant via the WalletHub `redirectUrl` returned by `CreatePaymentInstrument`. The runtime error a user actually sees is `Delegated signing grant is not active for the end user wallet. Please redirect end user to the WalletHub to grant the permissions`, which explicitly names the second step. The README did not.

The Tutorial 00 README at lines 144-150 already documents both layers in its \"Funding and Delegated Signing\" table. T01 troubleshooting is where users land when ProcessPayment fails, so the per-wallet grant needs to be there too.

## Changes

- T01 README:125 — replace the single-step entry with the verbatim error string + the two-step CDP grant flow (project toggle + per-wallet WalletHub).
- Privy variant left unchanged (it was already correct — the Privy frontend at localhost:3000 handles per-wallet grant in one step).

Docs only. No code change.

## Verification

- Verbatim error reproduced on 2026-06-12 against `us-west-2` and captured in `T01a_strands_first_run.log:1`.
- T00 README:144-150 already documents the per-wallet WalletHub flow; this PR brings T01 troubleshooting in line.