### PR TITLE
fix(payments): T01 Strands Step 5c uses a fresh agent

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/01-agents-payments-and-limits/strands_payment_agent.py
+++ b/01-features/08-agents-that-transact/00-getting-started/01-agents-payments-and-limits/strands_payment_agent.py
@@ -226,11 +226,20 @@ except Exception as e:
 
 # ── Step 5c: Plugin built-in tools ────────────────────────────────────────────
 print("\n── Step 5c: Built-in Payment Tools ──")
-# The plugin registers get_payment_session, get_payment_instrument, list_payment_instruments
-result = budget_agent("How much budget do I have left in my current session?")
+# The plugin registers get_payment_session, get_payment_instrument, list_payment_instruments.
+# A fresh agent is used here so a string prompt is always valid — reusing budget_agent
+# fails with TypeError if Step 5a/5b left it in interrupt state (e.g. ProcessPayment failed).
+introspection_agent = Agent(
+    model=BedrockModel(model_id=MODEL_ID, streaming=True),
+    tools=[http_request],
+    plugins=[budget_plugin],
+    system_prompt=SYSTEM_PROMPT,
+)
+
+result = introspection_agent("How much budget do I have left in my current session?")
 print(result.message)
 
-result = budget_agent("What payment instruments (wallets) do I have available?")
+result = introspection_agent("What payment instruments (wallets) do I have available?")
 print(result.message)
 
 # ── Step 5d: Uncapped session ─────────────────────────────────────────────────


### PR DESCRIPTION
## Issue

Tutorial 01's Strands variant reuses `budget_agent` for Step 5a (paid weather call) and Step 5c (plugin built-in tools). If Step 5a's ProcessPayment fails mid-call — for example because delegated signing wasn't granted via WalletHub — Strands activates the agent's interrupt state. The next call to that agent must then pass a list of \`interruptResponse\` objects, not a string. Step 5c passes a string, which raises:

\`\`\`
TypeError: prompt_type=<class 'str'> | must resume from interrupt with list of interruptResponse's
\`\`\`

Reproduced in the original test session at `T01a_strands_first_run.log:137-138` after the WalletHub grant was missing.

## Verification

1. **Strands docs confirm the behavior is intentional.** Per [strandsagents.com user guide on hooks](https://strandsagents.com/docs/user-guide/concepts/agents/hooks/index.md): \"When the agent is in an interrupt state, you must resume with a list of `interruptResponse` objects. Passing a plain string raises a `TypeError`.\"
2. **Live SDK reproduction.** Built an Agent against `strands-agents 1.43.0`, manually activated `_interrupt_state`, called it with a string — got the exact same TypeError. Built a second fresh Agent — its `_interrupt_state.activated` is False and accepts strings normally.

## Changes

`strands_payment_agent.py:227-245` — build an `introspection_agent` for Step 5c instead of reusing `budget_agent`. Same `budget_plugin` is wired in so the plugin's introspection tools (`get_payment_session`, `get_payment_instrument`, `list_payment_instruments`) are still registered.

The LangGraph variant builds a new react agent per session via `create_agent` and isn't affected — no change there.

Code-only fix, no behavior change for users on the happy path. For users on the unhappy path (Step 5a payment fails), Step 5c now succeeds instead of crashing the script before reaching Step 5d.