### PR TITLE
fix(05-auth): correct misleading outbound README + harden trust policies and prereq IAM

### DIFF
--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_auth_code.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_auth_code.py
@@ -136,6 +136,7 @@ def create_execution_role(role_name: str) -> str:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_m2m.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_m2m.py
@@ -168,6 +168,7 @@ def create_gateway_role(iam: object, lambda_arn: str) -> str:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_id_inbound_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/02-inbound-auth-EntraID/entra_id_inbound_auth.py
@@ -140,6 +140,7 @@ def create_execution_role(role_name: str) -> str:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_gateway_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_gateway_auth.py
@@ -315,6 +315,7 @@ def create_gateway(lambda_arn: str) -> dict:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }
@@ -473,6 +474,7 @@ def deploy_agent(gateway_url: str) -> dict:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_inbound_auth.py
+++ b/01-features/05-authenticate-and-authorize/01-inbound-auth/03-inbound-auth-okta/okta_inbound_auth.py
@@ -118,6 +118,7 @@ def create_execution_role(role_name: str) -> str:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/02-outbound-auth/01-outbound-auth-openai/README.md
+++ b/01-features/05-authenticate-and-authorize/02-outbound-auth/01-outbound-auth-openai/README.md
@@ -59,6 +59,15 @@ and injects it into the function as a keyword argument. The LLM never sees the r
 
 ## Sample Prompts
 
+> **Note:** These prompts describe what the agent does **once deployed to
+> AgentCore Runtime**. The setup script (`outbound_auth_runtime.py`) only
+> creates the API-key credential provider, prints the required IAM
+> permissions, and saves the agent code for reference — it does **not**
+> invoke the agent or make a live OpenAI/Azure call. A placeholder key is
+> acceptable for this exercise. The teaching point is that
+> `@requires_api_key` fetches the secret from Secrets Manager at runtime
+> instead of hardcoding it in the agent.
+
 **Prompt**: `Hello, how are you?`
 **Expected Behavior**: Agent responds using Azure OpenAI GPT-4.1-mini
 

--- a/01-features/05-authenticate-and-authorize/04-entra-obo-mcp-runtime/entra_obo_mcp_runtime.py
+++ b/01-features/05-authenticate-and-authorize/04-entra-obo-mcp-runtime/entra_obo_mcp_runtime.py
@@ -87,6 +87,7 @@ def create_execution_role(role_name: str, extra_policies: list = None) -> str:
                     "Effect": "Allow",
                     "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
                     "Action": "sts:AssumeRole",
+                    "Condition": {"StringEquals": {"aws:SourceAccount": ACCOUNT_ID}},
                 }
             ],
         }

--- a/01-features/05-authenticate-and-authorize/auth0-multi-agent-obo/README.md
+++ b/01-features/05-authenticate-and-authorize/auth0-multi-agent-obo/README.md
@@ -121,15 +121,28 @@ Your AWS credentials need permissions to:
         {
             "Effect": "Allow",
             "Action": [
-                "bedrock-agentcore:*",
-                "ecr:*",
+                "bedrock-agentcore:CreateAgentRuntime",
+                "bedrock-agentcore:GetAgentRuntime",
+                "bedrock-agentcore:InvokeAgentRuntime",
+                "bedrock-agentcore:DeleteAgentRuntime",
+                "bedrock-agentcore:GetWorkloadAccessToken",
+                "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+                "bedrock-agentcore:GetResourceOauth2Token",
+                "bedrock-agentcore:CreateOauth2CredentialProvider",
+                "bedrock-agentcore:GetOauth2CredentialProvider",
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchCheckLayerAvailability",
                 "iam:CreateRole",
                 "iam:AttachRolePolicy",
                 "iam:PassRole",
                 "iam:GetRole",
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:CreateSecret",
-                "logs:*"
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
## Summary
- **P1:** Outbound OpenAI exercise README implies a live GPT-4.1-mini call, but the setup script only creates the credential provider and never invokes the agent. Adds a Note clarifying it demonstrates secure storage/injection, not a live outbound call.
- **P2:** 7 inbound/OBO trust policies allow `bedrock-agentcore.amazonaws.com` to assume the role without an `aws:SourceAccount` condition (confused-deputy risk). The Cognito reference exercise already guards this; aligns the siblings.
- **P3:** `auth0-multi-agent-obo` prereq policy grants `bedrock-agentcore:*`, `ecr:*`, `logs:*` on `Resource "*"`. Enumerates only the required actions to prevent destructive-verb exposure.

## Test plan
- [x] Ran `01-inbound-auth-cognito` end-to-end in Workshop Studio (us-west-2): negative test (no token → AccessDeniedException) and positive test (valid JWT → agent response) both pass
- [x] Ran `02-outbound-auth-01-openai`: confirmed script creates provider and prints IAM/usage but never invokes agent (root cause of P1)
- [x] `python -m py_compile` on all edited `.py` files passes
- [ ] Verify auth0 multi-agent-obo tutorial still works with enumerated IAM policy

## Files changed (8)
| File | Change |
|------|--------|
| `02-outbound-auth/01-outbound-auth-openai/README.md` | Add Note clarifying setup script does not make live call |
| `01-inbound-auth/02-inbound-auth-EntraID/entra_id_inbound_auth.py` | Add `aws:SourceAccount` condition |
| `01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_m2m.py` | Add `aws:SourceAccount` condition |
| `01-inbound-auth/02-inbound-auth-EntraID/entra_gateway_auth_code.py` | Add `aws:SourceAccount` condition |
| `01-inbound-auth/03-inbound-auth-okta/okta_inbound_auth.py` | Add `aws:SourceAccount` condition |
| `01-inbound-auth/03-inbound-auth-okta/okta_gateway_auth.py` | Add `aws:SourceAccount` condition (2 trust policies) |
| `04-entra-obo-mcp-runtime/entra_obo_mcp_runtime.py` | Add `aws:SourceAccount` condition |
| `auth0-multi-agent-obo/README.md` | Replace wildcard actions with enumerated set |

🤖 Generated with [Claude Code](https://claude.com/claude-code)