### PR TITLE
Update finance personal assistant for Claude Haiku 4.5

### DIFF
--- a/02-use-cases/01-conversational-agents/finance-personal-assistant/README.md
+++ b/02-use-cases/01-conversational-agents/finance-personal-assistant/README.md
@@ -57,7 +57,7 @@ Participants should have:
 - AWS credentials configured for Amazon Bedrock access
 - Python 3.8+ installed on their development machine
 - AWS account with Amazon Bedrock access. In an AWS-conducted event, you will have a provisioned account
-- Enable [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for Anthropic Claude 3.7 Sonnet on Amazon Bedrock.
+- Enable [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for Claude Haiku 4.5 on Amazon Bedrock.
 - Jupyter Notebook or compatible IDE
 
 ## Sample Queries

--- a/02-use-cases/01-conversational-agents/finance-personal-assistant/lab1-develop_a_personal_budget_assistant_strands_agent.ipynb
+++ b/02-use-cases/01-conversational-agents/finance-personal-assistant/lab1-develop_a_personal_budget_assistant_strands_agent.ipynb
@@ -122,21 +122,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "23a9b211-80f1-40ce-83d8-cf74a6539a24",
-   "metadata": {},
-   "source": [
-    "**Make sure you have enabled [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for Anthropic Claude 3.7 Sonnet on Amazon Bedrock.**"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "13c2c292-8531-402b-8791-71b0f7af0b4b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Configure Bedrock model with Claude 3.7 Sonnet and guardrails\n",
+    "# Configure Bedrock model with Claude Haiku 4.5 and guardrails\n",
     "bedrock_model = BedrockModel(\n",
     "    model_id=\"global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n",
     "    region_name=\"us-west-2\",\n",
@@ -557,16 +549,7 @@
     "\n",
     "\n",
     "# Enhanced system prompt for structured outputs\n",
-    "BUDGET_SYSTEM_PROMPT = \"\"\"You are a helpful personal finance assistant. \n",
-    "You provide general strategies for creating budgets, tips on financial discipline to achieve financial milestones, and analyze financial trends. You do not provide any investment advice. \n",
-    "\n",
-    "When generating financial reports, always provide:\n",
-    "1. Clear budget breakdowns using the 50/30/20 rule or custom allocations\n",
-    "2. Specific, actionable recommendations (2-3 steps)\n",
-    "3. A financial health score based on spending patterns\n",
-    "4. Practical budgeting and spending advice\n",
-    "\n",
-    "Use structured output when requested to provide comprehensive financial reports.\"\"\"\n",
+    "BUDGET_SYSTEM_PROMPT = \"\"\"You are a helpful personal finance assistant. You help with budgeting, spending analysis, and financial discipline using the 50/30/20 rule or sensible custom allocations. You do not provide investment advice. Base your guidance on the user's income and spending, and keep it practical and actionable.\"\"\"\n",
     "\n",
     "# Continue with previous configurations\n",
     "bedrock_model = BedrockModel(\n",


### PR DESCRIPTION
## Summary

Updates the finance personal assistant (lab1) and its README to align with the Claude Haiku 4.5 model that is already configured in the notebook code.

## Changes

- **`BUDGET_SYSTEM_PROMPT` (lab1, budget_agent.py cell)**: Replaced the previous prompt. The old prompt broke the structured output instructions with Claude Haiku 4.5, so it was rewritten to be more concise and compatible.
- **Removed outdated note**: Deleted the markdown note instructing users to enable model access for Anthropic Claude 3.7 Sonnet, which is no longer required.
- **Model name references**: Updated remaining "Anthropic Claude 3.7 Sonnet" references to "Claude Haiku 4.5" in lab1 and the README, matching the model already used in code (`global.anthropic.claude-haiku-4-5-20251001-v1:0`).

## Testing

Notebook JSON validated. No code/logic changes beyond the system prompt text and documentation/comment updates.