### PR TITLE
fix(coding-agents): repair Hermes/Kiro containers and auto-detect region

### DIFF
--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/claude-code/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/claude-code/connect.py
@@ -15,7 +15,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/skills/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -32,7 +32,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -113,7 +114,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/codex/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/codex/connect.py
@@ -18,7 +18,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -35,7 +35,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -114,7 +115,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/cursor/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/cursor/connect.py
@@ -18,7 +18,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -35,7 +35,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -114,7 +115,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/frontend/app.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/frontend/app.py
@@ -45,7 +45,23 @@ app = Flask(__name__)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 AGENTS_DIR = os.path.dirname(SCRIPT_DIR)
 
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+def _default_region():
+    """Region resolution order: AWS_REGION env → infra.config (where agents
+    were actually deployed) → us-west-2 fallback."""
+    env_region = os.environ.get("AWS_REGION")
+    if env_region:
+        return env_region
+    infra_config = os.path.join(AGENTS_DIR, "infra.config")
+    if os.path.exists(infra_config):
+        with open(infra_config) as f:
+            for line in f:
+                if line.startswith("INFRA_REGION="):
+                    return line.split("=", 1)[1].strip()
+    return "us-west-2"
+
+
+REGION = _default_region()
 
 agentcore_client = AgentCoreRuntimeClient(region=REGION)
 

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/Dockerfile
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/Dockerfile
@@ -1,17 +1,29 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN dnf install -y --allowerasing git curl nodejs npm python3 python3-pip jq tar gzip unzip which findutils && dnf clean all
+# xz is required by the Hermes installer to extract its Node.js tarball.
+RUN dnf install -y --allowerasing git curl nodejs npm python3 python3-pip jq tar gzip xz unzip which findutils && dnf clean all
 
 RUN npm install -g typescript ts-node
 
 # Non-root user
 RUN useradd -m -d /home/agent -u 1000 agent
 
-# Hermes Agent CLI (installed as agent user so it lands in ~/.hermes/bin)
-USER agent
-ENV HOME=/home/agent
-RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash || true
-USER root
+# Hermes Agent CLI. Install as root so it lands in the FHS layout
+# (/usr/local/bin/hermes) — on PATH for every shell, including the interactive
+# login shell that run.sh execs into. Installing as the agent user puts it in
+# ~/.hermes/bin, which the login shell drops from PATH. Non-interactive flags
+# skip the API-key wizard (Bedrock auth comes from the runtime IAM role); no
+# `|| true` so a failed install fails the build loudly instead of silently
+# shipping a container without the hermes binary.
+RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+    | bash -s -- --non-interactive --skip-setup --skip-browser
+
+# The Bedrock provider imports the `anthropic` SDK at runtime (with its boto3
+# extra for SigV4-signed Bedrock calls), but the installer doesn't pull it into
+# hermes's venv. Add it explicitly so `hermes chat --provider bedrock` can
+# initialize. The venv is uv-managed (no pip), so use the managed uv the
+# installer dropped in /root/.hermes/bin. anthropic[bedrock] brings boto3/botocore.
+RUN /root/.hermes/bin/uv pip install --python /usr/local/lib/hermes-agent/venv/bin/python 'anthropic[bedrock]>=0.39.0'
 
 # boto3 + awscurl for AgentCore MCP tool calls
 RUN pip3 install --quiet boto3 awscurl

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/connect.py
@@ -18,7 +18,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -35,7 +35,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -114,7 +115,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/run.sh
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/hermes/run.sh
@@ -76,9 +76,11 @@ set -- "${ARGS[@]}"
 
 MODEL_FLAG="-m ${MODEL} --provider bedrock"
 
+# hermes v0.19+ requires the `chat` subcommand; non-interactive one-shot is
+# `-q/--query` (the old top-level `--non-interactive PROMPT` form was removed).
 if [ $# -gt 0 ]; then
   PROMPT="$*"
-  exec hermes $MODEL_FLAG --non-interactive "$PROMPT"
+  exec hermes chat $MODEL_FLAG -q "$PROMPT"
 else
-  exec hermes $MODEL_FLAG
+  exec hermes chat $MODEL_FLAG
 fi

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/kiro/Dockerfile
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/kiro/Dockerfile
@@ -1,6 +1,9 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN dnf install -y --allowerasing git curl nodejs npm python3 python3-pip jq tar gzip unzip which findutils && dnf clean all
+# `hostname` is not in the amazonlinux:2023 base image; the Kiro CLI shells out
+# to it for session/host naming, which otherwise spams
+# "/bin/sh: hostname: command not found" in the terminal.
+RUN dnf install -y --allowerasing git curl nodejs npm python3 python3-pip jq tar gzip unzip which findutils hostname && dnf clean all
 
 RUN npm install -g typescript ts-node
 

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/kiro/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/kiro/connect.py
@@ -18,7 +18,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -35,7 +35,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -114,7 +115,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")

--- a/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/open-code/connect.py
+++ b/01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/open-code/connect.py
@@ -18,7 +18,7 @@ Usage:
     python connect.py --cmd "ls /mnt/s3files/"
 
 Environment:
-    AWS_REGION                                  (default: us-west-2)
+    AWS_REGION                                  (default: runtime ARN region)
 """
 
 import argparse
@@ -35,7 +35,8 @@ from bedrock_agentcore.runtime.shell import ShellChannel, ShellSession
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REGION = os.environ.get("AWS_REGION", "us-west-2")
+# Region defaults to the runtime ARN's region (set after config loads); env overrides.
+REGION = os.environ.get("AWS_REGION")
 
 
 def load_config() -> dict:
@@ -114,7 +115,9 @@ async def run(args):
     session_id = args.session or str(uuid.uuid4())
     shell_id = str(uuid.uuid4())
 
-    client = AgentCoreRuntimeClient(region=REGION)
+    # Derive region from the runtime ARN unless AWS_REGION was set explicitly.
+    region = REGION or runtime_arn.split(":")[3]
+    client = AgentCoreRuntimeClient(region=region)
 
     print("Connecting to AgentCore Runtime...")
     print(f"  Runtime: {runtime_arn}")


### PR DESCRIPTION
**Issue number**: _N/A — small bug-fix; happy to open a tracking issue if required by the issue-first policy._

### Concise description of the PR

```
Fixes to the 03-code-agents-competition-e2e coding agents, because the Hermes
container shipped non-functional and region was a hardcoded manual step.
```

Changes (all under `01-features/02-host-your-agent/01-runtime/04-coding-agents/03-code-agents-competition-e2e/coding_agents/`):

**Hermes container was broken** — four compounding issues, all fixed:
- Installer ran as the `agent` user, so the CLI landed in `~/.hermes/bin`, which the interactive login shell drops from PATH → `exec: hermes: not found`. Now installed as root (FHS layout, `/usr/local/bin/hermes`).
- The build swallowed installer failures with `|| true`; removed so a broken install fails the image build loudly.
- Installer needs `xz` to extract its Node.js tarball; added to `dnf install`.
- `hermes` v0.19 requires the `chat` subcommand and `-q` for one-shot mode (the old top-level `--non-interactive PROMPT` form was removed); `run.sh` updated.
- The Bedrock provider imports `anthropic[bedrock]` (with boto3/botocore), missing from Hermes's uv-managed venv; installed via the managed uv.

**Kiro** — installed the `hostname` package (Kiro CLI shells out to `hostname`, absent from the `amazonlinux:2023` base image, spamming `hostname: command not found`).

**Region auto-detection** (removes hardcoded `us-west-2`):
- `frontend/app.py` resolves region from `AWS_REGION` → `infra.config` → fallback.
- all six `connect.py` derive region from the runtime ARN (env still overrides).

### User experience

**Before:** Hermes pane errored with `exec: hermes: not found`; Kiro spammed `hostname: command not found`; running the frontend/CLI outside `us-west-2` required a manual `AWS_REGION=` prefix.

**After:** Hermes and Kiro run cleanly; region is auto-detected from the deployed infra / runtime ARN. Verified end-to-end in `us-east-1`: claude-code, hermes, open-code, and kiro all respond via Bedrock through the MCP gateway.

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented (inline comments explain each fix)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)