### PR TITLE
docs(web-search): add common pitfalls to prevent import confusion

### DIFF
--- a/01-features/03-connect-your-agent-to-anything/03-web-search/README.md
+++ b/01-features/03-connect-your-agent-to-anything/03-web-search/README.md
@@ -104,6 +104,17 @@ python 03-langchain-agent/web_search_langchain.py
 python 01-raw-mcp/cleanup.py --gateway-id <id> --user-pool-id <id> --role-name <name>
 ```
 
+## Common Pitfalls
+
+| Mistake | Why it fails | Correct approach |
+|:--------|:-------------|:-----------------|
+| `from strands.tools.web_search import web_search` | No such module exists in `strands-agents` | Use the MCP-based Gateway approach shown in this sample |
+| `from strands_tools.web_search import web_search` | `strands-agents-tools` does not include a web search tool | Web search is a Gateway connector, not a local tool |
+| `from strands_tools.http_request import http_request; http_request(...)` | `http_request` is a Strands tool — it must be passed to an `Agent`, not called directly | Pass it in the `tools=[]` list and let the agent invoke it |
+| Using `connectorId: "web-search"` outside supported regions | The Web Search connector is region-limited (see availability docs) | Deploy the Gateway in a supported region (e.g., us-east-1) |
+
+> **Key concept:** There is no built-in `web_search` function you can import and call. Web search in AgentCore is an MCP-compliant connector exposed through a Gateway. Your agent discovers it via `tools/list` and invokes it via `tools/call` — see the tutorials above.
+
 ## Documentation
 
 - [Web Search Tool connector](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-target-connector-web-search-tool.html)

--- a/01-features/03-connect-your-agent-to-anything/README.md
+++ b/01-features/03-connect-your-agent-to-anything/README.md
@@ -50,6 +50,7 @@ with browser_session("us-west-2") as client:
 - **What it is**: A fully managed web search connector exposed through AgentCore gateway via MCP
 - **Use it for**: Agents that need real-time information — current events, latest releases, fact-checking, competitive intelligence
 - **Entry point**: Create a Gateway with `connectorId: "web-search"`, then connect any MCP client
+- **Not a local import**: There is no `from strands.tools.web_search import web_search` or `from strands_tools import web_search` — web search requires Gateway setup
 
 ```python
 from strands.tools.mcp.mcp_client import MCPClient


### PR DESCRIPTION
## Summary
- Adds a "Common Pitfalls" table to the web search README documenting frequent mistakes (non-existent imports like `strands.tools.web_search`, calling tools directly instead of passing to Agent, region availability)
- Adds a clarifying note to the parent README that web search is not a local import

## Motivation
Developers and coding agents frequently attempt `from strands.tools.web_search import web_search` or similar non-existent imports. This leads to `ModuleNotFoundError` and confusion about how web search actually works in AgentCore (via Gateway + MCP, not a local package).

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)