### PR TITLE
fix(01-harness): correct execution limits, share the poller, and stop leaking the role in 4 advanced samples

### DIFF
--- a/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
+++ b/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
@@ -36,8 +36,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── Language Presets ───────────────────────────────────────────────────────────
 LANGUAGE_PRESETS = {
@@ -155,6 +156,7 @@ def run_command(harness_arn, session_id, command):
 
 
 harness_id = None
+created_role = False
 try:
     # ── Step 0: IAM role ──────────────────────────────────────────────────────
     print("\n=== Step 0: IAM Role ===")
@@ -163,6 +165,7 @@ try:
         print(f"Using provided role: {role_arn}")
     else:
         role_arn = create_harness_role()
+        created_role = True
         print("Waiting for IAM propagation...")
         time.sleep(10)
 
@@ -176,13 +179,12 @@ try:
     print(f"Harness ID:  {harness_id}")
     print(f"Harness ARN: {harness_arn}")
 
-    for i in range(12):
-        status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-        print(f"  [{i + 1}] {status}")
-        if status == "READY":
-            print("✅ Harness ready")
-            break
-        time.sleep(5)
+    # A harness routinely takes ~2-3 minutes to reach READY, so this has to wait
+    # for the real thing rather than a fixed number of polls: falling through
+    # while the harness is still CREATING made the update_harness call below fail
+    # with "Cannot update agent ... while it is CREATING".
+    poll_harness_status(control, harness_id)
+    print("✅ Harness ready")
 
     # ── Step 2: Attach Custom Container ──────────────────────────────────────
     print(f"\n=== Step 2: Attach Custom Container ({container_uri}) ===")
@@ -192,13 +194,8 @@ try:
         systemPrompt=[{"text": system_prompt}],
     )
     print("Waiting for container update...")
-    for i in range(24):
-        status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-        print(f"  [{i + 1}] {status}")
-        if status == "READY":
-            print("✅ Harness updated with custom container")
-            break
-        time.sleep(5)
+    poll_harness_status(control, harness_id)
+    print("✅ Harness updated with custom container")
 
     # ── Step 3: Invoke Agent ─────────────────────────────────────────────────
     print("\n=== Step 3: Invoke Agent ===")
@@ -260,11 +257,17 @@ try:
     print("\n=== Done! ===")
 
 finally:
-    if harness_id and not args.skip_cleanup:
+    if not args.skip_cleanup:
         print("\n=== Cleanup ===")
-        try:
-            control.delete_harness(harnessId=harness_id)
-            print(f"Deleted harness: {harness_id}")
-        except Exception as e:
-            print(f"Warning: cleanup failed: {e}")
-        delete_harness_role()
+        if harness_id:
+            try:
+                control.delete_harness(harnessId=harness_id)
+                print(f"Deleted harness: {harness_id}")
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                print(f"Warning: cleanup failed: {e}")
+        # Only delete the role if we created it: --role-arn lets the caller pass
+        # in their own role, and deleting that would destroy something we don't
+        # own. Guarding on `harness_id` alone also meant a failure before the
+        # harness existed skipped cleanup entirely and leaked the role.
+        if created_role:
+            delete_harness_role()

--- a/01-features/01-harness/01-advanced-examples/03-execution-limits/README.md
+++ b/01-features/01-harness/01-advanced-examples/03-execution-limits/README.md
@@ -20,9 +20,11 @@ Each limit is demonstrated with before/after comparisons showing the difference.
 |:----------|:-----------------|
 | `maxIterations` | Maximum think → act → observe loop cycles |
 | `timeoutSeconds` | Wall-clock deadline for the entire invocation |
-| `maxTokens` | Maximum tokens the model can generate |
+| `maxTokens` | Maximum tokens the model can generate **per iteration** |
 
-Pass any combination to `invoke_harness`. The agent stops as soon as any limit is hit.
+Pass any combination to `invoke_harness`. `maxIterations` and `timeoutSeconds` stop
+the agent as soon as they are hit. `maxTokens` is scoped to a single iteration, so it
+bounds individual model calls rather than ending the invocation.
 Useful for keeping latency predictable, controlling cost, or preventing runaway tasks.
 
 ## Sample Prompts
@@ -33,8 +35,10 @@ Useful for keeping latency predictable, controlling cost, or preventing runaway 
 **Prompt with timeoutSeconds=5**: "Write a Python prime number script, run it, show output."
 **Expected Behavior**: Complex task cut short by the deadline — agent may not finish.
 
-**Prompt with maxTokens=10**: "Explain the history of Python in detail."
-**Expected Behavior**: Response is truncated to ~10 tokens — just a few words.
+**Prompt with maxTokens=256**: "Explain the history of Python in detail."
+**Expected Behavior**: A complete answer, *not* a truncated one — the limit applies per
+iteration, so the agent can continue across iterations. Compare the `outputTokens` in the
+usage metadata between this run and the `maxTokens=2048` run.
 
 **Prompt with all limits**: "List files, create summary.txt"
 **Expected Behavior**: Agent completes within whichever limit is hit first.
@@ -55,8 +59,11 @@ Useful for keeping latency predictable, controlling cost, or preventing runaway 
 ### Issue: timeoutSeconds=5 doesn't produce a truncated response
 **Solution**: The agent may respond quickly for simple tasks. Use a complex multi-step task (write + build + run + verify) to reliably trigger the timeout.
 
-### Issue: maxTokens very low causes a validation error
-**Solution**: Some models have a minimum maxTokens value. Try at least 10 tokens.
+### Issue: a low maxTokens doesn't truncate the response
+**Solution**: Expected — on `InvokeHarness`, `maxTokens` caps generation *per iteration*,
+not for the whole invocation, so the agent can keep producing output across iterations
+and still finish with `stopReason: end_turn`. To bound the total work of an invocation,
+use `maxIterations` or `timeoutSeconds`.
 
 ## AgentCore CLI
 

--- a/01-features/01-harness/01-advanced-examples/03-execution-limits/execution_limits.py
+++ b/01-features/01-harness/01-advanced-examples/03-execution-limits/execution_limits.py
@@ -4,10 +4,14 @@ Execution Limits with AgentCore Harness.
 Demonstrates how to control agent work per invocation using three limit parameters:
   - maxIterations: caps think → act → observe loop cycles
   - timeoutSeconds: wall-clock deadline for the entire invocation
-  - maxTokens: maximum tokens the model can generate
+  - maxTokens: maximum tokens the model can generate per iteration
 
 Each limit is demonstrated with a before/after comparison showing what happens when
 the agent hits a limit vs runs freely.
+
+Note that maxIterations and timeoutSeconds stop the agent — you will see
+`max_iterations_exceeded` / `timeout_exceeded` as the stopReason. maxTokens is
+scoped to a single iteration, so it does not cut off the overall response.
 
 Usage:
     python execution_limits.py
@@ -27,8 +31,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -41,160 +46,176 @@ account_id = boto3.client("sts").get_caller_identity()["Account"]
 print(f"Account: {account_id}")
 
 # ── Create IAM Role & Harness ─────────────────────────────────────────────────
+# Role creation and harness creation both run inside the try/finally so the
+# cleanup below fires even when a step in between fails — otherwise a
+# CreateHarness failure (an unavailable model, a role that has not finished
+# propagating) would exit leaving the role behind, and the role name is shared
+# by every sample in this folder.
 print("\n=== Setup: IAM Role & Harness ===")
-role_arn = create_harness_role()
-print(f"Execution Role ARN: {role_arn}")
-print("Waiting for IAM propagation...")
-time.sleep(10)
+harness_id = None
 
-HARNESS_NAME = f"ExecLimits_{uuid.uuid4().hex[:8]}"
-resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
-harness = resp["harness"]
-harness_id = harness["harnessId"]
-harness_arn = harness["arn"]
-print(f"Harness ID: {harness_id}")
+try:
+    role_arn = create_harness_role()
+    print(f"Execution Role ARN: {role_arn}")
+    print("Waiting for IAM propagation...")
+    time.sleep(10)
 
-for i in range(12):
-    status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-    print(f"  [{i + 1}] {status}")
-    if status == "READY":
-        print("✅ Harness is ready")
-        break
-    time.sleep(5)
+    HARNESS_NAME = f"ExecLimits_{uuid.uuid4().hex[:8]}"
+    resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
+    harness = resp["harness"]
+    harness_id = harness["harnessId"]
+    harness_arn = harness["arn"]
+    print(f"Harness ID: {harness_id}")
 
-# ── Helper Functions ─────────────────────────────────────────────────────────
+    poll_harness_status(control, harness_id)
+    print("✅ Harness is ready")
 
+    # ── Helper Functions ─────────────────────────────────────────────────────────
 
-def invoke(prompt: str, **limits) -> str:
-    """Invoke the harness with a prompt and optional execution limits.
+    def invoke(prompt: str, **limits) -> str:
+        """Invoke the harness with a prompt and optional execution limits.
 
-    Pass any of: maxIterations=, timeoutSeconds=, maxTokens=
-    Returns the session ID so you can use run() to inspect the VM.
-    """
-    sid = str(uuid.uuid4()).upper()
-    limit_str = ", ".join(f"{k}={v}" for k, v in limits.items()) or "(defaults)"
-    print(f"\n--- Limits: {limit_str} ---")
-    print(f"Session: {sid}\n")
+        Pass any of: maxIterations=, timeoutSeconds=, maxTokens=
+        Returns the session ID so you can use run() to inspect the VM.
+        """
+        sid = str(uuid.uuid4()).upper()
+        limit_str = ", ".join(f"{k}={v}" for k, v in limits.items()) or "(defaults)"
+        print(f"\n--- Limits: {limit_str} ---")
+        print(f"Session: {sid}\n")
 
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=sid,
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-        **limits,
+        response = client.invoke_harness(
+            harnessArn=harness_arn,
+            runtimeSessionId=sid,
+            messages=[{"role": "user", "content": [{"text": prompt}]}],
+            model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+            **limits,
+        )
+
+        for event in response["stream"]:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+            elif "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    print(delta["text"], end="", flush=True)
+            elif "messageStop" in event:
+                stop = event["messageStop"]
+                reason = stop.get("stopReason", "")
+                print(f"\n\n→ stopReason: {reason}")
+            elif "metadata" in event:
+                meta = event["metadata"]
+                usage = meta.get("usage", {})
+                if usage:
+                    print(f"→ usage: input={usage.get('inputTokens', 0)}, output={usage.get('outputTokens', 0)}")
+            elif "internalServerException" in event:
+                print(f"\nError: {event['internalServerException']}")
+        print()
+        return sid
+
+    def run(cmd: str, session_id: str):
+        """Run a shell command on the agent's VM for a given session."""
+        print(f"$ {cmd}")
+        resp = client.invoke_agent_runtime_command(
+            agentRuntimeArn=harness_arn,
+            runtimeSessionId=session_id,
+            body={"command": cmd},
+        )
+        for event in resp["stream"]:
+            if "chunk" in event:
+                chunk = event["chunk"]
+                if "contentDelta" in chunk:
+                    d = chunk["contentDelta"]
+                    if "stdout" in d:
+                        print(d["stdout"], end="", flush=True)
+                    if "stderr" in d:
+                        print(d["stderr"], end="", flush=True)
+                elif "contentStop" in chunk:
+                    print(f"\n[exit: {chunk['contentStop']['exitCode']}]")
+        print()
+
+    # ── Demo 1: maxIterations ──────────────────────────────────────────────────────
+    print("\n=== Demo 1: maxIterations ===")
+    print("maxIterations=1: Agent gets one tool call before it must respond.")
+    print("Expected: Agent can't create all 3 files in one iteration.\n")
+
+    sid = invoke(
+        "Create 3 files: hello.txt, world.txt, and readme.md with some content in each.",
+        maxIterations=1,
+    )
+    run("ls -la", sid)
+
+    print("\nmaxIterations=10: Agent can complete all 3 files.")
+    sid = invoke(
+        "Create 3 files: hello.txt, world.txt, and readme.md with some content in each.",
+        maxIterations=10,
+    )
+    run("ls -la", sid)
+    run("cat *.md", sid)
+
+    # ── Demo 2: timeoutSeconds ────────────────────────────────────────────────────
+    print("\n=== Demo 2: timeoutSeconds ===")
+    print("timeoutSeconds=5: Tight deadline — complex task will time out.\n")
+
+    invoke(
+        "Write a Python script that generates the first 50 prime numbers, save it to primes.py, "
+        "then run it and show the output.",
+        timeoutSeconds=5,
     )
 
-    for event in response["stream"]:
-        if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
-            if "toolUse" in start:
-                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-        elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                print(delta["text"], end="", flush=True)
-        elif "messageStop" in event:
-            stop = event["messageStop"]
-            reason = stop.get("stopReason", "")
-            print(f"\n\n→ stopReason: {reason}")
-        elif "metadata" in event:
-            meta = event["metadata"]
-            usage = meta.get("usage", {})
-            if usage:
-                print(f"→ usage: input={usage.get('inputTokens', 0)}, output={usage.get('outputTokens', 0)}")
-        elif "internalServerException" in event:
-            print(f"\nError: {event['internalServerException']}")
-    print()
-    return sid
-
-
-def run(cmd: str, session_id: str):
-    """Run a shell command on the agent's VM for a given session."""
-    print(f"$ {cmd}")
-    resp = client.invoke_agent_runtime_command(
-        agentRuntimeArn=harness_arn,
-        runtimeSessionId=session_id,
-        body={"command": cmd},
+    print("\ntimeoutSeconds=120: Generous timeout — task completes.\n")
+    invoke(
+        "Write a Python script that generates the first 50 prime numbers, save it to primes.py, "
+        "then run it and show the output.",
+        timeoutSeconds=120,
     )
-    for event in resp["stream"]:
-        if "chunk" in event:
-            chunk = event["chunk"]
-            if "contentDelta" in chunk:
-                d = chunk["contentDelta"]
-                if "stdout" in d:
-                    print(d["stdout"], end="", flush=True)
-                if "stderr" in d:
-                    print(d["stderr"], end="", flush=True)
-            elif "contentStop" in chunk:
-                print(f"\n[exit: {chunk['contentStop']['exitCode']}]")
-    print()
 
+    # ── Demo 3: maxTokens ─────────────────────────────────────────────────────────
+    # On InvokeHarness, maxTokens is a *per-iteration* ceiling ("the maximum
+    # number of tokens the agent can generate per iteration"), not a budget for
+    # the whole invocation. So it does not truncate the final answer: the agent
+    # can keep going across iterations, and a small value mainly bounds how much
+    # any one model call emits. Compare the reported output tokens rather than
+    # expecting the second response to be visibly longer than the first.
+    print("\n=== Demo 3: maxTokens ===")
+    print("maxTokens is per iteration, so neither run is truncated — watch the usage lines.\n")
 
-# ── Demo 1: maxIterations ──────────────────────────────────────────────────────
-print("\n=== Demo 1: maxIterations ===")
-print("maxIterations=1: Agent gets one tool call before it must respond.")
-print("Expected: Agent can't create all 3 files in one iteration.\n")
+    invoke(
+        "Explain the history of the Python programming language in detail.",
+        maxTokens=256,
+    )
 
-sid = invoke(
-    "Create 3 files: hello.txt, world.txt, and readme.md with some content in each.",
-    maxIterations=1,
-)
-run("ls -la", sid)
+    print("\nmaxTokens=2048: a higher per-iteration ceiling.\n")
+    invoke(
+        "Explain the history of the Python programming language in detail.",
+        maxTokens=2048,
+    )
 
-print("\nmaxIterations=10: Agent can complete all 3 files.")
-sid = invoke(
-    "Create 3 files: hello.txt, world.txt, and readme.md with some content in each.",
-    maxIterations=10,
-)
-run("ls -la", sid)
-run("cat *.md", sid)
+    # ── Demo 4: Combining Limits ──────────────────────────────────────────────────
+    print("\n=== Demo 4: Combining Limits ===")
+    print("maxIterations=3 + timeoutSeconds=30 + maxTokens=1024\n")
 
-# ── Demo 2: timeoutSeconds ────────────────────────────────────────────────────
-print("\n=== Demo 2: timeoutSeconds ===")
-print("timeoutSeconds=5: Tight deadline — complex task will time out.\n")
+    invoke(
+        "List all files in the current directory, then create a summary.txt with what you found.",
+        maxIterations=3,
+        timeoutSeconds=30,
+        maxTokens=1024,
+    )
 
-invoke(
-    "Write a Python script that generates the first 50 prime numbers, save it to primes.py, "
-    "then run it and show the output.",
-    timeoutSeconds=5,
-)
+finally:
+    # ── Cleanup ────────────────────────────────────────────────────────────────────
+    # Delete each resource independently: harness_id is None if CreateHarness
+    # itself failed, and a delete_harness error must not skip the role deletion —
+    # a leftover role is what makes the next run of any sample in this folder
+    # behave unpredictably, since they all share one role name.
+    print("\n=== Cleanup ===")
+    if harness_id:
+        try:
+            control.delete_harness(harnessId=harness_id)
+            print(f"Deleted harness: {harness_id}")
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+            print(f"Warning: could not delete harness {harness_id}: {e}")
 
-print("\ntimeoutSeconds=120: Generous timeout — task completes.\n")
-invoke(
-    "Write a Python script that generates the first 50 prime numbers, save it to primes.py, "
-    "then run it and show the output.",
-    timeoutSeconds=120,
-)
-
-# ── Demo 3: maxTokens ─────────────────────────────────────────────────────────
-print("\n=== Demo 3: maxTokens ===")
-print("maxTokens=10: Very tight token budget — model will be cut short.\n")
-
-invoke(
-    "Explain the history of the Python programming language in detail.",
-    maxTokens=10,
-)
-
-print("\nmaxTokens=2048: Normal budget — full response.\n")
-invoke(
-    "Explain the history of the Python programming language in detail.",
-    maxTokens=2048,
-)
-
-# ── Demo 4: Combining Limits ──────────────────────────────────────────────────
-print("\n=== Demo 4: Combining Limits ===")
-print("maxIterations=3 + timeoutSeconds=30 + maxTokens=1024\n")
-
-invoke(
-    "List all files in the current directory, then create a summary.txt with what you found.",
-    maxIterations=3,
-    timeoutSeconds=30,
-    maxTokens=1024,
-)
-
-# ── Cleanup ────────────────────────────────────────────────────────────────────
-print("\n=== Cleanup ===")
-control.delete_harness(harnessId=harness_id)
-print(f"Deleted harness: {harness_id}")
-delete_harness_role()
-print("Done.")
+    delete_harness_role()
+    print("Done.")

--- a/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
+++ b/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
@@ -29,8 +29,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -44,228 +45,238 @@ account_id = boto3.client("sts").get_caller_identity()["Account"]
 print(f"Account: {account_id}")
 
 # ── Create IAM Role & Harness ─────────────────────────────────────────────────
+# Role creation and harness creation both run inside the try/finally so the
+# cleanup below fires even when a step in between fails — otherwise a
+# CreateHarness failure (an unavailable model, a role that has not finished
+# propagating) would exit leaving the role behind, and the role name is shared
+# by every sample in this folder.
 print("\n=== Setup: IAM Role & Harness ===")
-role_arn = create_harness_role()
-print(f"Execution Role ARN: {role_arn}")
-print("Waiting for IAM propagation...")
-time.sleep(10)
-
-HARNESS_NAME = f"MCPIntegration_{uuid.uuid4().hex[:8]}"
-resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
-harness = resp["harness"]
-harness_id = harness["harnessId"]
-harness_arn = harness["arn"]
-print(f"Harness ID:  {harness_id}")
-print(f"Harness ARN: {harness_arn}")
-
-for i in range(12):
-    resp = control.get_harness(harnessId=harness_id)
-    status = resp["harness"]["status"]
-    print(f"  [{i + 1}] {status}")
-    if status == "READY":
-        print("✅ Harness is ready")
-        break
-    time.sleep(5)
-
-# ── Helper: stream harness response ──────────────────────────────────────────
-
-
-def stream_invoke(session_id, prompt, tools, timeout=300):
-    """Invoke harness with MCP tools and stream the response."""
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-        tools=tools,
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-        timeoutSeconds=timeout,
-    )
-    result = {"text": "", "tool_uses": [], "errors": []}
-    for event in response["stream"]:
-        if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
-            if "toolUse" in start:
-                tool_name = start["toolUse"].get("name", "?")
-                result["tool_uses"].append(tool_name)
-                print(f"\n[Tool: {tool_name}]", flush=True)
-        elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                result["text"] += delta["text"]
-                print(delta["text"], end="", flush=True)
-        elif "messageStop" in event:
-            print("\n")
-        elif "internalServerException" in event:
-            error = event["internalServerException"]
-            result["errors"].append(error)
-            print(f"\n❌ Error: {error}")
-    return result
-
-
-# ── Part 1: Basic MCP Integration — Exa Search ────────────────────────────────
-print("\n=== Part 1: Basic MCP Integration — Exa Search ===")
-session1 = str(uuid.uuid4()).upper()
-print(f"Session: {session1}\n")
-
-result = stream_invoke(
-    session_id=session1,
-    prompt=(
-        "Search for the latest developments in quantum computing in 2024. "
-        "Find 3-5 recent articles and summarize the key breakthroughs."
-    ),
-    tools=[
-        {
-            "type": "remote_mcp",
-            "name": "exa",
-            "config": {"remoteMcp": {"url": EXA_MCP_URL}},
-        }
-    ],
-)
-print(f"Tools used: {result['tool_uses']}")
-
-# ── Part 2: Multiple MCP Tools ────────────────────────────────────────────────
-print("\n=== Part 2: Multiple MCP Tools ===")
-session2 = str(uuid.uuid4()).upper()
-print(f"Session: {session2}\n")
-
-result = stream_invoke(
-    session_id=session2,
-    prompt=(
-        "Compare search results from different sources about 'AWS re:Invent 2024 announcements'. "
-        "What were the major announcements?"
-    ),
-    tools=[
-        {
-            "type": "remote_mcp",
-            "name": "exa_search",
-            "config": {"remoteMcp": {"url": EXA_MCP_URL}},
-        },
-        # Add other MCP servers here as needed:
-        # {
-        #     "type": "remote_mcp",
-        #     "name": "brave_search",
-        #     "config": {"remoteMcp": {"url": "https://mcp.brave.com/api"}},
-        # },
-    ],
-)
-print(f"Tools used: {result['tool_uses']}")
-
-# ── Part 3: MCP with Authentication ──────────────────────────────────────────
-print("\n=== Part 3: MCP with Authentication (env var pattern) ===")
-api_key = os.getenv("MCP_API_KEY", "")
-
-if api_key:
-    # Example: authenticated MCP server with bearer token in headers
-    # Header format may vary — check latest API docs for your MCP server
-    tools_config = [
-        {
-            "type": "remote_mcp",
-            "name": "authenticated_search",
-            "config": {
-                "remoteMcp": {
-                    "url": EXA_MCP_URL,
-                    # "headers": {"Authorization": f"Bearer {api_key}"}
-                }
-            },
-        }
-    ]
-    print(
-        f"✅ MCP configured with API key (first 8 chars): {api_key[:8]}..."
-    )  # codeql[py/clear-text-logging-sensitive-data]
-    print(f"Tool config: {json.dumps(tools_config, indent=2)}")
-else:
-    print("⚠️  No MCP_API_KEY found. Skipping authenticated example.")
-    print("   Set it with: export MCP_API_KEY='your-key-here'")
-
-# ── Part 4: Error Handling ────────────────────────────────────────────────────
-print("\n=== Part 4: Error Handling — Invalid MCP URL ===")
-session4 = str(uuid.uuid4()).upper()
-print(f"Testing with invalid MCP URL (session: {session4})\n")
+harness_id = None
 
 try:
+    role_arn = create_harness_role()
+    print(f"Execution Role ARN: {role_arn}")
+    print("Waiting for IAM propagation...")
+    time.sleep(10)
+
+    HARNESS_NAME = f"MCPIntegration_{uuid.uuid4().hex[:8]}"
+    resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
+    harness = resp["harness"]
+    harness_id = harness["harnessId"]
+    harness_arn = harness["arn"]
+    print(f"Harness ID:  {harness_id}")
+    print(f"Harness ARN: {harness_arn}")
+
+    poll_harness_status(control, harness_id)
+    print("✅ Harness is ready")
+
+    # ── Helper: stream harness response ──────────────────────────────────────────
+
+    def stream_invoke(session_id, prompt, tools, timeout=300):
+        """Invoke harness with MCP tools and stream the response."""
+        response = client.invoke_harness(
+            harnessArn=harness_arn,
+            runtimeSessionId=session_id,
+            messages=[{"role": "user", "content": [{"text": prompt}]}],
+            tools=tools,
+            model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+            timeoutSeconds=timeout,
+        )
+        result = {"text": "", "tool_uses": [], "errors": []}
+        for event in response["stream"]:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    tool_name = start["toolUse"].get("name", "?")
+                    result["tool_uses"].append(tool_name)
+                    print(f"\n[Tool: {tool_name}]", flush=True)
+            elif "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    result["text"] += delta["text"]
+                    print(delta["text"], end="", flush=True)
+            elif "messageStop" in event:
+                print("\n")
+            elif "internalServerException" in event:
+                error = event["internalServerException"]
+                result["errors"].append(error)
+                print(f"\n❌ Error: {error}")
+        return result
+
+    # ── Part 1: Basic MCP Integration — Exa Search ────────────────────────────────
+    print("\n=== Part 1: Basic MCP Integration — Exa Search ===")
+    session1 = str(uuid.uuid4()).upper()
+    print(f"Session: {session1}\n")
+
     result = stream_invoke(
-        session_id=session4,
-        prompt="Search for 'test query'",
+        session_id=session1,
+        prompt=(
+            "Search for the latest developments in quantum computing in 2024. "
+            "Find 3-5 recent articles and summarize the key breakthroughs."
+        ),
         tools=[
             {
                 "type": "remote_mcp",
-                "name": "invalid",
-                "config": {"remoteMcp": {"url": "https://invalid-mcp-url.example.com/mcp"}},
+                "name": "exa",
+                "config": {"remoteMcp": {"url": EXA_MCP_URL}},
             }
         ],
-        timeout=60,
     )
-    print(f"Errors encountered: {len(result['errors'])}")
-except Exception as e:
-    # Expected: invalid MCP URL raises runtimeClientError — the harness rejects it
-    # before the agent ever runs. This demonstrates graceful error surfacing.
-    print(f"✅ Expected error for invalid MCP URL: {type(e).__name__}")
-    print(f"   {str(e)[:200]}")
+    print(f"Tools used: {result['tool_uses']}")
 
-# ── Part 5: Advanced — Research Assistant ────────────────────────────────────
-print("\n=== Part 5: Advanced — Research Assistant ===")
-research_session = str(uuid.uuid4()).upper()
-print(f"Research session: {research_session}\n")
+    # ── Part 2: Multiple MCP Tools ────────────────────────────────────────────────
+    print("\n=== Part 2: Multiple MCP Tools ===")
+    session2 = str(uuid.uuid4()).upper()
+    print(f"Session: {session2}\n")
 
-research_prompt = """
-Research topic: "Generative AI trends in enterprise adoption for 2024"
+    result = stream_invoke(
+        session_id=session2,
+        prompt=(
+            "Compare search results from different sources about 'AWS re:Invent 2024 announcements'. "
+            "What were the major announcements?"
+        ),
+        tools=[
+            {
+                "type": "remote_mcp",
+                "name": "exa_search",
+                "config": {"remoteMcp": {"url": EXA_MCP_URL}},
+            },
+            # Add other MCP servers here as needed:
+            # {
+            #     "type": "remote_mcp",
+            #     "name": "brave_search",
+            #     "config": {"remoteMcp": {"url": "https://mcp.brave.com/api"}},
+            # },
+        ],
+    )
+    print(f"Tools used: {result['tool_uses']}")
 
-Please:
-1. Search for recent articles and reports about enterprise AI adoption
-2. Identify the top 5 trends
-3. For each trend, provide:
-   - Brief description
-   - Key statistics or data points
-   - Notable companies or use cases
-4. Save the report as a structured JSON file at /tmp/ai_trends_report.json
+    # ── Part 3: MCP with Authentication ──────────────────────────────────────────
+    print("\n=== Part 3: MCP with Authentication (env var pattern) ===")
+    api_key = os.getenv("MCP_API_KEY", "")
 
-Format the JSON as:
-{
-  "topic": "...",
-  "date": "...",
-  "trends": [{"name": "...", "description": "...", "statistics": [...], "examples": [...]}],
-  "sources": [...]
-}
-"""
+    if api_key:
+        # Example: authenticated MCP server with bearer token in headers
+        # Header format may vary — check latest API docs for your MCP server
+        tools_config = [
+            {
+                "type": "remote_mcp",
+                "name": "authenticated_search",
+                "config": {
+                    "remoteMcp": {
+                        "url": EXA_MCP_URL,
+                        # "headers": {"Authorization": f"Bearer {api_key}"}
+                    }
+                },
+            }
+        ]
+        print(
+            f"✅ MCP configured with API key (first 8 chars): {api_key[:8]}..."
+        )  # codeql[py/clear-text-logging-sensitive-data]
+        print(f"Tool config: {json.dumps(tools_config, indent=2)}")
+    else:
+        print("⚠️  No MCP_API_KEY found. Skipping authenticated example.")
+        print("   Set it with: export MCP_API_KEY='your-key-here'")
 
-result = stream_invoke(
-    session_id=research_session,
-    prompt=research_prompt,
-    tools=[
-        {
-            "type": "remote_mcp",
-            "name": "exa",
-            "config": {"remoteMcp": {"url": EXA_MCP_URL}},
-        }
-    ],
-    timeout=300,
-)
+    # ── Part 4: Error Handling ────────────────────────────────────────────────────
+    print("\n=== Part 4: Error Handling — Invalid MCP URL ===")
+    session4 = str(uuid.uuid4()).upper()
+    print(f"Testing with invalid MCP URL (session: {session4})\n")
 
-# Retrieve the report from the agent's VM
-print("\n--- Retrieving research report from VM ---")
-report_data = ""
-resp = client.invoke_agent_runtime_command(
-    agentRuntimeArn=harness_arn,
-    runtimeSessionId=research_session,
-    body={"command": "cat /tmp/ai_trends_report.json 2>/dev/null || echo '{}'"},
-)
-for event in resp["stream"]:
-    if "chunk" in event:
-        chunk = event["chunk"]
-        if "contentDelta" in chunk and "stdout" in chunk["contentDelta"]:
-            report_data += chunk["contentDelta"]["stdout"]
+    try:
+        result = stream_invoke(
+            session_id=session4,
+            prompt="Search for 'test query'",
+            tools=[
+                {
+                    "type": "remote_mcp",
+                    "name": "invalid",
+                    "config": {"remoteMcp": {"url": "https://invalid-mcp-url.example.com/mcp"}},
+                }
+            ],
+            timeout=60,
+        )
+        print(f"Errors encountered: {len(result['errors'])}")
+    except Exception as e:  # noqa: BLE001 - demo deliberately surfaces any error type
+        # Expected: invalid MCP URL raises runtimeClientError — the harness rejects it
+        # before the agent ever runs. This demonstrates graceful error surfacing.
+        print(f"✅ Expected error for invalid MCP URL: {type(e).__name__}")
+        print(f"   {str(e)[:200]}")
 
-try:
-    report = json.loads(report_data)
-    print("✅ Research Report Generated:")
-    print(json.dumps(report, indent=2)[:2000])  # show first 2000 chars
-except json.JSONDecodeError:
-    print("⚠️  Could not parse as JSON.")
-    print(f"Raw output (first 500 chars): {report_data[:500]}")
+    # ── Part 5: Advanced — Research Assistant ────────────────────────────────────
+    print("\n=== Part 5: Advanced — Research Assistant ===")
+    research_session = str(uuid.uuid4()).upper()
+    print(f"Research session: {research_session}\n")
 
-# ── Cleanup ────────────────────────────────────────────────────────────────────
-print("\n=== Cleanup ===")
-control.delete_harness(harnessId=harness_id)
-print(f"Deleted harness: {harness_id}")
-delete_harness_role()
-print("Done.")
+    research_prompt = """
+    Research topic: "Generative AI trends in enterprise adoption for 2024"
+
+    Please:
+    1. Search for recent articles and reports about enterprise AI adoption
+    2. Identify the top 5 trends
+    3. For each trend, provide:
+       - Brief description
+       - Key statistics or data points
+       - Notable companies or use cases
+    4. Save the report as a structured JSON file at /tmp/ai_trends_report.json
+
+    Format the JSON as:
+    {
+      "topic": "...",
+      "date": "...",
+      "trends": [{"name": "...", "description": "...", "statistics": [...], "examples": [...]}],
+      "sources": [...]
+    }
+    """
+
+    result = stream_invoke(
+        session_id=research_session,
+        prompt=research_prompt,
+        tools=[
+            {
+                "type": "remote_mcp",
+                "name": "exa",
+                "config": {"remoteMcp": {"url": EXA_MCP_URL}},
+            }
+        ],
+        timeout=300,
+    )
+
+    # Retrieve the report from the agent's VM
+    print("\n--- Retrieving research report from VM ---")
+    report_data = ""
+    resp = client.invoke_agent_runtime_command(
+        agentRuntimeArn=harness_arn,
+        runtimeSessionId=research_session,
+        body={"command": "cat /tmp/ai_trends_report.json 2>/dev/null || echo '{}'"},
+    )
+    for event in resp["stream"]:
+        if "chunk" in event:
+            chunk = event["chunk"]
+            if "contentDelta" in chunk and "stdout" in chunk["contentDelta"]:
+                report_data += chunk["contentDelta"]["stdout"]
+
+    try:
+        report = json.loads(report_data)
+        print("✅ Research Report Generated:")
+        print(json.dumps(report, indent=2)[:2000])  # show first 2000 chars
+    except json.JSONDecodeError:
+        print("⚠️  Could not parse as JSON.")
+        print(f"Raw output (first 500 chars): {report_data[:500]}")
+
+finally:
+    # ── Cleanup ────────────────────────────────────────────────────────────────────
+    # Delete each resource independently: harness_id is None if CreateHarness
+    # itself failed, and a delete_harness error must not skip the role deletion —
+    # a leftover role is what makes the next run of any sample in this folder
+    # behave unpredictably, since they all share one role name.
+    print("\n=== Cleanup ===")
+    if harness_id:
+        try:
+            control.delete_harness(harnessId=harness_id)
+            print(f"Deleted harness: {harness_id}")
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+            print(f"Warning: could not delete harness {harness_id}: {e}")
+
+    delete_harness_role()
+    print("Done.")

--- a/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
+++ b/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
@@ -170,9 +170,10 @@ try:
                 },
             }
         ]
-        print(
-            f"✅ MCP configured with API key (first 8 chars): {api_key[:8]}..."
-        )  # codeql[py/clear-text-logging-sensitive-data]
+        # Never echo the key itself, not even a prefix — sample output routinely
+        # ends up in terminal scrollback, CI logs and screenshots. Confirm that
+        # the variable was picked up and stop there.
+        print(f"✅ MCP configured with the API key from MCP_API_KEY ({len(api_key)} chars, value not logged)")
         print(f"Tool config: {json.dumps(tools_config, indent=2)}")
     else:
         print("⚠️  No MCP_API_KEY found. Skipping authenticated example.")

--- a/01-features/01-harness/01-advanced-examples/13-aws-skills/aws_skills.py
+++ b/01-features/01-harness/01-advanced-examples/13-aws-skills/aws_skills.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 AWS Skills for Harness
 
@@ -64,7 +63,6 @@ import os
 import sys
 import time
 import uuid
-
 from pathlib import Path
 
 import boto3
@@ -72,8 +70,9 @@ import botocore.exceptions
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from utils.iam import create_harness_role
 from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
+from utils.iam import create_harness_role, delete_harness_role
 
 REGION = os.getenv("AWS_DEFAULT_REGION")
 
@@ -85,9 +84,6 @@ DEFAULT_MODEL = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_GLOB = "core-skills/*"
 DEFAULT_SPECIFIC = "specialized-skills/operations-skills/troubleshooting-application-failures"
 DEFAULT_PROMPT = "What AWS skills do you have available? Give a short bulleted summary by category."
-
-HARNESS_POLL_INTERVAL = 5
-HARNESS_POLL_TIMEOUT = 120
 
 
 # ---------------------------------------------------------------------------
@@ -168,22 +164,6 @@ def build_skills(args):
     ]
 
 
-def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
-    """Poll until a Harness reaches the target status or times out."""
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = control.get_harness(harnessId=harness_id)
-        status = resp["harness"]["status"]
-        print(f"  Harness status: {status}")
-        if status == target_status:
-            return resp
-        if status in ("FAILED", "DELETE_FAILED"):
-            raise RuntimeError(f"Harness entered {status}")
-        if time.monotonic() > deadline:
-            raise TimeoutError(f"Harness not {target_status} after {timeout}s (current: {status})")
-        time.sleep(HARNESS_POLL_INTERVAL)
-
-
 def stream_response(client, harness_arn, session_id, message, model_id, raw=False):
     """Invoke a Harness and stream the response to stdout."""
     response = client.invoke_harness(
@@ -234,6 +214,7 @@ def main(args=None):
 
     skills = build_skills(args)
     harness_id = None
+    created_role = False
 
     try:
         # ── Step 0: IAM role ──────────────────────────────────────────
@@ -245,6 +226,7 @@ def main(args=None):
             print(f"  Using provided role: {role_arn}")
         else:
             role_arn = create_harness_role()
+            created_role = True
             print("  Waiting for IAM propagation...")
             time.sleep(10)
 
@@ -266,6 +248,8 @@ def main(args=None):
         harness_arn = resp["harness"]["arn"]
         print(f"  Harness ID:  {harness_id}")
         print(f"  Harness ARN: {harness_arn}")
+        # Harnesses that enable native AWS Skills routinely take ~3 minutes to
+        # reach READY; the shared poller's default timeout already allows for it.
         poll_harness_status(control, harness_id)
 
         # ── Step 2: Invoke and observe the loaded skills ──────────────
@@ -284,13 +268,21 @@ def main(args=None):
         print("=" * 60)
 
     finally:
-        if not args.skip_cleanup and harness_id:
+        if not args.skip_cleanup:
             print("\nCleaning up...")
-            try:
-                control.delete_harness(harnessId=harness_id)
-                print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"  Warning: failed to delete harness: {e}")
+            if harness_id:
+                try:
+                    control.delete_harness(harnessId=harness_id)
+                    print(f"  Deleted harness: {harness_id}")
+                except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                    print(f"  Warning: failed to delete harness: {e}")
+            # Delete the execution role too, but only the one we created — the
+            # role name is shared by every sample in this folder, so deleting a
+            # role the caller passed in with --role-arn would destroy something
+            # we don't own. Without this the role outlived the script and was
+            # left behind on any failure before Step 1 completed.
+            if created_role:
+                delete_harness_role()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Issue number**: _to follow_

### Concise description of the PR

```
Changes to four advanced Harness samples (01-custom-containers, 03-execution-limits,
04-mcp-integration, 13-aws-skills), applying the shared poller and role-lifecycle
fixes from #1857 and correcting a factual error in the execution-limits demo.
```

Follow-up to #1857 (merged), which added `utils/harness.py`. This applies the same
fixes to the four advanced samples that need no extra infrastructure to run.

### What changed

- **03-execution-limits** — the demo claimed `maxTokens` truncates the response
  (`maxTokens=10` → "~10 tokens"). On `InvokeHarness`, `maxTokens` is a
  **per-iteration** ceiling, not a budget for the whole invocation, so the agent
  keeps going across iterations and the answer is not truncated. Verified live:
  `maxTokens=256` still produced **1413** output tokens and stopped with
  `end_turn`. Corrected the code, docstring and README, and switched the demo to
  compare per-run output tokens. `maxIterations` and `timeoutSeconds` do stop the
  agent (`max_iterations_exceeded` / `timeout_exceeded`), which the demo still
  shows.
- **All four** — replace the local wait-for-READY loop with `poll_harness_status`
  from #1857. The local loops had a fixed ~60s ceiling on an operation that takes
  ~150s (longer for a container pull or an AWS-skills harness), and several
  checked for a `"FAILED"` status that isn't in the enum (`CREATE_FAILED` /
  `UPDATE_FAILED` / `DELETE_FAILED`), so they could never detect a failure.
- **03-execution-limits, 04-mcp-integration** — role and harness creation were
  above the `try`, so a `CreateHarness` failure exited leaving the shared IAM role
  behind. Moved creation inside `try/finally` and made cleanup delete each
  resource independently, matching #1857's getting-started fix.
- **01-custom-containers, 13-aws-skills** — already create inside `try`; gain a
  `created_role` guard so a caller-supplied `--role-arn` is never deleted.

### User experience

Before, on a fresh account these samples either timed out at 60s while the harness
was still `CREATING` and then failed at the next call, or (custom-containers /
visual-testing) failed the `update_harness` step with a `ConflictException`
because the poll fell through early. execution-limits additionally taught the
wrong mental model for `maxTokens`. After, each sample waits for the real status,
raises immediately with the service's `failureReason` on a genuine failure, and
never leaves the shared role behind.

### Testing

Live in `us-west-2` on an account with no pre-existing Harness resources — each
sample provisioned, ran end to end, and cleaned up with no leaked role or harness:

- **01-custom-containers** — attached `node:slim`, agent wrote and ran a Node
  server, installed an npm package on the custom image; both the create and the
  `update_harness` poll reached READY.
- **03-execution-limits** — `maxIterations=1` → `max_iterations_exceeded`;
  `timeoutSeconds=5` → `timeout_exceeded`; `maxTokens=256` → **not** truncated
  (1413 output tokens, `end_turn`), confirming the corrected behaviour.
- **04-mcp-integration** — MCP tools loaded and invoked across Parts 1–2, the
  invalid-URL error path (Part 4) surfaced cleanly, Part 5 ran.
- **13-aws-skills** — `--mode glob` loaded `core-skills/*` and the agent
  enumerated them (this is the sample that needs the boto3 floor from #1857).

`ruff check` and `ruff format --check` clean on all four files.
