### PR TITLE
fix(payments): pin agentcore CLI to 0.19+ for T02 deploy

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/README.md
@@ -49,15 +49,15 @@ App Backend                          AgentCore runtime
 - Tutorial 01 completed (understand the local agent + plugin flow)
 - Wallet funded with testnet USDC from [faucet.circle.com](https://faucet.circle.com/)
 - Python 3.10+
-- Node.js 20+ and the AgentCore CLI: `npm install -g @aws/agentcore`
+- Node.js 20+ and the AgentCore CLI 0.19+: `npm install -g @aws/agentcore@^0.19.0` (0.14 ships an empty `aws-targets.json` and the deploy fails — see Troubleshooting)
 - AWS CDK: `npm install -g aws-cdk`
 - AWS CLI configured
 
 ## CLI Commands
 
 ```bash
-# Install AgentCore CLI
-npm install -g @aws/agentcore
+# Install AgentCore CLI (0.19+)
+npm install -g @aws/agentcore@^0.19.0
 
 # Install Python dependencies
 pip install -r requirements.txt
@@ -134,8 +134,20 @@ python payment_agent.py
 
 Install Node.js 20+ and the AgentCore CLI:
 ```bash
-npm install -g @aws/agentcore
+npm install -g @aws/agentcore@^0.19.0
 agentcore --version
+```
+
+### agentcore deploy fails with `Target "default" not found in aws-targets.json`
+
+The agentcore CLI 0.14 scaffolds `<project>/agentcore/aws-targets.json` as an empty list, so `agentcore deploy` exits before the CDK synth. Upgrade to 0.19 or later:
+```bash
+npm install -g @aws/agentcore@^0.19.0
+agentcore --version
+```
+If you must stay on 0.14, hand-write the file before deploy:
+```bash
+echo '[{"name":"default","account":"<account-id>","region":"<region>"}]' > PaymentAgent/agentcore/aws-targets.json
 ```
 
 ### Deploy fails with CDK bootstrap error


### PR DESCRIPTION
## Issue

The Tutorial 02 prereqs say `npm install -g @aws/agentcore` with no version pin. The CLI's 0.14 release scaffolds `<project>/agentcore/aws-targets.json` as an empty array, so `agentcore deploy` exits with \`Target \"default\" not found in aws-targets.json\` before the CDK synth ever runs. A fresh user following the README hits this and the error gives no clue that the CLI version is the cause. Reproduced on 2026-06-12.

## Changes

- Prereqs and CLI Commands block: pin to `@aws/agentcore@^0.19.0`.
- New troubleshooting entry: \"agentcore deploy fails with `Target \"default\" not found in aws-targets.json`\" with the upgrade path and a hand-written `aws-targets.json` fallback for users who can't upgrade.

Docs only. No code change.

## Verification

- 0.14 reproduced the failure on 2026-06-12 against `us-west-2`.
- 0.19.0 deploys cleanly using the same script and account.
- Re-read of the cited file:line at upstream HEAD `3a8d5352`:
  - `deploy_payment_agent.py:154` is the `subprocess.run([\"agentcore\", \"deploy\", \"-y\"], ...)` call.
  - No version probe exists today; this PR is README-only.