### PR TITLE
fix(01-harness): fix memory lifecycle, share the poller, and stop leaking the role in 3 use-case samples

### DIFF
--- a/01-features/01-harness/02-use-cases/01-travel-agent/README.md
+++ b/01-features/01-harness/02-use-cases/01-travel-agent/README.md
@@ -83,7 +83,7 @@ Navigate to **CloudWatch → X-Ray → Traces** to see the full agent loop break
 ## Troubleshooting
 
 ### Issue: memory creation fails with `ConflictException`
-**Solution**: A memory named `TravelGuideMemory` already exists. The script handles this by listing and reusing it. If you want a fresh memory, delete the old one first.
+**Solution**: A memory named `TravelGuideMemory` already exists — usually left behind by an earlier run that did not finish cleaning up. The script only deletes memories it created itself, so it will not silently reuse and then delete one it does not own; it prints a warning and skips the memory demo. Delete the leftover memory (`aws bedrock-agentcore-control delete-memory --memory-id <id>`), or re-run with `--skip-memory`.
 
 ### Issue: Part 4 takes too long
 **Solution**: memory provisioning takes 3-5 minutes. Use `--skip-memory` to skip the memory demo entirely.

--- a/01-features/01-harness/02-use-cases/01-travel-agent/travel_agent.py
+++ b/01-features/01-harness/02-use-cases/01-travel-agent/travel_agent.py
@@ -35,8 +35,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 parser = argparse.ArgumentParser(description="Travel Guide Agent — Harness use case demo")
@@ -46,6 +47,13 @@ args = parser.parse_args()
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+MEMORY_NAME = "TravelGuideMemory"
+
+# Memory provisioning is slower than a harness and has its own status enum:
+# CREATING → ACTIVE, with a plain FAILED (unlike the harness, which reports
+# CREATE_FAILED and has no bare FAILED). There is no READY for a memory.
+MEMORY_POLL_INTERVAL = 10
+MEMORY_POLL_TIMEOUT = 600
 
 # ── Setup ─────────────────────────────────────────────────────────────────────
 control = get_agentcore_control_client()
@@ -59,12 +67,12 @@ print(f"Account: {account_id}")
 
 def stream_response(harness_arn, session_id, message, tools=None):
     """Invoke harness and stream the response. Returns accumulated text."""
-    kwargs = dict(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": message}]}],
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-    )
+    kwargs = {
+        "harnessArn": harness_arn,
+        "runtimeSessionId": session_id,
+        "messages": [{"role": "user", "content": [{"text": message}]}],
+        "model": {"bedrockModelConfig": {"modelId": MODEL_ID}},
+    }
     if tools:
         kwargs["tools"] = tools
 
@@ -128,6 +136,26 @@ def fetch_file(harness_arn, session_id, remote_path):
     return content
 
 
+def poll_memory_status(memory_id, timeout=MEMORY_POLL_TIMEOUT):
+    """Wait for a Memory to reach ACTIVE. Returns the memory dict.
+
+    Raises RuntimeError on FAILED and TimeoutError if it never settles, so the
+    caller cannot go on to attach a memory that is not usable yet.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        memory = control.get_memory(memoryId=memory_id)["memory"]
+        status = memory.get("status", "UNKNOWN")
+        print(f"  Memory status: {status}")
+        if status == "ACTIVE":
+            return memory
+        if status == "FAILED":
+            raise RuntimeError(f"Memory {memory_id} FAILED: {memory.get('failureReason', 'no reason given')}")
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"Memory {memory_id} not ACTIVE after {timeout}s (last status: {status})")
+        time.sleep(MEMORY_POLL_INTERVAL)
+
+
 harness_id = None
 memory_id = None
 
@@ -147,13 +175,11 @@ try:
     print(f"Harness ID:  {harness_id}")
     print(f"Harness ARN: {harness_arn}")
 
-    for i in range(12):
-        status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-        print(f"  [{i + 1}] {status}")
-        if status == "READY":
-            print("✅ Harness ready")
-            break
-        time.sleep(5)
+    # A harness routinely takes ~2-3 minutes to reach READY, so wait for the real
+    # status instead of a fixed number of polls — the old 12 x 5s ceiling expired
+    # first and let the sample invoke a harness that was still CREATING.
+    poll_harness_status(control, harness_id)
+    print("✅ Harness ready")
 
     # ── Part 2: Invoke Agent — HTML Travel Guide ──────────────────────────────
     print("\n=== Part 2: Invoke Agent — HTML Travel Guide ===")
@@ -187,49 +213,41 @@ try:
     if not args.skip_memory:
         print("\n=== Part 4: AgentCore Memory — Multi-Turn Conversation ===")
         print("Creating Memory instance (takes ~3-5 minutes)...")
+        # `memory_id` is only ever set when *this* run created the memory, so the
+        # cleanup below can never delete a memory that already belonged to the
+        # account. The previous version fell back to adopting any memory whose id
+        # contained "TravelGuide" and then deleted it on the way out, which
+        # destroyed a resource the sample did not own.
         try:
             resp = control.create_memory(
-                name="TravelGuideMemory",
+                name=MEMORY_NAME,
                 eventExpiryDuration=30,
                 description="Memory for TravelGuideAgent",
             )
-            memory_id = resp.get("id") or resp.get("memory", {}).get("id")
-        except Exception as e:
-            print(f"Create returned: {e}")
-            memory_id = None
+        except control.exceptions.ConflictException:
+            print(f"⚠️  A memory named {MEMORY_NAME} already exists — most likely left")
+            print("    behind by an earlier run that did not finish cleaning up.")
+            print("    Delete it, or re-run with --skip-memory. Skipping Part 4.")
+            resp = None
 
-        if not memory_id:
-            print("Looking for existing TravelGuideMemory...")
-            resp = control.list_memories()
-            for m in resp.get("memories", []):
-                if "TravelGuide" in m.get("id", ""):
-                    memory_id = m["id"]
-                    break
+        if resp:
+            memory_id = resp["memory"]["id"]
+            print(f"Memory ID: {memory_id}")
 
-        if memory_id:
-            for i in range(30):
-                resp = control.get_memory(memoryId=memory_id)
-                status = resp.get("status", resp.get("memory", {}).get("status", "UNKNOWN"))
-                print(f"  [{i + 1}] {status}")
-                if status in ("ACTIVE", "READY"):
-                    print("✅ Memory ready")
-                    break
-                time.sleep(10)
+            memory = poll_memory_status(memory_id)
+            memory_arn = memory["arn"]
+            print(f"✅ Memory ready — {memory_arn}")
 
-            memory_arn = resp.get("memory", {}).get("arn") or resp.get("arn")
             control.update_harness(
                 harnessId=harness_id,
                 memory={"optionalValue": {"agentCoreMemoryConfiguration": {"arn": memory_arn}}},
             )
-            print(f"Memory ARN: {memory_arn}")
             print("Waiting for harness to update with memory...")
-            for i in range(12):
-                status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-                print(f"  [{i + 1}] {status}")
-                if status == "READY":
-                    print("✅ Harness updated with memory")
-                    break
-                time.sleep(5)
+            # UpdateHarness moves the harness back through UPDATING; the shared
+            # poller waits for the real terminal status instead of a fixed number
+            # of polls, so the turns below cannot run against a mid-update harness.
+            poll_harness_status(control, harness_id)
+            print("✅ Harness updated with memory")
 
             # Multi-turn test
             memory_session_id = str(uuid.uuid4()).upper()
@@ -247,8 +265,6 @@ try:
                 memory_session_id,
                 "What's my name and what kind of music do I like? Recommend a place in Amsterdam where I can enjoy it.",
             )
-        else:
-            print("⚠️  Could not create or find TravelGuideMemory — skipping")
 
     # ── Part 5: Browser Tool — Live Weather Data ──────────────────────────────
     print("\n=== Part 5: Browser Tool — Live Amsterdam Weather ===")
@@ -345,18 +361,22 @@ try:
 finally:
     if not args.skip_cleanup:
         print("\n=== Cleanup ===")
+        # Delete the harness first: it holds a reference to the memory, and the
+        # role is what every other sample in this folder shares, so it goes last.
+        # Each delete stands alone — one failure must not skip the rest, or the
+        # leftovers silently break the next run.
         if harness_id:
             try:
                 control.delete_harness(harnessId=harness_id)
                 print(f"Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"Warning: {e}")
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                print(f"Warning: could not delete harness {harness_id}: {e}")
         if memory_id:
             try:
                 control.delete_memory(memoryId=memory_id)
                 print(f"Deleted memory: {memory_id}")
-            except Exception as e:
-                print(f"Warning: {e}")
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                print(f"Warning: could not delete memory {memory_id}: {e}")
         delete_harness_role()
         print("Done.")
     else:

--- a/01-features/01-harness/02-use-cases/02-webapp-visual-testing/webapp_visual_testing.py
+++ b/01-features/01-harness/02-use-cases/02-webapp-visual-testing/webapp_visual_testing.py
@@ -42,8 +42,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 parser = argparse.ArgumentParser(description="Automated Visual QA with Harness")
@@ -99,14 +100,12 @@ try:
     print(f"Harness ID:  {harness_id}")
     print(f"Harness ARN: {harness_arn}")
 
-    # Wait for READY before updating (update_harness rejects while CREATING)
+    # Wait for READY before updating (update_harness rejects while CREATING).
+    # This has to wait for the real status rather than a fixed number of polls:
+    # the old ceiling could expire while the harness was still CREATING, and the
+    # update below then failed with a ConflictException.
     print("Waiting for harness to become READY...")
-    for i in range(24):
-        status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-        print(f"  [{i + 1}] {status}")
-        if status == "READY":
-            break
-        time.sleep(5)
+    poll_harness_status(control, harness_id)
 
     print(f"Attaching Node.js container ({NODE_CONTAINER})...")
     control.update_harness(
@@ -114,13 +113,8 @@ try:
         environmentArtifact={"optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}},
     )
 
-    for i in range(24):
-        status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-        print(f"  [{i + 1}] {status}")
-        if status == "READY":
-            print("✅ Harness ready with Node.js container")
-            break
-        time.sleep(5)
+    poll_harness_status(control, harness_id)
+    print("✅ Harness ready with Node.js container")
 
     # ── Part 2: Prepare the Environment ──────────────────────────────────────
     print("\n=== Part 2: Prepare Environment ===")
@@ -276,7 +270,7 @@ Then list the screenshots: ls -la /tmp/screenshot_*.png"""
                 f.write(img_bytes)
             screenshots_saved.append(local_path)
             print(f"✅ Screenshot {i}: {len(img_bytes):,} bytes → {local_path}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - a bad screenshot must not abort the rest
             print(f"⚠️  Screenshot {i}: decode failed — {e}")
 
     print(f"\nRetrieved {len(screenshots_saved)} screenshots")
@@ -292,8 +286,8 @@ finally:
             try:
                 control.delete_harness(harnessId=harness_id)
                 print(f"Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"Warning: {e}")
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                print(f"Warning: could not delete harness {harness_id}: {e}")
         delete_harness_role()
         print("Done.")
     else:

--- a/01-features/01-harness/02-use-cases/03-aws-builder-agent/aws_builder_agent.py
+++ b/01-features/01-harness/02-use-cases/03-aws-builder-agent/aws_builder_agent.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 AWS Builder Agent — building agents with the harness + AWS Skills
 
@@ -55,8 +54,9 @@ import botocore.exceptions
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from utils.iam import create_harness_role
 from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
+from utils.iam import create_harness_role, delete_harness_role
 
 REGION = os.getenv("AWS_DEFAULT_REGION")
 
@@ -77,9 +77,6 @@ SCAFFOLD_PROMPT = (
     "README.md, and a package.json. Write real, runnable starter code — not "
     "placeholders. When done, list the files you created."
 )
-
-HARNESS_POLL_INTERVAL = 5
-HARNESS_POLL_TIMEOUT = 180
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────────
@@ -125,23 +122,6 @@ parser.add_argument(
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
-def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
-    """Poll until a Harness reaches the target status or times out."""
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = control.get_harness(harnessId=harness_id)
-        status = resp["harness"]["status"]
-        print(f"  Harness status: {status}")
-        if status == target_status:
-            return resp
-        if status in ("FAILED", "DELETE_FAILED"):
-            reason = resp["harness"].get("failureReason", "")
-            raise RuntimeError(f"Harness entered {status}. {reason}")
-        if time.monotonic() > deadline:
-            raise TimeoutError(f"Harness not {target_status} after {timeout}s (current: {status})")
-        time.sleep(HARNESS_POLL_INTERVAL)
-
-
 def stream_turn(client, harness_arn, session_id, message, model_id, raw=False):
     """Invoke the harness for one conversational turn and stream the response."""
     response = client.invoke_harness(
@@ -208,6 +188,7 @@ def main(args=None):
     design_prompt = args.message or DESIGN_PROMPT
     skills = [{"awsSkills": {"paths": args.skill_paths}}]
     harness_id = None
+    created_role = False
 
     try:
         # ── Step 0: IAM role ──────────────────────────────────────────
@@ -219,6 +200,7 @@ def main(args=None):
             print(f"  Using provided role: {role_arn}")
         else:
             role_arn = create_harness_role()
+            created_role = True
             print("  Waiting for IAM propagation...")
             time.sleep(10)
 
@@ -276,13 +258,21 @@ def main(args=None):
         print("=" * 60)
 
     finally:
-        if not args.skip_cleanup and harness_id:
+        if not args.skip_cleanup:
             print("\nCleaning up...")
-            try:
-                control.delete_harness(harnessId=harness_id)
-                print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"  Warning: failed to delete harness: {e}")
+            if harness_id:
+                try:
+                    control.delete_harness(harnessId=harness_id)
+                    print(f"  Deleted harness: {harness_id}")
+                except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                    print(f"  Warning: failed to delete harness: {e}")
+            # Delete the execution role too, but only the one we created — the
+            # role name is shared by every sample in this folder, so deleting a
+            # role the caller passed in with --role-arn would destroy something
+            # we don't own. Without this the role outlived the script and was
+            # left behind on any failure before Step 1 completed.
+            if created_role:
+                delete_harness_role()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Issue number**: _to follow_

### Concise description of the PR

```
Changes to the three use-case Harness samples (01-travel-agent, 02-webapp-visual-testing,
03-aws-builder-agent), applying the shared poller and role-lifecycle fixes from #1857/#1864
and correcting a cluster of AgentCore Memory lifecycle bugs in the travel agent.
```

### What changed

- **03-aws-builder-agent** — **never deleted the shared execution role at all**; it imported only `create_harness_role`. Every sample in this folder shares the role name `HarnessExecutionRole`, so the leftover role breaks the next sample's run. Now deletes it in `finally`, guarded by a `created_role` flag so a caller-supplied `--role-arn` is never destroyed. Also drops its private poller for the shared one — the local copy checked for a `"FAILED"` status that isn't in the enum (`CREATE_FAILED` / `UPDATE_FAILED` / `DELETE_FAILED`), so it could never detect a real failure, and its 180s ceiling left little margin over the ~145s a harness actually takes.

- **02-webapp-visual-testing** — both wait-for-READY loops were `for i in range(24)` with a 5s sleep: a hard 120s ceiling, while the live run needed ~145s. The loop fell through instead of raising, so the `update_harness` call that attaches the Node container then failed with `ConflictException`. Both replaced with `poll_harness_status`.

- **01-travel-agent — Memory lifecycle.** Four separate bugs in Part 4:
  - `create_memory` / `get_memory` return the resource under a top-level `"memory"` key only, so `resp.get("id") or resp.get("memory", {}).get("id")` had a **dead first branch**. Verified live: `resp.get("id")` is `None`.
  - The Memory status enum is `CREATING → ACTIVE` with a plain `FAILED` and **no `READY`** — different from the harness enum. The old loop waited for `("ACTIVE", "READY")` and never checked `FAILED`, so a failed memory was polled to the ceiling and its `failureReason` never surfaced. New `poll_memory_status()` honours the real enum and raises with the reason.
  - It fell back to **adopting any memory whose id contained `"TravelGuide"`** and then deleted it during cleanup — destroying a resource the sample doesn't own. `memory_id` is now only set when this run created the memory; a pre-existing one raises `ConflictException`, which is caught and the memory demo skipped with a clear message.
  - The harness create-wait (`range(12)`, a 60s ceiling versus ~145s observed) and the post-`update_harness` wait both replaced with the shared poller.
  - Cleanup deletes the harness before the memory it references, each guard independent so one failure can't skip the role deletion.

- Cleared pre-existing lint debt on the touched files (import order, `dict()` → literal, blind-except `noqa`) and removed a decorative shebang (EXE001), matching what #1864 did for `aws_skills.py`.

### User experience

Before, on a fresh account: **aws-builder-agent** completed successfully but left `HarnessExecutionRole` behind, so whichever sample ran next inherited a stale role with nothing pointing at the cause. **webapp-visual-testing** timed out at 120s while the harness was still `CREATING`, then failed the container attach with `ConflictException`. **travel-agent** could invoke a harness that was still `CREATING`, and its Memory step never reported a genuine failure — and if a `TravelGuideMemory` already existed, the sample silently adopted it and deleted it on the way out.

After, each sample waits for the real status, raises immediately with the service's `failureReason` on a genuine failure, only ever deletes resources it created itself, and leaves nothing behind.
