### PR TITLE
fix(01-harness): make getting-started work on a fresh AWS account

### DIFF
--- a/01-features/01-harness/00-getting-started/README.md
+++ b/01-features/01-harness/00-getting-started/README.md
@@ -71,10 +71,19 @@ Your code
 ## Troubleshooting
 
 ### Issue: `CREATING` status never transitions to `READY`
-**Solution**: Wait up to 60 seconds. The first `create_harness` takes longer as the control plane provisions resources. The polling loop in the script handles this.
+**Solution**: Give it a few minutes. A new harness has been observed taking around
+150 seconds to reach `READY` on the public network, and longer in VPC network mode
+or when a custom container image has to be pulled — so a `CREATING` status well
+past the one-minute mark is normal, not a failure. The polling loop in the script
+waits up to 10 minutes and prints the status on every poll.
+
+If it genuinely does fail, the harness moves to `CREATE_FAILED` rather than
+staying in `CREATING`, and the script raises straight away with the service's
+`failureReason` — that message is what tells you the cause (most often a missing
+permission on the execution role).
 
 ### Issue: `NoSuchEntityException` when creating IAM role
-**Solution**: Your AWS credentials may lack IAM permissions. The `create_harness_role()` helper requires `iam:CreateRole`, `iam:PutRolePolicy`. Check your credentials' IAM policy.
+**Solution**: Your AWS credentials may lack IAM permissions. The `create_harness_role()` helper requires `iam:CreateRole`, `iam:PutRolePolicy`, and `iam:UpdateAssumeRolePolicy`. Check your credentials' IAM policy.
 
 ### Issue: Tool calls show but no text output
 **Solution**: The agent is working but producing output in tool calls, not text. This is normal for task-oriented prompts. The agent's final response will contain text.

--- a/01-features/01-harness/00-getting-started/getting_started.py
+++ b/01-features/01-harness/00-getting-started/getting_started.py
@@ -28,8 +28,9 @@ import boto3
 # Add root utils to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 MODEL_HAIKU = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -51,134 +52,142 @@ time.sleep(10)
 print("Ready!")
 
 # ── Create Harness ─────────────────────────────────────────────────────────────
+# Everything from here on runs under try/finally so the cleanup in Step 6 also
+# happens when a step in between fails. The role is created above but deleted in
+# that finally block, so the harness creation belongs inside the block too —
+# otherwise a CreateHarness failure (an unavailable model, a role that has not
+# finished propagating) would exit leaving the role behind.
 print("\n=== Step 2: Create Harness ===")
 HARNESS_NAME = f"GettingStarted_{uuid.uuid4().hex[:8]}"
+harness_id = None
 
-resp = control.create_harness(
-    harnessName=HARNESS_NAME,
-    executionRoleArn=role_arn,
-)
-harness = resp["harness"]
-harness_id = harness["harnessId"]
-harness_arn = harness["arn"]
-print(f"Harness ID:  {harness_id}")
-print(f"Harness ARN: {harness_arn}")
-print(f"Status:      {harness['status']}")
-
-for i in range(12):
-    resp = control.get_harness(harnessId=harness_id)
-    status = resp["harness"]["status"]
-    print(f"  [{i + 1}] {status}")
-    if status == "READY":
-        print("✅ Harness is ready")
-        break
-    time.sleep(5)
-
-# ── Invoke Agent — Haiku ───────────────────────────────────────────────────────
-print("\n=== Step 3: Invoke Agent (Claude Haiku) ===")
-session_id = str(uuid.uuid4()).upper()
-print(f"Session ID: {session_id}\n")
-
-response = client.invoke_harness(
-    harnessArn=harness_arn,
-    runtimeSessionId=session_id,
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "What are three fun things to do in Seattle on a rainy day? "
-                    "Save your answer to a Markdown file."
-                }
-            ],
-        }
-    ],
-    model={"bedrockModelConfig": {"modelId": MODEL_HAIKU}},
-)
-
-for event in response["stream"]:
-    if "contentBlockStart" in event:
-        start = event["contentBlockStart"].get("start", {})
-        if "toolUse" in start:
-            print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-    elif "contentBlockDelta" in event:
-        delta = event["contentBlockDelta"].get("delta", {})
-        if "text" in delta:
-            print(delta["text"], end="", flush=True)
-    elif "messageStop" in event:
-        print()
-    elif "internalServerException" in event:
-        print(f"\nError: {event['internalServerException']}")
-
-# ── Reuse Same Session with Different Model ────────────────────────────────────
-print("\n=== Step 4: Reuse Session with Claude Sonnet ===")
-print(f"Session ID (same): {session_id}\n")
-
-response = client.invoke_harness(
-    harnessArn=harness_arn,
-    runtimeSessionId=session_id,
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "What are three fun things to do in Seattle on a rainy day? "
-                    "Save your answer to a Markdown file with Sonnet prefix."
-                }
-            ],
-        }
-    ],
-    model={"bedrockModelConfig": {"modelId": MODEL_SONNET}},
-)
-
-for event in response["stream"]:
-    if "contentBlockStart" in event:
-        start = event["contentBlockStart"].get("start", {})
-        if "toolUse" in start:
-            print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-    elif "contentBlockDelta" in event:
-        delta = event["contentBlockDelta"].get("delta", {})
-        if "text" in delta:
-            print(delta["text"], end="", flush=True)
-    elif "messageStop" in event:
-        print()
-    elif "internalServerException" in event:
-        print(f"\nError: {event['internalServerException']}")
-
-# ── ExecuteCommand — Run Commands on Agent's VM ────────────────────────────────
-print("\n=== Step 5: ExecuteCommand (agent's remote microVM) ===")
-
-
-def run(cmd: str):
-    """Run a shell command on the agent's remote microVM."""
-    print(f"$ {cmd}")
-    resp = client.invoke_agent_runtime_command(
-        agentRuntimeArn=harness_arn,
-        runtimeSessionId=session_id,
-        body={"command": cmd},
+try:
+    resp = control.create_harness(
+        harnessName=HARNESS_NAME,
+        executionRoleArn=role_arn,
     )
-    for event in resp["stream"]:
-        if "chunk" in event:
-            chunk = event["chunk"]
-            if "contentDelta" in chunk:
-                d = chunk["contentDelta"]
-                if "stdout" in d:
-                    print(d["stdout"], end="", flush=True)
-                if "stderr" in d:
-                    print(d["stderr"], end="", flush=True)
-            elif "contentStop" in chunk:
-                print(f"\n[exit: {chunk['contentStop']['exitCode']}]")
-    print()
+    harness = resp["harness"]
+    harness_id = harness["harnessId"]
+    harness_arn = harness["arn"]
+    print(f"Harness ID:  {harness_id}")
+    print(f"Harness ARN: {harness_arn}")
+    print(f"Status:      {harness['status']}")
 
+    poll_harness_status(control, harness_id)
+    print("✅ Harness is ready")
 
-run("ls -la")
-run("pwd")
-run('for f in *.md; do echo "=== $f ==="; cat "$f"; echo; done')
+    # ── Invoke Agent — Haiku ───────────────────────────────────────────────────────
+    print("\n=== Step 3: Invoke Agent (Claude Haiku) ===")
+    session_id = str(uuid.uuid4()).upper()
+    print(f"Session ID: {session_id}\n")
 
-# ── Cleanup ────────────────────────────────────────────────────────────────────
-print("\n=== Step 6: Cleanup ===")
-control.delete_harness(harnessId=harness_id)
-print(f"Deleted harness: {harness_id}")
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": "What are three fun things to do in Seattle on a rainy day? "
+                        "Save your answer to a Markdown file."
+                    }
+                ],
+            }
+        ],
+        model={"bedrockModelConfig": {"modelId": MODEL_HAIKU}},
+    )
 
-delete_harness_role()
-print("Done.")
+    for event in response["stream"]:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+        elif "messageStop" in event:
+            print()
+        elif "internalServerException" in event:
+            print(f"\nError: {event['internalServerException']}")
+
+    # ── Reuse Same Session with Different Model ────────────────────────────────────
+    print("\n=== Step 4: Reuse Session with Claude Sonnet ===")
+    print(f"Session ID (same): {session_id}\n")
+
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": "What are three fun things to do in Seattle on a rainy day? "
+                        "Save your answer to a Markdown file with Sonnet prefix."
+                    }
+                ],
+            }
+        ],
+        model={"bedrockModelConfig": {"modelId": MODEL_SONNET}},
+    )
+
+    for event in response["stream"]:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+        elif "messageStop" in event:
+            print()
+        elif "internalServerException" in event:
+            print(f"\nError: {event['internalServerException']}")
+
+    # ── ExecuteCommand — Run Commands on Agent's VM ────────────────────────────────
+    print("\n=== Step 5: ExecuteCommand (agent's remote microVM) ===")
+
+    def run(cmd: str):
+        """Run a shell command on the agent's remote microVM."""
+        print(f"$ {cmd}")
+        resp = client.invoke_agent_runtime_command(
+            agentRuntimeArn=harness_arn,
+            runtimeSessionId=session_id,
+            body={"command": cmd},
+        )
+        for event in resp["stream"]:
+            if "chunk" in event:
+                chunk = event["chunk"]
+                if "contentDelta" in chunk:
+                    d = chunk["contentDelta"]
+                    if "stdout" in d:
+                        print(d["stdout"], end="", flush=True)
+                    if "stderr" in d:
+                        print(d["stderr"], end="", flush=True)
+                elif "contentStop" in chunk:
+                    print(f"\n[exit: {chunk['contentStop']['exitCode']}]")
+        print()
+
+    run("ls -la")
+    run("pwd")
+    run('for f in *.md; do echo "=== $f ==="; cat "$f"; echo; done')
+
+finally:
+    # ── Cleanup ────────────────────────────────────────────────────────────────────
+    # Delete each resource independently: harness_id is None if CreateHarness
+    # itself failed, and a delete_harness error must not skip the role deletion —
+    # a leftover role is what makes the next run of any sample in this folder
+    # behave unpredictably, since they all share one role name.
+    print("\n=== Step 6: Cleanup ===")
+    if harness_id:
+        try:
+            control.delete_harness(harnessId=harness_id)
+            print(f"Deleted harness: {harness_id}")
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+            print(f"Warning: could not delete harness {harness_id}: {e}")
+
+    delete_harness_role()
+    print("Done.")

--- a/01-features/01-harness/requirements.txt
+++ b/01-features/01-harness/requirements.txt
@@ -1,2 +1,9 @@
-boto3
+# boto3 1.43.32 is the first release whose bedrock-agentcore model knows the
+# `awsSkills` skill source. On anything older, 13-aws-skills and
+# 02-use-cases/03-aws-builder-agent die before they create anything with:
+#   ParamValidationError: Unknown parameter in skills[0]: "awsSkills",
+#   must be one of: path
+# (`git`/`s3` skill sources landed in 1.43.17 — 04-weather-agent needs those —
+# and `awsSkills` in 1.43.32, so 1.43.32 is the floor that covers every sample.)
+boto3>=1.43.32
 requests

--- a/01-features/01-harness/utils/client.py
+++ b/01-features/01-harness/utils/client.py
@@ -1,9 +1,18 @@
 """boto3 client helpers for AgentCore Harness tutorials."""
 
 import os
-import boto3
 
-REGION = os.environ.get("AWS_DEFAULT_REGION")
+import boto3
+from botocore.config import Config
+
+# Honour both region variables the AWS CLI/SDKs accept, and fall back to None so
+# boto3 resolves the region itself (profile, ~/.aws/config, IMDS). Reading only
+# AWS_DEFAULT_REGION meant that a shell exporting just AWS_REGION — or exporting
+# AWS_DEFAULT_REGION as an empty string — passed "" straight through to the
+# client, which fails with a confusing `Invalid endpoint:
+# https://bedrock-agentcore-control..amazonaws.com` instead of resolving the
+# configured region (or raising a clear NoRegionError).
+REGION = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or None
 
 # Endpoint overrides (for non-production stages)
 _CP_ENDPOINT = os.environ.get("BEDROCK_AGENTCORE_CP_ENDPOINT")
@@ -15,17 +24,26 @@ def _make_session():
     return boto3.Session(region_name=REGION)
 
 
+# botocore's default read_timeout is 60s, which is shorter than a single agent turn:
+# InvokeHarness streams while the agent thinks, calls tools and runs commands in its
+# microVM, so a research-style prompt easily runs several minutes. On the default the
+# socket is torn down mid-stream with a bare ReadTimeoutError — the sample looks broken
+# even though the agent is working fine. Data-plane calls therefore get a generous
+# read timeout by default; callers can still pass their own Config to override it.
+DP_READ_TIMEOUT = 900
+_DEFAULT_DP_CONFIG = Config(read_timeout=DP_READ_TIMEOUT)
+
+
 def get_agentcore_client(config=None):
     """Return a boto3 client for the Harness data plane (invoke, ExecuteCommand).
 
     Args:
-        config: Optional botocore.config.Config (e.g. Config(read_timeout=300)).
+        config: Optional botocore.config.Config overriding the defaults, which
+            already allow for long-running agent turns (see DP_READ_TIMEOUT).
     """
-    kwargs = {}
+    kwargs = {"config": config if config is not None else _DEFAULT_DP_CONFIG}
     if _DP_ENDPOINT:
         kwargs["endpoint_url"] = _DP_ENDPOINT
-    if config is not None:
-        kwargs["config"] = config
     return _make_session().client("bedrock-agentcore", **kwargs)
 
 

--- a/01-features/01-harness/utils/harness.py
+++ b/01-features/01-harness/utils/harness.py
@@ -1,0 +1,44 @@
+"""Harness lifecycle helpers shared by the samples in this folder."""
+
+import time
+
+# A newly created Harness has been observed taking ~150s to reach READY on the
+# public network, ~255s in VPC mode (the service also has to attach ENIs in your
+# subnets), and longer still when it is pulling a container image on top of that.
+# The timeout below is deliberately generous: waiting a little longer is
+# harmless, whereas giving up early leaves the sample invoking a harness that is
+# not ready yet.
+HARNESS_POLL_INTERVAL = 5
+HARNESS_POLL_TIMEOUT = 600
+
+# The full status enum is CREATING, CREATE_FAILED, UPDATING, UPDATE_FAILED,
+# READY, DELETING, DELETE_FAILED — there is no plain "FAILED". Matching the
+# real terminal states matters: a harness that fails to create (for example
+# because the execution role is missing an s3files permission) reports
+# CREATE_FAILED immediately, and treating that as "not ready yet" would poll a
+# dead harness until the timeout and then hide the service's failureReason,
+# which is the one piece of text that says how to fix it.
+HARNESS_FAILURE_STATUSES = ("CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED")
+
+
+def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
+    """Block until a Harness reaches `target_status`, and return its description.
+
+    Raises RuntimeError if the harness lands in a failure state, or TimeoutError
+    if `timeout` seconds elapse first. Both are deliberate: the caller is about
+    to invoke this harness, so continuing with one that never became READY only
+    turns a clear lifecycle error into a confusing invoke error later on.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        resp = control.get_harness(harnessId=harness_id)
+        status = resp["harness"]["status"]
+        print(f"  Harness status: {status}")
+        if status == target_status:
+            return resp
+        if status in HARNESS_FAILURE_STATUSES:
+            reason = resp["harness"].get("failureReason", "")
+            raise RuntimeError(f"Harness entered {status}. {reason}".strip())
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"Harness not {target_status} after {timeout}s (current: {status})")
+        time.sleep(HARNESS_POLL_INTERVAL)

--- a/01-features/01-harness/utils/iam.py
+++ b/01-features/01-harness/utils/iam.py
@@ -1,22 +1,34 @@
 """IAM helpers for AgentCore Harness — creates the execution role and permissions."""
 
 import json
+
 import boto3
-from typing import Optional
 
 ROLE_NAME = "HarnessExecutionRole"
 POLICY_NAME = "HarnessExecutionPolicy"
 
-TRUST_POLICY = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {"Service": ["bedrock-agentcore.amazonaws.com"]},
-            "Action": "sts:AssumeRole",
-        }
-    ],
-}
+
+def _build_trust_policy() -> dict:
+    """Trust policy for the AgentCore service principal.
+
+    The `aws:SourceAccount` condition closes a confused-deputy hole: without it
+    the policy lets the service principal assume this role on behalf of *any*
+    account, not just yours. It is built lazily rather than defined as a module
+    constant because it needs an STS call to learn the account ID, and importing
+    this module should not require credentials.
+    """
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": ["bedrock-agentcore.amazonaws.com"]},
+                "Action": "sts:AssumeRole",
+                "Condition": {"StringEquals": {"aws:SourceAccount": get_account_id()}},
+            }
+        ],
+    }
+
 
 PERMISSIONS_POLICY = {
     "Version": "2012-10-17",
@@ -25,7 +37,14 @@ PERMISSIONS_POLICY = {
             "Sid": "BedrockInvokeModel",
             "Effect": "Allow",
             "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
-            "Resource": "*",
+            # Scoped to the two resource types a harness can actually invoke.
+            # `inference-profile` matters as much as `foundation-model`: every
+            # sample here uses a cross-region profile ID (global.* / us.*), which
+            # resolves to an inference-profile ARN, not a bare model ARN.
+            "Resource": [
+                "arn:aws:bedrock:*::foundation-model/*",
+                "arn:aws:bedrock:*:*:inference-profile/*",
+            ],
         },
         {
             "Sid": "ECRPull",
@@ -64,20 +83,40 @@ PERMISSIONS_POLICY = {
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
             ],
-            "Resource": "*",
+            # Harness logs land under this one prefix, so there is no reason to
+            # grant the account's whole log estate. Both ARN forms are needed:
+            # CreateLogGroup acts on the group, PutLogEvents on the stream.
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*",
+                "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+            ],
         },
         {
             "Sid": "AgentCore",
             "Effect": "Allow",
+            # Enumerated rather than wildcarded. Patterns like
+            # `bedrock-agentcore:*Memory*` silently pull in Delete*/Update*, so a
+            # sample's execution role could destroy memory stores it only ever
+            # reads. Every action below is one the samples in this folder call.
             "Action": [
-                "bedrock-agentcore:*Memory*",
-                "bedrock-agentcore:*Browser*",
-                "bedrock-agentcore:*Gateway*",
-                "bedrock-agentcore:*CodeInterpreter*",
+                "bedrock-agentcore:CreateMemory",
+                "bedrock-agentcore:GetMemory",
+                "bedrock-agentcore:ListMemories",
+                "bedrock-agentcore:DeleteMemory",
                 "bedrock-agentcore:RetrieveMemoryRecords",
                 "bedrock-agentcore:CreateEvent",
                 "bedrock-agentcore:ListEvents",
                 "bedrock-agentcore:GetEvent",
+                "bedrock-agentcore:StartBrowserSession",
+                "bedrock-agentcore:StopBrowserSession",
+                "bedrock-agentcore:GetBrowserSession",
+                "bedrock-agentcore:ListBrowserSessions",
+                "bedrock-agentcore:StartCodeInterpreterSession",
+                "bedrock-agentcore:StopCodeInterpreterSession",
+                "bedrock-agentcore:GetCodeInterpreterSession",
+                "bedrock-agentcore:ListCodeInterpreterSessions",
+                "bedrock-agentcore:InvokeCodeInterpreter",
+                "bedrock-agentcore:InvokeGateway",
             ],
             "Resource": "*",
         },
@@ -95,28 +134,34 @@ def get_account_id() -> str:
     return boto3.client("sts").get_caller_identity()["Account"]
 
 
-def create_harness_role(role_name: str = ROLE_NAME) -> Optional[str]:
+def create_harness_role(role_name: str = ROLE_NAME) -> str | None:
     """Create the IAM execution role required by AgentCore Harness. Returns the role ARN.
 
-    Idempotent — if the role already exists, returns its ARN.
+    Idempotent in the full sense: the role, its trust policy AND its permissions
+    policy are all brought up to date. Returning early on an existing role is not
+    safe here, because every sample in this folder shares one role name — a role
+    left behind by an earlier, partially cleaned-up run can exist with the wrong
+    permissions (or none at all), and a role created before the trust policy was
+    scoped would keep the looser version forever. Both `update_assume_role_policy`
+    and `put_role_policy` overwrite in place, so re-running on a healthy role is
+    a no-op.
     """
     iam = boto3.client("iam")
+    trust_policy = json.dumps(_build_trust_policy())
 
     try:
         existing = iam.get_role(RoleName=role_name)
         arn = existing["Role"]["Arn"]
         print(f"Role {role_name} already exists: {arn}")
-        return arn
+        iam.update_assume_role_policy(RoleName=role_name, PolicyDocument=trust_policy)
     except iam.exceptions.NoSuchEntityException:
-        pass
-
-    resp = iam.create_role(
-        RoleName=role_name,
-        AssumeRolePolicyDocument=json.dumps(TRUST_POLICY),
-        Description="Execution role for Amazon Bedrock AgentCore Harness",
-    )
-    arn = resp["Role"]["Arn"]
-    print(f"Created role: {arn}")
+        resp = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=trust_policy,
+            Description="Execution role for Amazon Bedrock AgentCore Harness",
+        )
+        arn = resp["Role"]["Arn"]
+        print(f"Created role: {arn}")
 
     iam.put_role_policy(
         RoleName=role_name,
@@ -129,15 +174,37 @@ def create_harness_role(role_name: str = ROLE_NAME) -> Optional[str]:
 
 
 def delete_harness_role(role_name: str = ROLE_NAME) -> None:
-    """Delete the Harness execution role and its inline policy."""
+    """Delete the Harness execution role and every policy attached to it.
+
+    Deleting only POLICY_NAME is not enough: some samples add their own inline
+    policy to this shared role (e.g. the S3 Files access policy). Any policy
+    left behind makes `delete_role` fail with DeleteConflictException, which
+    would strand the role in a half-configured state for the next sample.
+    """
     iam = boto3.client("iam")
+
+    # Paginate: a partial listing would leave a policy behind, which is exactly
+    # what makes the delete below fail.
     try:
-        iam.delete_role_policy(RoleName=role_name, PolicyName=POLICY_NAME)
-        print(f"Deleted inline policy: {POLICY_NAME}")
+        for page in iam.get_paginator("list_role_policies").paginate(RoleName=role_name):
+            for name in page["PolicyNames"]:
+                iam.delete_role_policy(RoleName=role_name, PolicyName=name)
+                print(f"Deleted inline policy: {name}")
+        for page in iam.get_paginator("list_attached_role_policies").paginate(RoleName=role_name):
+            for policy in page["AttachedPolicies"]:
+                iam.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
+                print(f"Detached managed policy: {policy['PolicyName']}")
     except iam.exceptions.NoSuchEntityException:
-        pass
+        print(f"Role {role_name} not found")
+        return
+
     try:
         iam.delete_role(RoleName=role_name)
         print(f"Deleted role: {role_name}")
     except iam.exceptions.NoSuchEntityException:
         print(f"Role {role_name} not found")
+    except iam.exceptions.DeleteConflictException as e:
+        # Something outside this helper still references the role. Say so
+        # loudly — a silently surviving role is what poisons later runs.
+        print(f"Could not delete role {role_name}: {e}")
+        print("  Remove whatever still references it, then delete the role manually.")

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -129,3 +129,4 @@
 - Varun Gunda (vvargu)
 - Anil Nadiminti (aniloncloud)
 - Deepak Singh (deepaxs)
+- rmncardoso


### PR DESCRIPTION
**Issue number**: _to follow — tracking issue being opened_

### Concise description of the PR

```
Changes to 01-features/01-harness/00-getting-started and the shared utils/ helpers
it imports, because the getting-started sample fails on a fresh AWS account and
leaves the account in a state the other samples can't recover from.
```

### Scope

`00-getting-started`, the shared `utils/` helpers it imports (`client.py`,
`iam.py`, new `harness.py`) and `requirements.txt`. The other 18 samples in this
folder share several of these defects and follow in separate PRs to keep this one
reviewable.

### User experience

Before — `python getting_started.py` on a clean account:

```
  [1] CREATING
  ... [12] CREATING
=== Step 3: Invoke Agent (Claude Haiku) ===
botocore.errorfactory.ValidationException: Harness is not READY
```

…then exits without deleting the IAM role it created. Every sample here shares the
role name `HarnessExecutionRole`, and `create_harness_role()` returned early when
the role already existed — so that stale role breaks the next sample too, with
nothing pointing at the cause.

After — the sample completes. If creation genuinely fails it raises immediately
with the service's `failureReason`, and cleanup runs either way.

### What changed

- **`getting_started.py`** — the wait-for-READY loop was `for i in range(12)` with
  a 5s sleep: a hard 60s ceiling on an operation measured at ~150s, and it fell
  through instead of raising. Now uses the shared poller. Harness creation moved
  inside the `try` so a `CreateHarness` failure can't leak the role created just
  above it.
- **`utils/harness.py`** (new) — one correct `poll_harness_status()`. This loop
  appears 16 times across the folder in 4 incompatible variants, most checking for
  a `FAILED` status that isn't in the enum (`CREATE_FAILED` / `UPDATE_FAILED` /
  `DELETE_FAILED`), so they can't detect failure at all.
- **`utils/iam.py`** — least privilege (scoped Bedrock and Logs resources, 18
  enumerated AgentCore actions in place of `*Memory*`-style wildcards that
  silently included `Delete*`, `aws:SourceAccount` on the trust policy) and full
  idempotency, so re-running repairs an existing role. Deletion now removes every
  attached policy, which a leftover would otherwise block with
  `DeleteConflictException`.
- **`utils/client.py`** — honour `AWS_REGION` as well as `AWS_DEFAULT_REGION` (an
  empty or missing var produced `Invalid endpoint:
  https://bedrock-agentcore-control..amazonaws.com`); default data-plane
  `read_timeout=900`, since botocore's 60s default is shorter than one agent turn
  and cut the stream off mid-response.
- **`README.md`** — "Wait up to 60 seconds" contradicted the ~150s reality; also
  documents `iam:UpdateAssumeRolePolicy`.
- **`requirements.txt`** — `boto3>=1.43.32`, the first release whose
  `bedrock-agentcore` model knows `awsSkills`; unpinned, it resolves to whatever
  is installed and older versions raise `ParamValidationError`.
