### PR TITLE
fix(payments): align boto3 region with AWS_REGION from .env

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/deploy_payment_agent.py
+++ b/01-features/08-agents-that-transact/00-getting-started/02-deploy-to-agentcore-runtime/deploy_payment_agent.py
@@ -38,7 +38,7 @@ import boto3
 from dotenv import load_dotenv
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from utils import load_tutorial_env, print_summary, update_env_file
+from utils import load_tutorial_env, print_summary, resolve_region, update_env_file
 
 ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
 load_dotenv(ENV_FILE, override=True)
@@ -46,10 +46,10 @@ load_dotenv(ENV_FILE, override=True)
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 # ── Verify AWS credentials ────────────────────────────────────────────────────
+REGION = resolve_region()
 session = boto3.Session()
 identity = session.client("sts").get_caller_identity()
 account_id = identity["Account"]
-REGION = session.region_name or os.environ.get("AWS_REGION", "us-west-2")
 print(f"Authenticated as: {identity['Arn']}")
 print(f"Account: {account_id}")
 print(f"Region: {REGION}")

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/bazaar_gateway_agent.py
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/bazaar_gateway_agent.py
@@ -45,17 +45,18 @@ import boto3
 from dotenv import load_dotenv
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from utils import load_tutorial_env, print_summary
+from utils import load_tutorial_env, print_summary, resolve_region
 
 ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
 load_dotenv(ENV_FILE, override=True)
 
 # ── Verify AWS credentials ────────────────────────────────────────────────────
+REGION = resolve_region()
 session = boto3.Session()
 identity = session.client("sts").get_caller_identity()
 print(f"Authenticated as: {identity['Arn']}")
 print(f"Account: {identity['Account']}")
-print(f"Region: {session.region_name}")
+print(f"Region: {REGION}")
 
 # ── Step 1: Gateway Setup (manual) ───────────────────────────────────────────
 print("""

--- a/01-features/08-agents-that-transact/00-getting-started/utils.py
+++ b/01-features/08-agents-that-transact/00-getting-started/utils.py
@@ -35,6 +35,28 @@ RESOURCE_RETRIEVAL_ROLE = "AgentCorePaymentsResourceRetrievalRole"
 # ═════════════════════════════════════════════════════════════════
 
 
+def resolve_region(default="us-west-2"):
+    """Resolve the AWS region the tutorials should use, and align boto3 with it.
+
+    boto3 reads `AWS_DEFAULT_REGION` from the environment but ignores
+    `AWS_REGION` (the env var name used by the AWS SDK for JavaScript and by
+    the tutorial `.env` files). Without this helper, a `.env` that sets
+    `AWS_REGION=us-west-2` is silently ignored and `boto3.Session()` falls
+    back to whatever `~/.aws/config` says, which is often a different region.
+
+    Promote `AWS_REGION` to `AWS_DEFAULT_REGION` if the operator hasn't set
+    `AWS_DEFAULT_REGION` explicitly, then return the resolved value.
+    """
+    if "AWS_REGION" in os.environ and "AWS_DEFAULT_REGION" not in os.environ:
+        os.environ["AWS_DEFAULT_REGION"] = os.environ["AWS_REGION"]
+    return (
+        os.environ.get("AWS_DEFAULT_REGION")
+        or os.environ.get("AWS_REGION")
+        or boto3.Session().region_name
+        or default
+    )
+
+
 def load_payment_env(env_file=".env"):
     """Load .env file and return config dict."""
     load_dotenv(env_file, override=True)
@@ -442,8 +464,7 @@ def setup_cognito_user_pool(pool_name="AgentCorePaymentsPool"):
 
     Returns dict with pool_id, client_id, client_secret, token_url.
     """
-    session = boto3.Session()
-    region = session.region_name
+    region = resolve_region()
     cognito = boto3.client("cognito-idp", region_name=region)
 
     pool_resp = cognito.create_user_pool(


### PR DESCRIPTION
## Issue

The tutorial `.env` files set `AWS_REGION`, but boto3 reads `AWS_DEFAULT_REGION` from the environment and **ignores `AWS_REGION` entirely** (`AWS_REGION` is the env var the AWS SDK for JavaScript honors; the Python SDK does not). So a `.env` that sets `AWS_REGION=us-west-2` is silently ignored, and `boto3.Session()` falls back to whatever `~/.aws/config` says — commonly `us-east-1`. Resources get created in the wrong region without any warning.

Live-reproduced today: with `AWS_REGION=us-west-2` set and no `AWS_DEFAULT_REGION`, `boto3.Session().region_name` returns `us-east-1` (from `~/.aws/config`).

The boto3 docs confirm `AWS_REGION` is not in the recognized env-var list: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html#using-environment-variables

## Changes

`utils.py`: add a `resolve_region(default=\"us-west-2\")` helper that promotes `AWS_REGION` to `AWS_DEFAULT_REGION` when the operator hasn't set `AWS_DEFAULT_REGION` explicitly, then returns the resolved region. If both env vars are set, the operator's explicit `AWS_DEFAULT_REGION` is preserved.

Three call sites use the helper:
- `deploy_payment_agent.py:48-52` — Tutorial 02 deploy script
- `bazaar_gateway_agent.py:53-58` — Tutorial 04 gateway script
- `utils.setup_cognito_user_pool` (line 467) — Cognito setup helper

Setup scripts (`setup_agentcore_payments.py`, `multi_provider_setup.py`) already pass `region_name=` explicitly to `boto3.Session`, so they aren't affected.

## Verification

**Static** — tested `resolve_region()` against 4 env states with `~/.aws/config` set to `us-east-1`:

| Env state | Old behavior | New behavior |
|---|---|---|
| `AWS_REGION=us-west-2`, no `AWS_DEFAULT_REGION` | boto3 picked `us-east-1` from `~/.aws/config` (silent skew) | All boto3 surfaces aligned to `us-west-2` |
| `AWS_DEFAULT_REGION=eu-west-1` (operator explicit) | boto3 picks `eu-west-1` | boto3 picks `eu-west-1` (no overwrite) |
| Neither env set | boto3 falls back to config | boto3 falls back to config (unchanged) |
| `AWS_DEFAULT_REGION` only | works | works (unchanged) |

**Live AWS** — ran `agentcore deploy` against `us-west-2` with `AWS_REGION=us-west-2` and `AWS_DEFAULT_REGION` unset:
- Before the fix: deploy would land in `us-east-1`
- After the fix: CFN stack `AgentCore-PaymentAgent-default` reaches `CREATE_COMPLETE` in **us-west-2**, confirmed not present in us-east-1. Stack torn down after.

## Notes

No hardcoded account, region, or ARN in the diff. The default fallback (`us-west-2`) matches what the existing code uses (`os.environ.get(\"AWS_REGION\", \"us-west-2\")`); it's a last-resort fallback only when nothing else is set.