### PR TITLE
fix(01-harness): inherit the shared harness poller in gateway-integration

### DIFF
--- a/01-features/01-harness/01-advanced-examples/02-gateway-integration/README.md
+++ b/01-features/01-harness/01-advanced-examples/02-gateway-integration/README.md
@@ -73,8 +73,11 @@ changing your agent code.
 ### Issue: Target `FAILED` status
 **Solution**: Check the MCP endpoint is reachable. The default Exa endpoint (`https://mcp.exa.ai/mcp`) requires public internet access from the gateway.
 
-### Issue: `HARNESS_POLL_TIMEOUT` exceeded
-**Solution**: Increase `HARNESS_POLL_TIMEOUT` constant or retry after a few minutes.
+### Issue: `Harness not READY after 600s`
+**Solution**: Harness provisioning is measured at ~150s on the public network and ~255s in VPC mode, so the shared poller in `utils/harness.py` allows 600s. Exceeding that usually means the harness is genuinely stuck rather than slow — check `get_harness` for a `CREATE_FAILED` status and its `failureReason`.
+
+### Issue: cleanup logs `Harness still provisioning, retrying delete`
+**Solution**: Expected. A harness cannot be deleted while it is still `CREATING`, so cleanup waits for provisioning to finish before deleting. It gives up after the same 600s and warns rather than failing the run.
 
 ## AgentCore CLI
 

--- a/01-features/01-harness/01-advanced-examples/02-gateway-integration/gateway_integration.py
+++ b/01-features/01-harness/01-advanced-examples/02-gateway-integration/gateway_integration.py
@@ -47,6 +47,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from utils.iam import create_harness_role
 from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import HARNESS_POLL_INTERVAL, HARNESS_POLL_TIMEOUT, poll_harness_status
 
 REGION = os.getenv("AWS_DEFAULT_REGION")
 
@@ -62,7 +63,6 @@ DEFAULT_PROMPT = (
 
 GATEWAY_POLL_INTERVAL = 5
 GATEWAY_POLL_TIMEOUT = 120
-HARNESS_POLL_TIMEOUT = 120
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 parser = argparse.ArgumentParser(
@@ -110,21 +110,6 @@ def poll_target_status(control, gateway_id, target_id, target_status="READY", ti
         time.sleep(GATEWAY_POLL_INTERVAL)
 
 
-def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = control.get_harness(harnessId=harness_id)
-        status = resp["harness"]["status"]
-        print(f"  Harness status: {status}")
-        if status == target_status:
-            return resp
-        if status in ("FAILED", "DELETE_FAILED"):
-            raise RuntimeError(f"Harness {status}")
-        if time.monotonic() > deadline:
-            raise TimeoutError(f"Harness not {target_status} after {timeout}s")
-        time.sleep(GATEWAY_POLL_INTERVAL)
-
-
 def stream_response(client, harness_arn, session_id, message, model_id, gateway_arn, raw=False):
     response = client.invoke_harness(
         harnessArn=harness_arn,
@@ -164,13 +149,35 @@ def stream_response(client, harness_arn, session_id, message, model_id, gateway_
     return full_text
 
 
-def _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id):
-    if harness_id:
+def _delete_harness(harness_control, harness_id, timeout=HARNESS_POLL_TIMEOUT):
+    """Delete a Harness, waiting out the ConflictException raised while it is still CREATING.
+
+    A harness cannot be deleted until it leaves CREATING, and cleanup runs at
+    precisely the moment that is most likely to be true: the `finally` block
+    after a step failed mid-provisioning. Without this wait the delete is
+    rejected on its only attempt and the harness is left behind — which then
+    counts against the account's harness quota with nothing pointing at why.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
         try:
             harness_control.delete_harness(harnessId=harness_id)
             print(f"  Deleted harness: {harness_id}")
-        except Exception as e:
-            print(f"  Warning: {e}")
+            return
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] != "ConflictException":
+                print(f"  Warning: could not delete harness {harness_id}: {e}")
+                return
+            if time.monotonic() > deadline:
+                print(f"  Warning: harness {harness_id} still not deletable after {timeout}s: {e}")
+                return
+            print(f"  Harness still provisioning, retrying delete in {HARNESS_POLL_INTERVAL}s...")
+            time.sleep(HARNESS_POLL_INTERVAL)
+
+
+def _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id):
+    if harness_id:
+        _delete_harness(harness_control, harness_id)
     if gateway_id and target_id:
         try:
             gw_control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -130,3 +130,4 @@
 - Anil Nadiminti (aniloncloud)
 - Deepak Singh (deepaxs)
 - rmncardoso
+- Bryan Conklin (thor4)


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

**Issue number**: #1862

### Concise description of the PR

```
Changes to 01-features/01-harness/01-advanced-examples/02-gateway-integration,
because the sample fails on a first run and leaves the harness behind when it
does. It carries a private copy of poll_harness_status instead of using the
shared helper added in #1857, and its cleanup cannot delete a harness that is
still CREATING.
```

### User experience

**Before** — `python gateway_integration.py` in a clean account:

```
  Harness status: CREATING
  ... (repeats)
TimeoutError: Harness not READY after 120s

Cleaning up...
  Warning: An error occurred (ConflictException) when calling the DeleteHarness operation
  Deleted target: ...
  Deleted gateway: ...
```

The gateway and target are cleaned up. The harness is not, and nothing in the output says what to do about it.

**After** — the sample completes. If the harness genuinely fails to create it raises immediately with the service's `failureReason`, and cleanup removes the harness either way, waiting for provisioning to finish first if it has to:

```
  Harness still provisioning, retrying delete in 5s...
  Deleted harness: ...
```

### What changed

- **Deleted the private `poll_harness_status`** and imported `utils.harness.poll_harness_status`. This fixes two defects at once. `HARNESS_POLL_TIMEOUT` was `120`, against provisioning that #1857 measured at ~150s on the public network and ~255s in VPC mode — which is why the shared poller allows 600s. The local copy also checked for a `FAILED` status that **is not in the enum** (`CREATING`, `CREATE_FAILED`, `UPDATING`, `UPDATE_FAILED`, `READY`, `DELETING`, `DELETE_FAILED`), so a harness that failed to create was treated as merely slow, polled to the timeout, and its `failureReason` never surfaced. Importing the shared helper also stops the constant drifting from the shared value again.

- **`_delete_harness()` waits out `ConflictException`.** A harness cannot be deleted while it is still `CREATING`, and `finally` runs at exactly the moment that is most likely to be true — right after a step failed mid-provisioning. The single `delete_harness` call was rejected, swallowed by a broad `except Exception`, and the harness was left behind counting against the account's harness quota with nothing pointing at why. The retry uses the same 600s budget as the poller, keys off `e.response["Error"]["Code"]` rather than matching the exception text, and returns immediately on any other error code.

- **README troubleshooting.** The entry told readers to "increase `HARNESS_POLL_TIMEOUT`", a constant this file no longer defines. Replaced with the real timeout, the `CREATE_FAILED` / `failureReason` check to run when it is exceeded, and a note that the retry-delete log line is expected rather than an error.

### Notes for reviewers

- **Deliberately not included: reuse of an existing harness.** I originally had a `list_harnesses()` "get or create" step, because stuck harnesses accumulate across failed runs. I dropped it. It treats the symptom rather than the cause, and with the poller and cleanup both correct they no longer accumulate. It would also introduce a concurrency hazard the current sample does not have — two runs in one account, the second adopts the first's harness and then deletes it in cleanup while the first is still invoking it — and it obscures what this sample is here to demonstrate, which is the create → use → delete lifecycle. If reuse is wanted, an explicit `--harness-id` alongside `--skip-cleanup` seems the safer shape and I am happy to add it in a follow-up.

- **Scope kept narrow.** Only this sample and its README. The two remaining `BLE001` findings on the file are pre-existing and in code this change does not touch, so I left them per the contributing guidance on not reformatting unrelated code. `ruff` findings on the file go from 4 to 3.

- **Related to #1857**, which fixed the same class of defect in `00-getting-started` and noted the other samples in this folder share it. I checked the open PRs and did not find one covering this sample.

### How it was tested

- Ran the sample end to end against a real account in `us-west-2`, which is how the timeout and the `ConflictException` cleanup failure were found.
- Verified the module imports and resolves `poll_harness_status` from `utils.harness` with the 600s timeout.
- Exercised `_delete_harness` against stubbed clients over five paths: deletes first try; retries through repeated `ConflictException` then succeeds; does **not** retry on a non-conflict error code; gives up at the timeout without raising, so it cannot mask the original failure; and warns without raising when the harness is already gone.
- `ruff check` on the changed file: 3 findings, all pre-existing, none introduced.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [x] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
