### PR TITLE
Fix broken example links in OBO Reference Guide

### DIFF
--- a/01-features/05-authenticate-and-authorize/obo-training/OBO Reference Guide.md
+++ b/01-features/05-authenticate-and-authorize/obo-training/OBO Reference Guide.md
@@ -480,14 +480,14 @@ For providers not listed above, use `CustomOauth2` with the appropriate grant ty
 
 ## Runnable Examples
 
-The shapes above are easier to internalize when you can run them. The repo includes end-to-end working examples under [`examples/`](./examples/):
+The shapes above are easier to internalize when you can run them. End-to-end working examples live under [`3-examples/`](./3-examples/):
 
 | Use Case | What it demonstrates | Path |
 |---|---|---|
-| **UC1 — agent → downstream** | A single OBO hop **inside agent code**. Agent receives a user JWT, calls AgentCore Identity, gets a downstream token, calls the downstream API directly. | [`examples/01-agent-to-downstream/`](./examples/01-agent-to-downstream/) (Entra + Okta, both `local/` and `real-world/`) |
-| **UC2 — agent → Gateway → API** | **Two OBO hops in one chain**: OBO #1 in agent code, OBO #2 inside AgentCore Gateway. User identity (`oid`) preserved across all three tokens. | [`examples/02-agent-via-gateway/entra/real-world/`](./examples/02-agent-via-gateway/entra/real-world/) (Entra; Okta planned) |
+| **UC1 — agent → downstream** | A single OBO hop **inside agent code**. Agent receives a user JWT, calls AgentCore Identity, gets a downstream token, calls the downstream API directly. | [`3-examples/01-agent-to-downstream/`](./3-examples/01-agent-to-downstream/) — Entra + Okta, both `local/` and `real-world/` |
+| **UC2 — agent → Gateway → API** | **Two OBO hops in one chain**: OBO #1 in agent code, OBO #2 inside AgentCore Gateway. User identity preserved across all three tokens (`oid` on Entra, `sub`+`uid` on Okta). | [`3-examples/02-agent-via-gateway/`](./3-examples/02-agent-via-gateway/) — Entra + Okta, `real-world/` only |
 
-UC2's `ARCHITECTURE.md` walks through how the same OBO primitive applies at two different layers (code vs infrastructure) and decodes the three tokens (T_user → T_gateway → T_graph) so you can see the audience rotating while the user identity stays constant. Read that for the cleanest illustration of why OBO chains are valuable.
+UC2's `ARCHITECTURE.md` walks through how the same OBO primitive applies at two different layers (code vs infrastructure) and decodes the three tokens (T_user → T_gateway → T_downstream) so you can see the actor rotating (`azp`/`appid` on Entra, `cid` on Okta) while the user identity stays constant. On Entra the audience also rotates per hop; on Okta the audience stays constant at the auth server's audience and scope is what narrows. Read that for the cleanest illustration of why OBO chains are valuable.
 
 ---
 


### PR DESCRIPTION
The Runnable Examples section in `01-features/05-authenticate-and-authorize/obo-training/OBO Reference Guide.md` had relative links to `examples/01-agent-to-downstream/` and `examples/02-agent-via-gateway/entra/real-world/` that no longer resolve — the folder is now `3-examples/` and both use cases have Okta variants (not just Entra).

Fix:

- Use absolute awslabs URLs so the links resolve regardless of where the file is being viewed.
- Update the path to `3-examples/`.
- Mark UC2 Okta complete (was 'planned').
- Generalize the walkthrough paragraph so it covers both Entra (`azp`/`oid`) and Okta (`cid`/`sub`+`uid`) claim conventions.
