### PR TITLE
docs: fix evaluations next step link

### DIFF
--- a/06-workshops/07-AgentCore-evaluations/01-creating-custom-evaluators/README.md
+++ b/06-workshops/07-AgentCore-evaluations/01-creating-custom-evaluators/README.md
@@ -69,4 +69,4 @@ Custom evaluators provide maximum flexibility by allowing you to define every as
 - Technical support agents assessed on troubleshooting methodology
 
 ## Next Steps
-After completing this tutorial, proceed to [Using On-demand Evaluation](../01-setting-evaluations) to learn how to apply these evaluators to your agent traces.
+After completing this tutorial, proceed to [Using On-demand Evaluation](../02-running-evaluations) to learn how to apply these evaluators to your agent traces.


### PR DESCRIPTION
## Summary
- update the custom evaluators tutorial Next Steps link to the current running evaluations tutorial path
- replace the stale `../01-setting-evaluations` target with `../02-running-evaluations`

Closes #1512

## Verification
- `git diff --check`
- verified `06-workshops/07-AgentCore-evaluations/02-running-evaluations` exists on `main` via GitHub Contents API
