### PR TITLE
fix(payments): T03 wait for the new wallet to be funded before checking balance

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/03-user-onboarding-wallet-funding/user_onboarding.py
+++ b/01-features/08-agents-that-transact/00-getting-started/03-user-onboarding-wallet-funding/user_onboarding.py
@@ -167,6 +167,8 @@ print("    4. Choose 'Connect agent' → 'Give access'")
 print()
 print("  Without delegation: ProcessPayment fails with a signing error.")
 
+input("\nPress Enter when the new wallet is funded and signing is granted... ")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # PART 2 — Backend Operations
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Issue

Tutorial 03 Section 1 creates a brand-new payment instrument for `tutorial-03-user`. Section 2 prints faucet instructions and Section 3 prints delegation instructions, but the script then runs straight into Section 4, which calls `GetPaymentInstrumentBalance` against the unfunded wallet. The API returns:

\`\`\`
ValidationException: No balance found on chain 'base-sepolia' for token 'USDC'
\`\`\`

A user reading the output sees a confusing AWS API error rather than a clean balance read. The print at line 148 says \"ACTION REQUIRED: Fund the wallet **before continuing**\" but nothing in the script actually halts.

Reproduced from the original test session at `T03_user_onboarding.log:73`.

## Changes

`user_onboarding.py:170` — add an `input(\"Press Enter when the new wallet is funded and signing is granted... \")` pause at the end of Section 3, before Section 4's balance check.

This matches the existing pattern at `setup_agentcore_payments.py:412` in Tutorial 00, which uses an identical `input()` after its delegation instructions before checking balance.

Two-line change. No semantic change for users on the happy path who run through interactively — they pause where the README's tone already implied they should pause. For users running unattended, this is the smallest possible behavior change to make the \"before continuing\" promise true.

## Verification

- Re-read upstream code: line 148 makes the promise; the next code path is Section 4's balance check at line 187.
- Original test log shows the ValidationException firing on the new instrument because the script ran through without waiting.
- T00's `setup_agentcore_payments.py:412` is the established precedent for this pattern in the same tutorial set.