### PR TITLE
Add Slack chat UX example with human-in-the-loop (Welt)

### DIFF
--- a/03-integrations/README.md
+++ b/03-integrations/README.md
@@ -50,6 +50,7 @@ This folder contains framework and protocol integrations that demonstrate how to
 ## 🎨 UX Examples
 
 * **[Streamlit Chat](./ux-examples/streamlit-chat/)**: Interactive chat interface with AgentCore backend integration
+* **[Slack Chat (Welt)](./ux-examples/slack-welt/)**: Chat with an AgentCore agent in Slack, with human-in-the-loop approvals
 
 ## 🚀 Integration Patterns
 

--- a/03-integrations/ux-examples/slack-welt/README.md
+++ b/03-integrations/ux-examples/slack-welt/README.md
@@ -1,0 +1,123 @@
+# Slack Chat Interface with Human-in-the-Loop
+
+| Information        | Details                                                |
+|--------------------|--------------------------------------------------------|
+| Agent type         | Asynchronous (streaming)                               |
+| Agentic Framework  | Strands Agents                                         |
+| LLM model          | Anthropic Claude (Strands default)                     |
+| Components         | AgentCore Runtime, Slack (via Welt)                    |
+| Example complexity | Intermediate                                           |
+| SDK used           | Amazon Bedrock AgentCore Python SDK, welt-io-strands   |
+
+This example puts an agent deployed on Amazon Bedrock AgentCore Runtime behind a Slack chat interface: mention it in a thread, watch its reply stream back, and — when the agent needs a decision — answer an approval prompt inline before it continues. [Welt](https://github.com/iwamot/welt) handles the Slack side; the agent and Welt exchange a small JSON [wire contract](https://github.com/iwamot/welt/blob/main/docs/wire.md), which the [welt-io-strands](https://github.com/iwamot/welt-io-strands) adapter translates to and from Strands values, so the agent code stays plain Strands.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant U as Slack user
+    participant W as Welt (Slack frontend)
+    participant A as AgentCore Runtime<br/>(example agent + welt-io-strands)
+
+    U->>W: @mention in a thread
+    W->>A: invoke (JSON wire contract)
+
+    opt the agent needs a decision (human-in-the-loop)
+        A-->>W: stream events, ending with interrupt
+        W-->>U: Approve / Cancel + text field
+        U->>W: answer (button press or typed instruction)
+        W->>A: resume with the answer
+    end
+
+    A-->>W: stream events (SSE)
+    W-->>U: streamed reply
+```
+
+## Prerequisites
+
+- Python 3.10 or higher
+- uv
+- AWS CLI configured with credentials, and access to Amazon Bedrock AgentCore
+- Access enabled for a Bedrock model the agent can call — the Strands default is an Anthropic Claude model; the `generate_image` tool uses a Stability AI image model in `us-west-2`
+- A Slack workspace where you can install an app
+
+Welt invokes the deployed agent with the verified Slack identity as the `runtimeUserId`, so the credentials Welt runs with need both `bedrock-agentcore:InvokeAgentRuntime` and `bedrock-agentcore:InvokeAgentRuntimeForUser` on the agent's runtime ARN.
+
+## Setup
+
+### 1. Create a Slack app
+
+Create a Slack app from Welt's [`manifest.yml`](https://github.com/iwamot/welt/blob/main/manifest.yml): generate an app-level token with the `connections:write` scope (`xapp-1-...`), then install the app to your workspace and copy the bot token (`xoxb-...`).
+
+### 2. Deploy the example agent
+
+Clone this repository and change into this directory:
+
+```bash
+git clone https://github.com/awslabs/agentcore-samples.git
+cd agentcore-samples/03-integrations/ux-examples/slack-welt
+```
+
+Deploy [`example/agent.py`](example/agent.py) to AgentCore Runtime with the [AgentCore CLI](https://github.com/aws/agentcore-cli):
+
+```bash
+agentcore create --name WeltExample --framework Strands --model-provider Bedrock --memory none
+cp example/agent.py WeltExample/app/WeltExample/main.py
+cd WeltExample
+uv add --project app/WeltExample welt-io-strands strands-agents-tools
+agentcore deploy
+```
+
+Note the agent runtime ARN from the deploy output — Welt's `AGENT_ARN` points at it. Set `MODEL_ID` to another Converse model if you prefer; unset, the agent uses the Strands default.
+
+> Prefer to try it before deploying? Welt's [Quick Start](https://github.com/iwamot/welt#quick-start) runs both the agent and Welt on your machine first.
+
+### 3. Run Welt
+
+Clone Welt:
+
+```bash
+git clone https://github.com/iwamot/welt.git
+cd welt
+```
+
+Save the tokens and the agent runtime ARN in a `.env` file at the repository root:
+
+```sh
+SLACK_APP_TOKEN=xapp-1-...
+SLACK_BOT_TOKEN=xoxb-...
+AGENT_ARN=arn:aws:bedrock-agentcore:...
+```
+
+And run it:
+
+```bash
+uv run --env-file .env main.py
+```
+
+Welt invokes the deployed agent through the standard AWS SDK, so run it where AWS credentials are available — environment variables, a profile, or an SSO session. Welt's [README](https://github.com/iwamot/welt#readme) covers the Slack app setup and every supported variable; for hosting it instead of running it locally, the same process ships as the container image `ghcr.io/iwamot/welt`.
+
+## Usage
+
+Invite the app to a channel (`/invite @YourApp`) and mention it, or send it a direct message. Welt streams the reply into a thread:
+
+- **Streaming + tool use**: `@YourApp what time is it?`
+- **File output**: `@YourApp draw a picture of a cat`
+- **Human-in-the-loop**: `@YourApp deploy to prod` → the run pauses with **Approve** / **Cancel** buttons and a text field. Press a button, or type an instruction like `run the tests first`; the run resumes on whichever comes first.
+
+## How it works
+
+[`example/agent.py`](example/agent.py) is a standalone agent you deploy to AgentCore Runtime. Its `@app.entrypoint` function receives Welt's payload and streams events back:
+
+- A conversation turn arrives as [Bedrock Converse-shaped `messages`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Message.html); `decode_messages` restores any uploaded file bytes, and the agent streams a reply.
+- `renderable_events` reduces the raw Strands `stream_async` events to the JSON events Welt renders — text, tool-use indicators, file uploads, and interrupts.
+- On an interrupt, the stream ends with an `interrupt` event and the agent is held for the session; Welt posts the buttons, and the answer returns as `interrupt_responses`, which `decode_interrupt_responses` turns into the values that resume the run.
+
+The example agent's tools are `current_time` (text streaming), `generate_image` (uploads a file into the thread), and `sample_dangerous_action` (a no-op that pauses for approval). See [Welt's Interrupts doc](https://github.com/iwamot/welt/blob/main/docs/interrupts.md) for how each prompt renders and resumes.
+
+## Resources
+
+- [Welt](https://github.com/iwamot/welt) — the Slack frontend, its wire contract, and setup
+- [welt-io-strands](https://github.com/iwamot/welt-io-strands) — the Strands adapter and its example agent
+- [Amazon Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock-agentcore/)
+- [Strands Agents](https://github.com/strands-agents/sdk-python)

--- a/03-integrations/ux-examples/slack-welt/example/agent.py
+++ b/03-integrations/ux-examples/slack-welt/example/agent.py
@@ -1,0 +1,132 @@
+"""A small AgentCore agent that Welt can drive.
+
+Receives Welt's payload, feeds it to a Strands agent, and yields the
+renderable subset of its `stream_async` events — the AgentCore Runtime SDK
+emits each one as SSE, which Welt (https://github.com/iwamot/welt) renders
+into Slack. The payload carries one of two envelopes: Converse-shaped
+`messages` for a conversation turn, or `interrupt_responses` when a human
+answered the approval buttons of an interrupted run.
+
+This example is a standalone deployable; Welt drives it only through the
+JSON wire contract, which welt-io-strands adapts in both directions.
+"""
+
+import os
+import tempfile
+from collections.abc import AsyncIterator
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent, ToolContext, tool
+from strands_tools import current_time, generate_image
+
+from welt_io_strands import (
+    decode_interrupt_responses,
+    decode_messages,
+    interrupt_reason,
+    renderable_events,
+)
+
+# generate_image saves each image under ./output as a side effect, and the
+# temp dir is the writable path in the AgentCore Runtime container.
+os.chdir(tempfile.gettempdir())
+
+app = BedrockAgentCoreApp()
+
+# Where an interrupted Agent waits for its answers. One slot is enough:
+# AgentCore Runtime runs each session in its own microVM, so this process
+# never serves two sessions. Resume only: a normal turn always builds a
+# fresh Agent from the messages Welt sends (the Slack thread is the source
+# of truth for conversation history, so the slot must not stand in for
+# it). No persistence either — the slot lives and dies with the session's
+# microVM (recycled on idle timeout, 8 hours at most).
+_interrupted_agent: Agent | None = None
+
+
+@tool(context=True)
+def sample_dangerous_action(tool_context: ToolContext, action: str) -> str:
+    """
+    Pretend to run a dangerous or irreversible action the user asked for.
+
+    A sample of the approval round trip: the interrupt below pauses the
+    run until someone answers in the Slack thread — with the buttons, or
+    by typing an instruction into the text field. Nothing is actually
+    executed.
+
+    Args:
+        tool_context (ToolContext): The Strands tool context.
+        action (str): The action to pretend to run.
+
+    Returns:
+        str: The outcome of the action.
+    """
+    answer = tool_context.interrupt(
+        "example-dangerous-action-approval",
+        reason=interrupt_reason(
+            f"May I run this dangerous action? — {action}",
+            [
+                {"value": "y", "label": "Approve", "style": "primary"},
+                {"value": "n", "label": "Cancel"},
+            ],
+            input={"label": "Or tell me what to do instead"},
+        ),
+    )
+    if answer == "y":
+        return f"Ran: {action}. (This example doesn't actually run anything.)"
+    if answer == "n":
+        return "The action was cancelled by the user."
+    return f"The action was not run. The user said instead: {answer}"
+
+
+@app.entrypoint
+async def invoke(payload: dict) -> AsyncIterator[dict]:
+    """
+    Stream a reply to the conversation or approval answers Welt sent.
+
+    Args:
+        payload (dict): The invocation payload: Converse-shaped `messages`
+            built by Welt from the Slack thread (file blocks
+            base64-encoded), or `interrupt_responses` carrying the button
+            answers that resume an interrupted run.
+
+    Yields:
+        dict: The renderable subset of Strands `stream_async` events.
+    """
+    global _interrupted_agent
+
+    if "interrupt_responses" in payload:
+        agent = _interrupted_agent
+        _interrupted_agent = None
+        if agent is None:  # The microVM was recycled while the buttons waited.
+            # The SDK reports the raise as an `error` event, and Welt renders
+            # its resume-failure notice.
+            raise RuntimeError("No interrupted agent to resume in this session.")
+        stream = agent.stream_async(decode_interrupt_responses(payload["interrupt_responses"]))
+    else:
+        messages = payload.get("messages")
+        if not isinstance(messages, list) or not messages:
+            yield {"data": "I received an empty conversation, so there is nothing to reply to."}
+            return
+        messages = decode_messages(messages)  # base64 file bytes -> raw bytes
+        agent = Agent(
+            # Any Converse model; unset falls back to the Strands default.
+            model=os.environ.get("MODEL_ID"),
+            tools=[current_time, generate_image, sample_dangerous_action],
+            callback_handler=None,
+        )
+        stream = agent.stream_async(messages)
+
+    interrupted = False
+    # Reduce the stream to the JSON-serializable events Welt renders
+    async for event in renderable_events(stream):
+        if "interrupt" in event:
+            interrupted = True
+        yield event
+
+    if interrupted:
+        # Re-stashed on every interrupted stop, so a resume that interrupts
+        # again keeps working.
+        _interrupted_agent = agent
+
+
+if __name__ == "__main__":
+    app.run()

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -126,3 +126,4 @@
 - Fabio Balancin (balancin)
 - Varun Gunda (vvargu)
 - Anil Nadiminti (aniloncloud)
+- Takashi Iwamoto (iwamot)


### PR DESCRIPTION
## What this adds

`03-integrations/ux-examples/slack-welt` — a sample that puts an agent deployed on AgentCore Runtime behind a Slack chat interface, including the human-in-the-loop round trip: the agent can pause mid-run for a decision, which is answered in the Slack thread (Approve / Cancel buttons plus a free-text field) before the run resumes.

The Slack side is handled by [Welt](https://github.com/iwamot/welt), an open-source Slack frontend for AgentCore agents. The bundled example agent (Strands) talks to it through a JSON wire contract via the [welt-io-strands](https://github.com/iwamot/welt-io-strands) adapter, and exercises text streaming, tool-use indicators, file upload, and an approval interrupt.

## Why

`ux-examples` currently has a Streamlit chat interface. This adds a Slack one, and covers a capability the existing UX samples do not: pausing a run for a human decision and resuming it from the chat surface itself.

## Contents

- `03-integrations/ux-examples/slack-welt/README.md` — setup (create the Slack app → deploy the agent → run Welt), a sequence diagram of the flow, and how the wire contract is handled on the agent side
- `03-integrations/ux-examples/slack-welt/example/agent.py` — the deployable example agent
- one line in `03-integrations/README.md` listing the sample under UX Examples
- a `CONTRIBUTORS.md` entry

Disclosure: I am the author of Welt and welt-io-strands.