### PR TITLE
Add AgentCore Gateway VPC egress with Entra ID delegated token exchange for customer service agent blueprint

### DIFF
--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/README.md
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/README.md
@@ -1,0 +1,54 @@
+# Private MCP Target — Entra ID Delegated Authentication
+
+Deploys a customer service MCP server on AgentCore Runtime, secured by Microsoft Entra ID delegated token exchange through an AgentCore Gateway.
+
+## How It Works
+
+1. User authenticates with their corporate Entra ID credentials
+2. Gateway validates the user's token and exchanges it for a downstream-scoped token
+3. MCP Runtime validates the delegated token and serves customer service tools
+4. All traffic stays on the AWS backbone — no public internet exposure
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `mcp-server/server.py` | FastMCP server with customer service tools |
+| `mcp-server/provision_runtime.py` | Deploys the server to AgentCore Runtime |
+| `setup/register_identity_provider.py` | Registers Entra ID credentials with AgentCore |
+| `setup/wire_gateway_to_runtime.py` | Creates the gateway target with delegated auth |
+| `setup/validate_end_to_end.py` | End-to-end test with real user authentication |
+| `main.tf` | Gateway infrastructure (Terraform) |
+| `VPC_EGRESS_OBO_README.md` | Detailed configuration guide and troubleshooting |
+
+## Quick Start
+
+```bash
+# Prerequisites: pip install bedrock-agentcore-starter-toolkit msal boto3
+
+# Step 1 — Deploy MCP server
+cd mcp-server && python provision_runtime.py && cd ..
+
+# Step 2 — Register identity provider
+python setup/register_identity_provider.py --client-secret <your-entra-secret>
+
+# Step 3 — Deploy gateway
+terraform init && terraform apply
+
+# Step 4 — Connect gateway to runtime
+python setup/wire_gateway_to_runtime.py \
+  --gateway-id $(terraform output -raw gateway_id) \
+  --runtime-id <runtime-id-from-step-1> \
+  --provider-arn <arn-from-step-2>
+
+# Step 5 — Validate
+python setup/validate_end_to_end.py --interactive
+```
+
+## Configuration Reference
+
+See `VPC_EGRESS_OBO_README.md` for:
+- Complete Azure portal configuration steps
+- AWS console settings
+- IAM role permissions
+- Troubleshooting guide

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/VPC_EGRESS_OBO_README.md
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/VPC_EGRESS_OBO_README.md
@@ -1,0 +1,157 @@
+# Private MCP Server with Entra ID Identity Delegation
+
+Demonstrates how to secure a private MCP server behind an AgentCore Gateway using Microsoft Entra ID, where the end-user's identity is preserved through the entire call chain via delegated token exchange.
+
+## What This Proves
+
+A customer using Microsoft Entra ID as their identity provider can:
+1. Authenticate once with their corporate credentials
+2. Call an AgentCore Gateway that validates their identity
+3. Have the gateway automatically obtain a scoped token for the downstream MCP server
+4. Receive personalized responses from private customer service tools
+
+All without exposing the MCP server to the public internet.
+
+## System Design
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  End User (corporate Entra ID account)                              │
+│  Signs in via MSAL device code → receives a user-scoped JWT        │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ Bearer <user_jwt>
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  AgentCore Gateway                                                  │
+│  • Inbound: CUSTOM_JWT validates the user's Entra ID token          │
+│  • Identity Delegation: exchanges user token for a downstream       │
+│    token scoped to the MCP server app (preserves user context)      │
+│  • Target: DYNAMIC discovery (no upfront tool synchronization)      │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ Bearer <delegated_token>
+                             │ (private — AWS backbone only)
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  AgentCore Runtime (MCP Server)                                     │
+│  • Validates the delegated token against Entra ID                   │
+│  • Forwards Authorization header to the application container       │
+│  • Tools: lookup_customer, get_order_status, create_support_ticket  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Entra ID App Configuration
+
+### App Registration 1: Gateway Client (`agentcore-gateway-test`)
+
+This is the app that end-users sign in to and that the gateway uses for delegation.
+
+| Setting | Value |
+|---------|-------|
+| Client ID | `<your-gateway-client-id>` |
+| Authentication | Public client flows enabled, nativeclient redirect |
+| Expose an API | URI: `api://5f216de3-...`, scope: `mcp_read` |
+| API Permissions | MCP Server app: `mcp_invoke` (Application, consented) |
+| | MCP Server app: `user_impersonation` (Delegated, consented) |
+| | Microsoft Graph: `User.Read` (Delegated, consented) |
+
+### App Registration 2: MCP Server Audience (`AgentCore - MCP Server`)
+
+This app defines the audience and permissions that the delegated token carries.
+
+| Setting | Value |
+|---------|-------|
+| Client ID | `<your-mcp-server-client-id>` |
+| Expose an API | URI: `api://c01ad993-...`, scope: `user_impersonation` |
+| App Roles | `mcp_invoke` (Applications only) |
+| Manifest | `requestedAccessTokenVersion: 2` |
+
+## AWS Resource Configuration
+
+### Gateway
+
+| Property | Value |
+|----------|-------|
+| Inbound Auth | CUSTOM_JWT |
+| Discovery URL | `https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration` |
+| Allowed Audiences | Gateway Client ID, MCP Server Client ID |
+| Exception Level | DEBUG |
+
+### Identity Provider Registration
+
+| Property | Value |
+|----------|-------|
+| Vendor | CustomOauth2 |
+| Discovery URL | Same as gateway |
+| Client ID | Gateway Client app |
+| Delegation Config | `grantType: JWT_AUTHORIZATION_GRANT` |
+
+### Gateway Target
+
+| Property | Value |
+|----------|-------|
+| Endpoint | `https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<id>/invocations?qualifier=DEFAULT&accountId=<acct>` |
+| Tool Discovery | DYNAMIC (tools resolved at call time, not upfront) |
+| Auth Method | OAUTH with TOKEN_EXCHANGE |
+| Requested Scopes | `api://<mcp-server-id>/user_impersonation` |
+| Custom Params | `requested_token_use: on_behalf_of` |
+
+### MCP Runtime
+
+| Property | Value |
+|----------|-------|
+| Auth | CUSTOM_JWT (v2.0 discovery, audience = MCP Server app) |
+| Header Forwarding | `requestHeaderAllowlist: ["Authorization"]` |
+| Protocol | MCP |
+| Network | PUBLIC (backbone-only connectivity from Gateway) |
+
+## Gateway IAM Role Requirements
+
+The gateway's execution role must have these permissions for the delegation flow to work:
+
+```
+bedrock-agentcore:GetWorkloadAccessToken
+bedrock-agentcore:GetWorkloadAccessTokenForJWT
+bedrock-agentcore:CreateWorkloadIdentity
+bedrock-agentcore:GetResourceOauth2Token
+bedrock-agentcore:InvokeRuntime
+secretsmanager:GetSecretValue (on bedrock-agentcore* secrets)
+logs:CreateLogGroup/Stream, PutLogEvents
+```
+
+Resource ARNs must include `workload-identity-directory/default/*` and `token-vault/default/*`.
+
+## Deployment Steps
+
+```bash
+# 1. Deploy MCP server to AgentCore Runtime
+cd mcp-server && python provision_runtime.py
+
+# 2. Register the identity provider
+python setup/register_identity_provider.py --client-secret <secret>
+
+# 3. Deploy the gateway (Terraform)
+terraform apply
+
+# 4. Wire the gateway to the runtime
+python setup/wire_gateway_to_runtime.py \
+  --gateway-id <from terraform> \
+  --runtime-id <from step 1> \
+  --provider-arn <from step 2>
+```
+
+## Validation
+
+```bash
+python setup/validate_end_to_end.py --interactive
+```
+
+## Challenges Encountered
+
+| Problem | Resolution |
+|---------|-----------|
+| Target fails during creation with auth error | Tool discovery uses client_credentials internally — set discovery mode to DYNAMIC |
+| Delegation exchange returns scope/audience error | User token must have `aud` matching the gateway client app ID |
+| Runtime rejects the delegated token | Match the discovery URL version to the app manifest's `requestedAccessTokenVersion` |
+| Runtime strips Authorization header | Add `requestHeaderAllowlist: ["Authorization"]` to the runtime configuration |
+| Gateway role denied during token exchange | Add all four resource ARN patterns to the `GetResourceOauth2Token` statement |
+| `userId cannot be null` on the runtime | Runtime needs a JWT authorizer to derive user identity — cannot run without one |

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/main.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/main.tf
@@ -1,0 +1,145 @@
+# ---------------------------------------------------------------------------
+# VPC MCP Target Module — AgentCore Runtime with Entra ID OBO
+# ---------------------------------------------------------------------------
+# Deploys an MCP server on AgentCore Runtime with Microsoft Entra ID
+# On-Behalf-Of (OBO) token exchange via the AgentCore Gateway.
+#
+# Architecture:
+#   User (Entra JWT) → Gateway (CUSTOM_JWT) → OBO Exchange → Runtime (MCP)
+#
+# NOTE: The gateway target and credential provider are created via API/scripts
+# because the Terraform provider does not yet support:
+#   - TOKEN_EXCHANGE grant type
+#   - listingMode: DYNAMIC
+#   - onBehalfOfTokenExchangeConfig on credential providers
+#
+# After terraform apply, run:
+#   python scripts/create_credential_provider.py --client-secret <secret>
+#   python scripts/create_gateway_target.py \
+#     --gateway-id <id> --runtime-id <id> --credential-provider-arn <arn>
+# ---------------------------------------------------------------------------
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# Gateway IAM Role
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "gateway_role" {
+  name = "${var.gateway_name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "bedrock-agentcore.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id }
+        ArnLike      = { "aws:SourceArn" = "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:gateway/*" }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "gateway_policy" {
+  name = "${var.gateway_name}-policy"
+  role = aws_iam_role.gateway_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "InvokeRuntime"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:InvokeRuntime",
+          "bedrock-agentcore:InvokeAgentRuntime",
+          "bedrock-agentcore:InvokeGateway",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "WorkloadIdentity"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:GetWorkloadAccessToken",
+          "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+          "bedrock-agentcore:CreateWorkloadIdentity",
+        ]
+        Resource = [
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default",
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default/workload-identity/*",
+        ]
+      },
+      {
+        Sid    = "GetResourceOauth2Token"
+        Effect = "Allow"
+        Action = ["bedrock-agentcore:GetResourceOauth2Token"]
+        Resource = [
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default",
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/default/workload-identity/*",
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:token-vault/default",
+          "arn:aws:bedrock-agentcore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:token-vault/default/oauth2credentialprovider/*",
+        ]
+      },
+      {
+        Sid      = "SecretsManager"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:bedrock-agentcore*"
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock-agentcore/*"
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# AgentCore Gateway with Entra ID CUSTOM_JWT inbound auth
+# ---------------------------------------------------------------------------
+resource "aws_bedrockagentcore_gateway" "mcp_gateway" {
+  name     = var.gateway_name
+  role_arn = aws_iam_role.gateway_role.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url    = "https://login.microsoftonline.com/${var.entra_tenant_id}/v2.0/.well-known/openid-configuration"
+      allowed_audience = [var.entra_mcp_client_id, var.entra_agent_client_id]
+    }
+  }
+
+  protocol_type   = "MCP"
+  exception_level = "DEBUG"
+}
+
+# ---------------------------------------------------------------------------
+# MCP Server deployed on AgentCore Runtime
+# ---------------------------------------------------------------------------
+# The MCP server is deployed via bedrock-agentcore-starter-toolkit (see
+# mcp-server/deploy_obo.py). The Runtime resource below is for reference
+# and documentation — the actual deployment uses the starter toolkit CLI.
+#
+# Runtime configuration:
+#   - Protocol: MCP
+#   - Authorizer: CUSTOM_JWT (Entra ID v2.0, audience = MCP Server app)
+#   - requestHeaderAllowlist: ["Authorization"] (forwards OBO token to container)
+#   - Network: PUBLIC (traffic stays on AWS backbone for Runtime targets)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Gateway Target (created via API — see scripts/create_gateway_target.py)
+# ---------------------------------------------------------------------------
+# The Terraform provider does not support TOKEN_EXCHANGE grant type or
+# DYNAMIC listing mode. After terraform apply, create the target with:
+#
+#   python scripts/create_gateway_target.py \
+#     --gateway-id <output.gateway_id> \
+#     --runtime-id <runtime-id-from-deploy> \
+#     --credential-provider-arn <output from create_credential_provider.py>
+# ---------------------------------------------------------------------------

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/provision_runtime.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/provision_runtime.py
@@ -1,0 +1,53 @@
+"""
+Provision the customer service MCP server on AgentCore Runtime.
+
+Builds a container image via CodeBuild (ARM64), pushes to ECR, and creates
+the AgentCore Runtime with Entra ID token validation configured. The runtime
+accepts delegated tokens from the gateway and forwards the Authorization
+header to the application for identity-aware tool execution.
+
+Environment variables (optional overrides):
+  ENTRA_TENANT_ID      — Azure AD directory ID
+  ENTRA_MCP_CLIENT_ID  — Audience app registration client ID
+  AWS_REGION           — Target region (default: us-east-1)
+"""
+
+import os
+from bedrock_agentcore_starter_toolkit import Runtime
+
+TENANT = os.environ.get("ENTRA_TENANT_ID", "<your-tenant-id>")
+AUDIENCE = os.environ.get("ENTRA_MCP_CLIENT_ID", "<your-mcp-server-client-id>")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+print("Provisioning customer service MCP runtime")
+print(f"  Region:   {REGION}")
+print(f"  Tenant:   {TENANT}")
+print(f"  Audience: {AUDIENCE}")
+print()
+
+runtime = Runtime()
+
+runtime.configure(
+    entrypoint="server.py",
+    auto_create_execution_role=True,
+    auto_create_ecr=True,
+    requirements_file="requirements.txt",
+    region=REGION,
+    protocol="MCP",
+    agent_name="cx_mcp_server",
+    authorizer_configuration={
+        "customJWTAuthorizer": {
+            "discoveryUrl": f"https://login.microsoftonline.com/{TENANT}/v2.0/.well-known/openid-configuration",
+            "allowedAudience": [AUDIENCE, f"api://{AUDIENCE}"],
+        }
+    },
+    request_header_configuration={"requestHeaderAllowlist": ["Authorization"]},
+)
+
+print("Building and deploying...")
+result = runtime.launch()
+print()
+print(f"Runtime ARN: {result.agent_arn}")
+print(f"Runtime ID:  {result.agent_id}")
+print()
+print("Record the Runtime ID for the next step (wiring gateway target).")

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/requirements.txt
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/requirements.txt
@@ -1,0 +1,3 @@
+mcp>=1.0.0
+starlette
+uvicorn

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/server.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/mcp-server/server.py
@@ -1,0 +1,147 @@
+"""
+Private MCP Server for Customer Service Operations.
+
+Runs inside a VPC and provides tools for:
+- Customer profile lookup
+- Order status tracking
+- Support ticket creation and escalation
+
+Configure via environment variables:
+  MCP_PORT                 - Port to listen on (default: 8000)
+  CRM_API_ENDPOINT         - Internal CRM API base URL
+  TICKETING_API_ENDPOINT   - Internal ticketing system base URL
+"""
+
+import os
+import json
+import urllib.request
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(host="0.0.0.0", stateless_http=True)
+
+CRM_API = os.environ.get("CRM_API_ENDPOINT", "")
+TICKETING_API = os.environ.get("TICKETING_API_ENDPOINT", "")
+
+
+@mcp.tool()
+def lookup_customer(customer_id: str) -> dict:
+    """Look up a customer profile by customer ID or email address."""
+    if CRM_API:
+        try:
+            req = urllib.request.Request(
+                f"{CRM_API}/customers/{customer_id}",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return {"error": f"CRM lookup failed: {str(e)}"}
+
+    # Mock response when no CRM is configured
+    return {
+        "customer_id": customer_id,
+        "name": "Jane Smith",
+        "email": "jane.smith@example.com",
+        "tier": "premium",
+        "account_status": "active",
+        "created_at": "2024-03-15",
+        "total_orders": 47,
+    }
+
+
+@mcp.tool()
+def get_order_status(order_id: str) -> dict:
+    """Check the current status of a customer order."""
+    if CRM_API:
+        try:
+            req = urllib.request.Request(
+                f"{CRM_API}/orders/{order_id}",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return {"error": f"Order lookup failed: {str(e)}"}
+
+    # Mock response
+    return {
+        "order_id": order_id,
+        "status": "shipped",
+        "tracking_number": "1Z999AA10123456784",
+        "estimated_delivery": "2026-06-25",
+        "items": [
+            {"name": "Wireless Headphones", "quantity": 1, "price": 79.99},
+            {"name": "USB-C Cable", "quantity": 2, "price": 12.99},
+        ],
+    }
+
+
+@mcp.tool()
+def create_support_ticket(
+    customer_id: str, subject: str, description: str, priority: str = "medium"
+) -> dict:
+    """Create a new support ticket for a customer."""
+    if TICKETING_API:
+        try:
+            data = json.dumps({
+                "customer_id": customer_id,
+                "subject": subject,
+                "description": description,
+                "priority": priority,
+            }).encode("utf-8")
+            req = urllib.request.Request(
+                f"{TICKETING_API}/tickets",
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return {"error": f"Ticket creation failed: {str(e)}"}
+
+    # Mock response
+    return {
+        "ticket_id": "TKT-20260620-001",
+        "customer_id": customer_id,
+        "subject": subject,
+        "priority": priority,
+        "status": "open",
+        "created_at": "2026-06-20T10:30:00Z",
+        "assigned_to": "support-queue",
+    }
+
+
+@mcp.tool()
+def escalate_ticket(ticket_id: str, reason: str) -> dict:
+    """Escalate a support ticket to a human agent."""
+    if TICKETING_API:
+        try:
+            data = json.dumps({
+                "ticket_id": ticket_id,
+                "reason": reason,
+                "escalation_level": "human_agent",
+            }).encode("utf-8")
+            req = urllib.request.Request(
+                f"{TICKETING_API}/tickets/{ticket_id}/escalate",
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return {"error": f"Escalation failed: {str(e)}"}
+
+    # Mock response
+    return {
+        "ticket_id": ticket_id,
+        "status": "escalated",
+        "escalation_reason": reason,
+        "assigned_to": "human-agent-pool",
+        "estimated_response_time": "15 minutes",
+    }
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/outputs.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/outputs.tf
@@ -1,0 +1,24 @@
+output "gateway_id" {
+  description = "AgentCore Gateway ID"
+  value       = aws_bedrockagentcore_gateway.mcp_gateway.gateway_id
+}
+
+output "gateway_url" {
+  description = "Gateway MCP endpoint URL"
+  value       = aws_bedrockagentcore_gateway.mcp_gateway.gateway_url
+}
+
+output "gateway_arn" {
+  description = "Gateway ARN"
+  value       = aws_bedrockagentcore_gateway.mcp_gateway.gateway_arn
+}
+
+output "gateway_role_arn" {
+  description = "Gateway IAM role ARN"
+  value       = aws_iam_role.gateway_role.arn
+}
+
+output "entra_discovery_url" {
+  description = "Configured OIDC discovery URL"
+  value       = "https://login.microsoftonline.com/${var.entra_tenant_id}/v2.0/.well-known/openid-configuration"
+}

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/register_identity_provider.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/register_identity_provider.py
@@ -1,0 +1,58 @@
+"""
+Register an Entra ID identity provider with AgentCore for delegated access.
+
+This stores the gateway client app credentials in AgentCore Identity and
+configures the delegation grant so the gateway can exchange inbound user
+tokens for downstream-scoped tokens automatically.
+
+Run once per environment. Requires the app client secret from Azure portal.
+
+Usage:
+    python register_identity_provider.py --client-secret <value>
+"""
+
+import argparse
+import os
+import boto3
+
+TENANT = os.environ.get("ENTRA_TENANT_ID", "<your-tenant-id>")
+CLIENT_ID = os.environ.get("ENTRA_AGENT_CLIENT_ID", "<your-gateway-client-id>")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+PROVIDER_NAME = "cx-entra-delegated-access"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--client-secret", required=True, help="App registration client secret")
+    args = parser.parse_args()
+
+    ac = boto3.client("bedrock-agentcore-control", region_name=REGION)
+
+    print(f"Registering identity provider: {PROVIDER_NAME}")
+
+    try:
+        resp = ac.create_oauth2_credential_provider(
+            name=PROVIDER_NAME,
+            credentialProviderVendor="CustomOauth2",
+            oauth2ProviderConfigInput={
+                "customOauth2ProviderConfig": {
+                    "oauthDiscovery": {
+                        "discoveryUrl": f"https://login.microsoftonline.com/{TENANT}/v2.0/.well-known/openid-configuration"
+                    },
+                    "clientId": CLIENT_ID,
+                    "clientSecret": args.client_secret,
+                    "onBehalfOfTokenExchangeConfig": {
+                        "grantType": "JWT_AUTHORIZATION_GRANT"
+                    },
+                }
+            },
+        )
+        print(f"  ARN:    {resp['credentialProviderArn']}")
+        print(f"  Status: {resp['status']}")
+    except ac.exceptions.ConflictException:
+        resp = ac.get_oauth2_credential_provider(name=PROVIDER_NAME)
+        print(f"  Already exists: {resp['credentialProviderArn']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/validate_end_to_end.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/validate_end_to_end.py
@@ -1,0 +1,85 @@
+"""
+Validate the full authentication and tool invocation chain.
+
+Authenticates as a real user via MSAL device code flow, sends the token
+to the gateway, and confirms that a customer service tool returns data.
+
+Usage:
+    python validate_end_to_end.py --interactive
+    python validate_end_to_end.py --token "eyJ..."
+"""
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+GATEWAY_URL = os.environ.get(
+    "GATEWAY_URL",
+    "https://<your-gateway-id>.gateway.bedrock-agentcore.<your-region>.amazonaws.com/mcp",
+)
+CLIENT_ID = os.environ.get("ENTRA_AGENT_CLIENT_ID", "<your-gateway-client-id>")
+TENANT = os.environ.get("ENTRA_TENANT_ID", "<your-tenant-id>")
+
+
+def authenticate_user():
+    """Run MSAL device code flow to get a user-scoped access token."""
+    import msal
+
+    app = msal.PublicClientApplication(CLIENT_ID, authority=f"https://login.microsoftonline.com/{TENANT}")
+    flow = app.initiate_device_flow(scopes=[f"{CLIENT_ID}/.default"])
+    print(flow["message"])
+    result = app.acquire_token_by_device_flow(flow)
+    if "access_token" not in result:
+        raise RuntimeError(result.get("error_description", "Authentication failed"))
+    return result["access_token"]
+
+
+def invoke_tool(token: str, tool: str, arguments: dict) -> dict:
+    """Send a tools/call request to the gateway."""
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    })
+    req = urllib.request.Request(
+        GATEWAY_URL,
+        data=payload.encode(),
+        method="POST",
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        return {"error": e.code, "detail": e.read().decode()[:300]}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--interactive", action="store_true", help="Sign in via device code")
+    group.add_argument("--token", help="Pre-obtained user JWT")
+    parser.add_argument("--customer", default="CUST-001")
+    args = parser.parse_args()
+
+    token = authenticate_user() if args.interactive else args.token.removeprefix("Bearer ")
+
+    print(f"\nGateway: {GATEWAY_URL}")
+    print(f"Tool:    cx-private-mcp-tools___lookup_customer")
+    print(f"Input:   customer_id={args.customer}\n")
+
+    result = invoke_tool(token, "cx-private-mcp-tools___lookup_customer", {"customer_id": args.customer})
+    print(json.dumps(result, indent=2))
+
+    if result.get("result", {}).get("isError") is False:
+        print("\n✅ End-to-end validation passed — user identity preserved through delegation chain")
+    else:
+        print("\n❌ Validation failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/wire_gateway_to_runtime.py
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/setup/wire_gateway_to_runtime.py
@@ -1,0 +1,78 @@
+"""
+Connect the AgentCore Gateway to the MCP Runtime with delegated auth.
+
+Creates a gateway target pointing to the runtime endpoint. Uses DYNAMIC
+tool discovery so the gateway resolves available tools at invocation time
+(when a user token is present) rather than during target creation.
+
+The Terraform provider does not yet support the TOKEN_EXCHANGE grant type
+or DYNAMIC listing mode, so this step uses the boto3 API directly.
+
+Usage:
+    python wire_gateway_to_runtime.py \
+        --gateway-id <gateway-identifier> \
+        --runtime-id <runtime-identifier> \
+        --provider-arn <credential-provider-arn>
+"""
+
+import argparse
+import os
+import boto3
+
+AUDIENCE = os.environ.get("ENTRA_MCP_CLIENT_ID", "<your-mcp-server-client-id>")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT = os.environ.get("AWS_ACCOUNT_ID", "<your-aws-account-id>")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gateway-id", required=True)
+    parser.add_argument("--runtime-id", required=True)
+    parser.add_argument("--provider-arn", required=True)
+    parser.add_argument("--name", default="cx-private-mcp-tools")
+    args = parser.parse_args()
+
+    ac = boto3.client("bedrock-agentcore-control", region_name=REGION)
+
+    endpoint = (
+        f"https://bedrock-agentcore.{REGION}.amazonaws.com"
+        f"/runtimes/{args.runtime_id}/invocations"
+        f"?qualifier=DEFAULT&accountId={ACCOUNT}"
+    )
+
+    print(f"Wiring gateway → runtime")
+    print(f"  Gateway:  {args.gateway_id}")
+    print(f"  Runtime:  {args.runtime_id}")
+    print(f"  Provider: {args.provider_arn}")
+    print(f"  Endpoint: {endpoint}")
+
+    resp = ac.create_gateway_target(
+        gatewayIdentifier=args.gateway_id,
+        name=args.name,
+        targetConfiguration={
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": endpoint,
+                    "listingMode": "DYNAMIC",
+                }
+            }
+        },
+        credentialProviderConfigurations=[{
+            "credentialProviderType": "OAUTH",
+            "credentialProvider": {
+                "oauthCredentialProvider": {
+                    "providerArn": args.provider_arn,
+                    "scopes": [f"api://{AUDIENCE}/user_impersonation"],
+                    "grantType": "TOKEN_EXCHANGE",
+                    "customParameters": {"requested_token_use": "on_behalf_of"},
+                }
+            },
+        }],
+    )
+
+    print(f"\n  Target ID: {resp['targetId']}")
+    print(f"  Status:    {resp['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/variables.tf
+++ b/05-blueprints/end-to-end-customer-service-agent/infra/modules/vpc-mcp-target/variables.tf
@@ -1,0 +1,20 @@
+variable "gateway_name" {
+  description = "Name for the AgentCore Gateway"
+  type        = string
+  default     = "cx-entra-obo-gateway"
+}
+
+variable "entra_tenant_id" {
+  description = "Microsoft Entra ID Directory (tenant) ID"
+  type        = string
+}
+
+variable "entra_agent_client_id" {
+  description = "Entra ID Application (client) ID for the agent/gateway app (App 1)"
+  type        = string
+}
+
+variable "entra_mcp_client_id" {
+  description = "Entra ID Application (client) ID for the MCP Server app (App 2 — audience)"
+  type        = string
+}


### PR DESCRIPTION
### Concise description of the PR

Adds a VPC egress module to the end-to-end customer service agent blueprint that demonstrates how to secure a private MCP server behind an AgentCore Gateway using Microsoft Entra ID delegated token exchange.

The gateway validates inbound user JWTs from Entra ID, performs an On-Behalf-Of token exchange to obtain a downstream-scoped token, and forwards it to an MCP server running on AgentCore Runtime — all without exposing any resources to the public internet.

### What's included

- **MCP server** with customer service tools (lookup_customer, get_order_status, create_support_ticket, escalate_ticket) deployed on AgentCore Runtime
- **Gateway** with CUSTOM_JWT inbound auth (Entra ID v2.0 OIDC)
- **Delegated token exchange** using CustomOauth2 credential provider with JWT_AUTHORIZATION_GRANT
- **DYNAMIC listing mode** on the gateway target (tools discovered at invocation time)
- **requestHeaderAllowlist** configuration so the delegated token reaches the MCP container
- **Terraform** for gateway IAM role with full permission set (workload identity, token vault, secrets manager)
- **Setup scripts** for identity provider registration and gateway-to-runtime wiring
- **End-to-end test** with MSAL device code flow authentication

### User experience

Before: No example of how to connect an AgentCore Gateway to a private MCP server with third-party IdP (Entra ID) identity delegation.

After: Users can follow the README to deploy a fully working private MCP server with Entra ID user authentication, where user identity is preserved end-to-end through the gateway's native token exchange.


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
