### PR TITLE
fix(memory): unblock three first-run failures in AgentCore Memory samples

### DIFF
--- a/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
+++ b/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
@@ -58,6 +58,9 @@ except _iam.exceptions.NoSuchEntityException:
             }
         ),
     )
+    # IAM is eventually consistent: CreateMemory below fails with "Please provide a role
+    # with a valid trust policy" if it runs before the new role has propagated.
+    time.sleep(10)
 SESSION_ID = f"sess-{int(time.time())}"
 
 control = boto3.client("bedrock-agentcore-control", region_name=REGION)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/README.md
@@ -16,7 +16,7 @@ A single memory resource can host any combination of these; records land in dist
 ## Run
 
 ```bash
-pip install boto3 bedrock-agentcore
+pip install -r ../requirements.txt   # the sdk surface needs bedrock-agentcore>=1.14
 python semantic.py boto3        # default — direct service calls
 python semantic.py sdk          # AgentCore MemoryClient helpers
 ```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/README.md
@@ -52,11 +52,11 @@ aws bedrock-agentcore-control create-memory \
         "semanticOverride": {
           "extraction": {
             "appendToPrompt": "Focus only on health-related facts.",
-            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0"
+            "modelId": "global.anthropic.claude-opus-4-6-v1"
           },
           "consolidation": {
             "appendToPrompt": "Prefer the more recent record on conflict.",
-            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0"
+            "modelId": "global.anthropic.claude-opus-4-6-v1"
           }
         }
       }

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
 MEMORY_ROLE_ARN = os.environ.get("MEMORY_EXECUTION_ROLE_ARN", "")
-MODEL_ID = os.getenv("OVERRIDE_MODEL_ID", "anthropic.claude-3-5-sonnet-20241022-v2:0")
+MODEL_ID = os.getenv("OVERRIDE_MODEL_ID", "global.anthropic.claude-opus-4-6-v1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
 EXTRACTION_WAIT_SECONDS = 75

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/README.md
@@ -11,7 +11,7 @@ Memory records can carry structured metadata (key → value) so retrieval can ap
 ## Run
 
 ```bash
-pip install boto3 bedrock-agentcore
+pip install -r ../requirements.txt   # indexedKeys needs boto3>=1.43.35
 python structured-metadata.py boto3   # default — direct service calls
 python structured-metadata.py sdk     # documents the SDK gap (no indexedKeys / batch / metadataFilters helpers)
 ```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/08-manage-extraction/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/08-manage-extraction/README.md
@@ -19,6 +19,7 @@ Events marked with `extractionMode="SKIP"` are stored in short-term memory norma
 ### Run
 
 ```bash
+pip install -r ../requirements.txt   # extractionMode needs boto3>=1.43.35
 python skip-extraction.py boto3   # direct service calls
 python skip-extraction.py sdk     # AgentCore MemoryClient helpers
 ```

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-strands-agent/02-custom-hook/healthcare-assistant-using-episodic/README.md
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/examples/multi-agent/with-strands-agent/02-custom-hook/healthcare-assistant-using-episodic/README.md
@@ -204,7 +204,7 @@ allergy_agent = Agent(
 Change the `model` parameter in agent creation:
 ```python
 Agent(
-    model="anthropic.claude-3-5-sonnet-20241022-v2:0",  # Different model
+    model="global.anthropic.claude-opus-4-6-v1",  # Different model
     system_prompt="...",
     tools=[...]
 )

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/requirements.txt
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/requirements.txt
@@ -1,0 +1,2 @@
+boto3>=1.43.35
+bedrock-agentcore>=1.14


### PR DESCRIPTION
## What

Three unrelated defects that each stop a memory sample on a clean first run. All were found by working through the `01-features/04-manage-context-of-your-agent/memory` READMEs as a participant would and executing every documented command against a live account.

| Commit | Defect | Fix |
|---|---|---|
| `ac3c65a7` | `04-quickstart-boto3.py` fails on first run only | Wait for IAM propagation |
| `46df4f29` | Three sub-features fail on older SDK/botocore | Pin dependency floors |
| `9604af5b` | `02-strategy-overrides` uses a retired model id | Update the id |

## 1. IAM propagation race (`00-getting-started`)

The quickstart creates its own execution role, then immediately calls `CreateMemory`:

```
ValidationException: Please provide a role with a valid trust policy
```

The trust policy is correct. IAM is eventually consistent, and `CreateMemory` runs before the new role has propagated. It only fails on the very first run, self-heals, then hides, so it lands on exactly the people least able to debug it: first-time users on step one.

Confirmed by retrying the same unchanged role ARN about 30s later, which succeeds. A `time.sleep(10)` sits inside the `except NoSuchEntityException` branch, so it costs nothing on the warm path where the role already exists.

## 2. Unpinned dependency floors (`02-long-term-memory`)

Three scripts call parameters that do not exist in older releases. Nothing in the tree declared a floor:

| Script | Error on an older environment |
|---|---|
| `06-record-metadata/structured-metadata.py boto3` | `Unknown parameter in input: "indexedKeys"` |
| `08-manage-extraction/skip-extraction.py boto3` | `Unknown parameter in input: "extractionMode"` |
| `01-built-in-strategies/semantic.py sdk` | `search_long_term_memories() got an unexpected keyword argument 'namespace'` |

The sample code is correct in all three cases. `structured-metadata.py` fails at 0 seconds on `indexedKeys`, which is item 3 of its own "What you learn" list. `skip-extraction.py` fails *after* `CreateMemory` succeeds, so it also leaks a billable resource.

Floors were established by bisecting published wheels rather than assumed, since the two botocore parameters land 34 patch releases apart:

```
botocore 1.43.0  -> CreateMemory has no indexedKeys
botocore 1.43.1  -> indexedKeys appears
botocore 1.43.34 -> CreateEvent has no extractionMode
botocore 1.43.35 -> extractionMode appears
bedrock-agentcore 1.9.0  -> namespace_prefix only
bedrock-agentcore 1.10.0 -> namespace= appears
bedrock-agentcore 1.11.0 -> no MemoryMetadataFilter.build_expression
bedrock-agentcore 1.12.0 -> build_expression appears
```

`boto3>=1.43.35` is the binding constraint, since it requires `botocore>=1.43.35` which also covers `indexedKeys`. This agrees with the existing `06-production-patterns/00-multi-region-replication` pin of `boto3>=1.43.36`, which also uses `extractionMode`. `bedrock-agentcore>=1.14` keeps the floor already documented in `semantic.py` and `04-namespaces/README.md` rather than lowering it to the measured 1.12 minimum.

Adds one `requirements.txt` at the `02-long-term-memory` level, since all three affected sub-features live under it, and points the three affected README run blocks at it.

## 3. Retired model id (`02-strategy-overrides`)

`strategies-with-overrides.py` defaulted to `anthropic.claude-3-5-sonnet-20241022-v2:0`, which no longer resolves:

```
anthropic.claude-3-5-sonnet-20241022-v2:0
  -> ResourceNotFoundException: This model version is not supported
global.anthropic.claude-opus-4-6-v1
  -> OK
```

This folder is the only place in the memory tree that lets you choose the extraction and consolidation model, so the retired id makes the lesson unreachable. `MODEL_ID` is a module-level constant read by `_override_strategy()`, which both surfaces call, so one default covers both. The `OVERRIDE_MODEL_ID` environment override is unchanged. Also updates the two documentation occurrences a participant would copy: the AWS CLI walkthrough in this folder's README, and the "Using Different Models" snippet in the episodic healthcare example.

## Testing

Live account, `us-east-1`, in a venv pinned to the exact proposed floors (`boto3==1.43.35`, `botocore==1.43.35`, `bedrock-agentcore==1.14.0`). All three previously failing runs now exit 0:

- `structured-metadata.py boto3` — EU metadata filter returned the expected record with `region`/`tier` metadata
- `skip-extraction.py boto3` — 12 events stored, 7 extracted, 4 correctly skipped
- `semantic.py sdk` — all three semantic queries returned scored records
- `strategies-with-overrides.py boto3` — extracted 4 medical facts and correctly suppressed the deliberate non-medical line

The IAM race was reproduced and fixed with a standalone script before patching the sample: fresh role fails, same ARN succeeds on retry.

`ruff check` and `ruff format --check` both pass on the two changed Python files, matching `.github/workflows/python-lint.yml`.

## Scope

Deliberately limited to `01-features/04-manage-context-of-your-agent`, the area that was actually executed and verified. The retired model id also appears in `05-authenticate-and-authorize`, `06-workshops`, an IaC doc table, and two `bedrock-models.yml` files. Those are left alone here since they were not run, and are worth a separate sweep.

Eight files, +12/-6.