### PR TITLE
fix(payments): self-heal empty aws-targets.json before T02 deploy

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/README.md
@@ -138,6 +138,13 @@ npm install -g @aws/agentcore
 agentcore --version
 ```
 
+### agentcore deploy fails with `Target "default" not found in aws-targets.json`
+
+Some agentcore CLI versions scaffold `<project>/agentcore/aws-targets.json` as an empty list, which makes `agentcore deploy` exit before the CDK synth. The `deploy_payment_agent.py` script appends a `default` entry automatically when it sees this. If you ran `agentcore deploy` directly, write the file by hand and re-run:
+```bash
+echo '[{"name":"default","account":"<account-id>","region":"<region>"}]' > PaymentAgent/agentcore/aws-targets.json
+```
+
 ### Deploy fails with CDK bootstrap error
 
 Bootstrap CDK in your account/region first:

--- a/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/deploy_payment_agent.py
+++ b/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/deploy_payment_agent.py
@@ -146,6 +146,27 @@ if os.path.exists(lock_file):
 
 print("pyproject.toml updated")
 
+# Some agentcore CLI versions scaffold aws-targets.json as an empty list,
+# which causes `agentcore deploy` to exit with `Target "default" not found
+# in aws-targets.json`. Append a default target if one is missing, and leave
+# any other entries alone.
+targets_file = os.path.join(project_dir, "agentcore", "aws-targets.json")
+if os.path.exists(targets_file):
+    try:
+        with open(targets_file) as f:
+            targets = json.loads(f.read() or "[]")
+    except json.JSONDecodeError:
+        targets = None
+    if (
+        isinstance(targets, list)
+        and all(isinstance(t, dict) and "name" in t for t in targets)
+        and not any(t["name"] == "default" for t in targets)
+    ):
+        targets.append({"name": "default", "account": account_id, "region": REGION})
+        with open(targets_file, "w") as f:
+            f.write(json.dumps(targets, indent=2))
+        print(f"Added default target to aws-targets.json (account={account_id}, region={REGION})")
+
 # ── Step 7: Deploy to AgentCore Runtime ───────────────────────────────────────
 print("\n── Step 7: Deploy to AgentCore Runtime ──")
 print("This creates billable AWS resources (Lambda, CloudWatch, API Gateway).")


### PR DESCRIPTION
## Issue

The `@aws/agentcore` CLI scaffolds `<project>/agentcore/aws-targets.json` as an empty list. `agentcore deploy` then exits with `Target "default" not found in aws-targets.json` before the CDK synth runs, and the user sees a confusing error with no clear next step.

Live-reproduced today on both **0.14.0** and **0.19.0** (current `latest`). The scaffold writes `[]` regardless of CLI version, so a fresh user following Tutorial 02 cannot deploy without intervention.

A version pin in the README would not help here — the behavior is consistent across the versions a fresh user is likely to install. This PR uses a property-based check instead: if the file exists but doesn't contain a `default` target, append one using the account/region the script has already resolved.

## Changes

`deploy_payment_agent.py`: between scaffolding (`agentcore create`) and deploy (`agentcore deploy`), check `aws-targets.json` and append a `default` entry if missing. Existing entries are preserved. Malformed JSON, unexpected shapes (top-level dict, garbage list entries), and missing files are all left alone so the user sees the underlying CLI error rather than a silent overwrite.

`README.md`: troubleshooting entry covering the symptom and a one-line manual fix for users running `agentcore deploy` directly without the script.

## Verification

**Static** — tested the probe in isolation against 8 input shapes:

| Input shape | Action |
|---|---|
| `[]` (the actual scaffold output) | Append `default` |
| File missing | Pass through |
| `[{name: default, ...}]` | No-op |
| Malformed JSON | Pass through |
| Whitespace-only | Pass through (treated as malformed) |
| `[{name: prod, ...}]` | Append `default`, preserve `prod` |
| Garbage list `[1, 2, "x"]` | Pass through |
| Top-level dict `{...}` instead of list | Pass through |

All 8 pass. The inserted code in `deploy_payment_agent.py` is byte-equivalent to the standalone-tested function.

**Live AWS** — ran end-to-end against `us-west-2` on both CLI versions:

| CLI version | Scaffold output | Without probe | With probe |
|---|---|---|---|
| `0.14.0` | `[]` | Fails: `Target "default" not found in aws-targets.json` | CFN stack `AgentCore-PaymentAgent-default` reaches `CREATE_COMPLETE` |
| `0.19.0` | `[]` | Same failure | Same success |

Both stacks were torn down after validation. Variables `account_id` (line 51) and `REGION` (line 52) are already in scope at the insertion point. `json` and `os` are already imported. The probe is positioned after the existing `if not os.path.exists(project_dir)` skip so the directory is guaranteed to exist.