### PR TITLE
fix(os-actions): remove trailing slash from base_url to prevent doubl…

### DIFF
--- a/01-features/03-connect-your-agent-to-anything/02-browser/13-os-actions/os_actions.py
+++ b/01-features/03-connect-your-agent-to-anything/02-browser/13-os-actions/os_actions.py
@@ -276,7 +276,7 @@ def main():
     print(f"Created browser: {browser_id}")
 
     # Setup endpoint and credentials
-    base_url = f"https://bedrock-agentcore.{region}.amazonaws.com/"
+    base_url = f"https://bedrock-agentcore.{region}.amazonaws.com"
     credentials, _ = get_credentials(region)
 
     # Start session

--- a/01-features/03-connect-your-agent-to-anything/02-browser/13-os-actions/os_actions.py
+++ b/01-features/03-connect-your-agent-to-anything/02-browser/13-os-actions/os_actions.py
@@ -175,16 +175,16 @@ def delete_execution_role(role_name: str) -> None:
     policy_arn = f"arn:aws:iam::{account_id}:policy/BrowserOSActPolicy"
     try:
         iam.detach_role_policy(RoleName=role_name, PolicyArn=policy_arn)
-    except Exception:
-        pass
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not detach role policy: {e}")
     try:
         iam.delete_role_policy(RoleName=role_name, PolicyName="BrowserOSActPolicy")
-    except Exception:
-        pass
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not delete inline policy: {e}")
     try:
         iam.delete_role(RoleName=role_name)
         print(f"Deleted IAM role: {role_name}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Could not delete role: {e}")
 
 
@@ -296,7 +296,7 @@ def main():
         try:
             cp_client.delete_browser(browserId=browser_id)
             print(f"Deleted browser: {browser_id}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Could not delete browser: {e}")
         delete_execution_role(role_name)
     else:


### PR DESCRIPTION
…e-slash 404s

# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**:

##  Concise description of the PR                                                                                                                                                                              
   
  Remove trailing slash from base_url in os_actions.py, because the helper                                                                                                                                   
  functions (start_session, stop_session, invoke) each prepend a leading '/'                                                                                                                                 
  to their path segments, producing double-slash URLs                                                                                                                                                        
  (e.g. //browsers/<id>/sessions/start) that result in HTTP 404 errors.                                                                                                                                      
                                                                                                                                                                                                             
##  User experience                                                                                                                                                                                            
                                                                                                                                                                                                             
  ▎ Before: Running os_actions.py fails immediately after browser creation with requests.exceptions.HTTPError: 404 Client Error: Not Found — the session never starts and none of the OS-level actions       
  execute.                                                                                                                                                                                                 
                                                                                                                                                                                                             
  ▎ After: base_url has no trailing slash, so all constructed URLs are well-formed (e.g. https://bedrock-agentcore.<region>.amazonaws.com/browsers/<id>/sessions/start). The session starts successfully and 
  the full mouse, scroll, keyboard, and screenshot action demo runs to completion.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [ x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [x ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x ] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x ] I have performed a self-review of this change
* [x ] Changes have been tested
* [ x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
