### PR TITLE
fix(01-harness): apply least-privilege to Harness execution role and trust policy

### DIFF
--- a/01-features/01-harness/utils/iam.py
+++ b/01-features/01-harness/utils/iam.py
@@ -7,16 +7,18 @@ from typing import Optional
 ROLE_NAME = "HarnessExecutionRole"
 POLICY_NAME = "HarnessExecutionPolicy"
 
-TRUST_POLICY = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {"Service": ["bedrock-agentcore.amazonaws.com"]},
-            "Action": "sts:AssumeRole",
-        }
-    ],
-}
+def _build_trust_policy():
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": ["bedrock-agentcore.amazonaws.com"]},
+                "Action": "sts:AssumeRole",
+                "Condition": {"StringEquals": {"aws:SourceAccount": get_account_id()}},
+            }
+        ],
+    }
 
 PERMISSIONS_POLICY = {
     "Version": "2012-10-17",
@@ -25,7 +27,10 @@ PERMISSIONS_POLICY = {
             "Sid": "BedrockInvokeModel",
             "Effect": "Allow",
             "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
-            "Resource": "*",
+            "Resource": [
+                "arn:aws:bedrock:*::foundation-model/*",
+                "arn:aws:bedrock:*:*:inference-profile/*",
+            ],
         },
         {
             "Sid": "ECRPull",
@@ -64,20 +69,29 @@ PERMISSIONS_POLICY = {
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
             ],
-            "Resource": "*",
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*",
+                "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+            ],
         },
         {
             "Sid": "AgentCore",
             "Effect": "Allow",
             "Action": [
-                "bedrock-agentcore:*Memory*",
-                "bedrock-agentcore:*Browser*",
-                "bedrock-agentcore:*Gateway*",
-                "bedrock-agentcore:*CodeInterpreter*",
                 "bedrock-agentcore:RetrieveMemoryRecords",
                 "bedrock-agentcore:CreateEvent",
                 "bedrock-agentcore:ListEvents",
                 "bedrock-agentcore:GetEvent",
+                "bedrock-agentcore:StartBrowserSession",
+                "bedrock-agentcore:StopBrowserSession",
+                "bedrock-agentcore:GetBrowserSession",
+                "bedrock-agentcore:ListBrowserSessions",
+                "bedrock-agentcore:StartCodeInterpreterSession",
+                "bedrock-agentcore:StopCodeInterpreterSession",
+                "bedrock-agentcore:GetCodeInterpreterSession",
+                "bedrock-agentcore:ListCodeInterpreterSessions",
+                "bedrock-agentcore:InvokeCodeInterpreter",
+                "bedrock-agentcore:InvokeGateway",
             ],
             "Resource": "*",
         },
@@ -112,7 +126,7 @@ def create_harness_role(role_name: str = ROLE_NAME) -> Optional[str]:
 
     resp = iam.create_role(
         RoleName=role_name,
-        AssumeRolePolicyDocument=json.dumps(TRUST_POLICY),
+        AssumeRolePolicyDocument=json.dumps(_build_trust_policy()),
         Description="Execution role for Amazon Bedrock AgentCore Harness",
     )
     arn = resp["Role"]["Arn"]

--- a/01-features/02-host-your-agent/01-runtime/01-hosting-agents/07-typescript-agents/07-direct-code-deploy-typescript/iam.sh
+++ b/01-features/02-host-your-agent/01-runtime/01-hosting-agents/07-typescript-agents/07-direct-code-deploy-typescript/iam.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROLE_NAME="TypescriptExecutionRole"
 POLICY_NAME="TypescriptExecutionPolicy"
 
-TRUST_POLICY='{
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+TRUST_POLICY=$(cat <<EOTRUST
+{
   "Version": "2012-10-17",
   "Statement": [
     {
@@ -12,10 +15,17 @@ TRUST_POLICY='{
       "Principal": {
         "Service": "bedrock-agentcore.amazonaws.com"
       },
-      "Action": "sts:AssumeRole"
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "$ACCOUNT_ID"
+        }
+      }
     }
   ]
-}'
+}
+EOTRUST
+)
 
 PERMISSIONS_POLICY='{
   "Version": "2012-10-17",
@@ -24,7 +34,7 @@ PERMISSIONS_POLICY='{
       "Sid": "BedrockInvokeModel",
       "Effect": "Allow",
       "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
-      "Resource": "*"
+      "Resource": ["arn:aws:bedrock:*::foundation-model/*", "arn:aws:bedrock:*:*:inference-profile/*"]
     },
     {
       "Sid": "ECRPull",
@@ -59,20 +69,26 @@ PERMISSIONS_POLICY='{
       "Sid": "CloudWatchLogs",
       "Effect": "Allow",
       "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-      "Resource": "*"
+      "Resource": ["arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*", "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"]
     },
     {
       "Sid": "AgentCore",
       "Effect": "Allow",
       "Action": [
-        "bedrock-agentcore:*Memory*",
-        "bedrock-agentcore:*Browser*",
-        "bedrock-agentcore:*Gateway*",
-        "bedrock-agentcore:*CodeInterpreter*",
         "bedrock-agentcore:RetrieveMemoryRecords",
         "bedrock-agentcore:CreateEvent",
         "bedrock-agentcore:ListEvents",
-        "bedrock-agentcore:GetEvent"
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:StartBrowserSession",
+        "bedrock-agentcore:StopBrowserSession",
+        "bedrock-agentcore:GetBrowserSession",
+        "bedrock-agentcore:ListBrowserSessions",
+        "bedrock-agentcore:StartCodeInterpreterSession",
+        "bedrock-agentcore:StopCodeInterpreterSession",
+        "bedrock-agentcore:GetCodeInterpreterSession",
+        "bedrock-agentcore:ListCodeInterpreterSessions",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+        "bedrock-agentcore:InvokeGateway"
       ],
       "Resource": "*"
     },

--- a/06-workshops/01-AgentCore-runtime/01-hosting-agent/07-direct-code-deploy-typescript/iam.sh
+++ b/06-workshops/01-AgentCore-runtime/01-hosting-agent/07-direct-code-deploy-typescript/iam.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROLE_NAME="TypescriptExecutionRole"
 POLICY_NAME="TypescriptExecutionPolicy"
 
-TRUST_POLICY='{
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+TRUST_POLICY=$(cat <<EOTRUST
+{
   "Version": "2012-10-17",
   "Statement": [
     {
@@ -12,10 +15,17 @@ TRUST_POLICY='{
       "Principal": {
         "Service": "bedrock-agentcore.amazonaws.com"
       },
-      "Action": "sts:AssumeRole"
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "$ACCOUNT_ID"
+        }
+      }
     }
   ]
-}'
+}
+EOTRUST
+)
 
 PERMISSIONS_POLICY='{
   "Version": "2012-10-17",
@@ -24,7 +34,7 @@ PERMISSIONS_POLICY='{
       "Sid": "BedrockInvokeModel",
       "Effect": "Allow",
       "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
-      "Resource": "*"
+      "Resource": ["arn:aws:bedrock:*::foundation-model/*", "arn:aws:bedrock:*:*:inference-profile/*"]
     },
     {
       "Sid": "ECRPull",
@@ -59,20 +69,26 @@ PERMISSIONS_POLICY='{
       "Sid": "CloudWatchLogs",
       "Effect": "Allow",
       "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-      "Resource": "*"
+      "Resource": ["arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*", "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"]
     },
     {
       "Sid": "AgentCore",
       "Effect": "Allow",
       "Action": [
-        "bedrock-agentcore:*Memory*",
-        "bedrock-agentcore:*Browser*",
-        "bedrock-agentcore:*Gateway*",
-        "bedrock-agentcore:*CodeInterpreter*",
         "bedrock-agentcore:RetrieveMemoryRecords",
         "bedrock-agentcore:CreateEvent",
         "bedrock-agentcore:ListEvents",
-        "bedrock-agentcore:GetEvent"
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:StartBrowserSession",
+        "bedrock-agentcore:StopBrowserSession",
+        "bedrock-agentcore:GetBrowserSession",
+        "bedrock-agentcore:ListBrowserSessions",
+        "bedrock-agentcore:StartCodeInterpreterSession",
+        "bedrock-agentcore:StopCodeInterpreterSession",
+        "bedrock-agentcore:GetCodeInterpreterSession",
+        "bedrock-agentcore:ListCodeInterpreterSessions",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+        "bedrock-agentcore:InvokeGateway"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Summary
- **H1:** `InvokeModel` and `logs` actions used `Resource: "*"`. Scoped `InvokeModel` to `foundation-model/*` + `inference-profile/*` ARNs; logs to `/aws/bedrock-agentcore/runtimes/*` prefix.
- **H2:** AgentCore actions used wildcard patterns (`*Memory*`, `*Browser*`, `*Gateway*`, `*CodeInterpreter*`) that silently include destructive verbs (Delete*, Stop*, Update*). Enumerated only the specific actions the harness samples use.
- **H3:** Trust policy for `bedrock-agentcore.amazonaws.com` lacked an `aws:SourceAccount` condition (confused-deputy risk). Added it, matching the getting-started `deploy.py` reference.

Applied to `utils/iam.py` and its TypeScript twin `iam.sh` (both the features and workshop copies).

## Files changed (3)
| File | Change |
|------|--------|
| `01-features/01-harness/utils/iam.py` | All three fixes (H1+H2+H3) |
| `01-features/02-host-your-agent/.../07-direct-code-deploy-typescript/iam.sh` | Same fixes in shell |
| `06-workshops/01-AgentCore-runtime/.../07-direct-code-deploy-typescript/iam.sh` | Synced copy |

## Test plan
- [x] `python -m py_compile utils/iam.py` passes
- [x] `bash -n iam.sh` passes
- [ ] Run harness getting-started sample end-to-end with tightened role — verify no AccessDenied
- [ ] Verify Memory, Browser, CodeInterpreter, and Gateway samples still work with enumerated actions

## Notes
- ECR auth-token and `sts:GetServiceBearerToken` legitimately require `Resource: "*"` (APIs don't support resource scoping) — left as-is.
- `Resource: "*"` retained on the AgentCore statement as a minimal first step; scope to specific resource ARNs in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)