### PR TITLE
fix(01-harness): stop 01-custom-containers prompting for tools its images lack

### DIFF
--- a/01-features/01-harness/01-advanced-examples/01-custom-containers/README.md
+++ b/01-features/01-harness/01-advanced-examples/01-custom-containers/README.md
@@ -36,10 +36,15 @@ By default, harness runs on Amazon Linux 2023 with Python. Custom containers let
                 │
                 ▼
         [Firecracker microVM]
-        - node, npm, full Node.js ecosystem
-        - Agent can install packages, run servers, use curl
+        - Whatever the image ships (e.g. node + npm, or the Go toolchain)
+        - Agent can install packages and run servers
         - Same session ID = same VM state persists
 ```
+
+> **Only what the image ships is available.** Minimal base images omit tools you
+> may take for granted: `python:3.12-slim` has neither `curl` nor `wget`, and
+> `golang:1.24` has no `file`. Prefer language built-ins (Node's `http`, Python's
+> `urllib`) over shelling out, or install the tool first.
 
 ## Sample Prompts
 
@@ -52,8 +57,11 @@ By default, harness runs on Amazon Linux 2023 with Python. Custom containers let
 **Prompt (node/npm)**: "Install chalk and write a colorful banner script."
 **Expected Behavior**: Agent runs `npm install chalk`, writes `colors.js`, executes it showing colored output.
 
+**Prompt (python)**: "Write a Python HTTP server on port 3000 that returns JSON with the current time. Test it, then kill the server."
+**Expected Behavior**: Agent creates `/tmp/server.py` using `http.server`, starts it in background, makes a request with `urllib` (the `python:3.12-slim` image has no `curl` or `wget`), shows JSON output, kills server.
+
 **Prompt (go/cross-compile)**: "Cross-compile for linux/amd64 and show the file info."
-**Expected Behavior**: Agent sets `GOOS=linux GOARCH=amd64`, runs `go build -o goserver_linux_amd64`, shows file with `file` command.
+**Expected Behavior**: Agent sets `GOOS=linux GOARCH=amd64`, runs `go build -o goserver_linux_amd64`, shows the size with `ls -lh` and the architecture with `readelf -h` (the `golang:1.24` image has no `file` binary).
 
 ## Key Concepts
 

--- a/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
+++ b/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
@@ -138,9 +138,11 @@ def stream_invoke(harness_arn, session_id, message, model_id=args.model):
         except client.exceptions.RuntimeClientError as e:
             if attempt == INVOKE_MAX_ATTEMPTS:
                 raise
-            print(f"  Runtime not ready yet ({e.response['Error']['Code']}); "
-                  f"retrying in {INVOKE_RETRY_DELAY}s "
-                  f"[attempt {attempt}/{INVOKE_MAX_ATTEMPTS}]")
+            print(
+                f"  Runtime not ready yet ({e.response['Error']['Code']}); "
+                f"retrying in {INVOKE_RETRY_DELAY}s "
+                f"[attempt {attempt}/{INVOKE_MAX_ATTEMPTS}]"
+            )
             time.sleep(INVOKE_RETRY_DELAY)
     for event in response["stream"]:
         if "contentBlockStart" in event:

--- a/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
+++ b/01-features/01-harness/01-advanced-examples/01-custom-containers/custom_container.py
@@ -70,7 +70,8 @@ LANGUAGE_PRESETS = {
             "Write a Python HTTP server using http.server that listens on port 3000 "
             "and returns JSON with the current time, Python version, OS, and platform info. "
             "Save it to /tmp/server.py. Then test it: start the server in the background, "
-            "curl localhost:3000, and kill the server. Show the output."
+            "make an HTTP request using Python's urllib (the python:3.12-slim image has no "
+            "curl or wget), and kill the server. Show the output."
         ),
     },
 }
@@ -108,16 +109,39 @@ account_id = boto3.client("sts").get_caller_identity()["Account"]
 print(f"Account: {account_id}")
 print(f"Language: {args.language}  Container: {container_uri}")
 
+# The first invoke against a freshly attached container can race the microVM's
+# health check. Three attempts 15s apart covers the lag seen in practice without
+# masking a genuinely broken image, which fails every attempt the same way.
+INVOKE_MAX_ATTEMPTS = 3
+INVOKE_RETRY_DELAY = 15
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
 def stream_invoke(harness_arn, session_id, message, model_id=args.model):
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": message}]}],
-        model={"bedrockModelConfig": {"modelId": model_id}},
-    )
+    # A harness reporting READY does not guarantee the custom container's microVM
+    # is already answering health checks: the first invoke of a session boots a
+    # fresh VM from the image, and that has been observed losing the race, with
+    # InvokeHarness raising "Runtime health check failed or timed out" while the
+    # container itself logged a clean startup. Retrying the call absorbs it.
+    # Only the call is retried, never a stream that already yielded output, so no
+    # text can be printed twice.
+    for attempt in range(1, INVOKE_MAX_ATTEMPTS + 1):
+        try:
+            response = client.invoke_harness(
+                harnessArn=harness_arn,
+                runtimeSessionId=session_id,
+                messages=[{"role": "user", "content": [{"text": message}]}],
+                model={"bedrockModelConfig": {"modelId": model_id}},
+            )
+            break
+        except client.exceptions.RuntimeClientError as e:
+            if attempt == INVOKE_MAX_ATTEMPTS:
+                raise
+            print(f"  Runtime not ready yet ({e.response['Error']['Code']}); "
+                  f"retrying in {INVOKE_RETRY_DELAY}s "
+                  f"[attempt {attempt}/{INVOKE_MAX_ATTEMPTS}]")
+            time.sleep(INVOKE_RETRY_DELAY)
     for event in response["stream"]:
         if "contentBlockStart" in event:
             start = event["contentBlockStart"].get("start", {})
@@ -170,8 +194,11 @@ try:
         time.sleep(10)
 
     # ── Step 1: Create Harness ────────────────────────────────────────────────
+    # Name after the selected language, not a hardcoded "NodeContainer" — a Go or
+    # Python run mislabelled as Node makes leaked resources (and their auto-named
+    # managed memory) impossible to tell apart in the console.
     print("\n=== Step 1: Create Harness ===")
-    HARNESS_NAME = f"NodeContainer_{uuid.uuid4().hex[:8]}"
+    HARNESS_NAME = f"{args.language.capitalize()}Container_{uuid.uuid4().hex[:8]}"
     resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
     harness = resp["harness"]
     harness_id = harness["harnessId"]
@@ -243,7 +270,8 @@ try:
             session_id,
             "Cross-compile the /tmp/goserver/main.go binary for linux/amd64. "
             "Use GOOS=linux GOARCH=amd64 go build -o /tmp/goserver_linux_amd64. "
-            "Show the file size and architecture using 'file' command.",
+            "Show the file size with ls -lh and the architecture with 'readelf -h' "
+            "(the golang:1.24 image has no 'file' binary).",
         )
 
     elif args.language == "python":


### PR DESCRIPTION
## Problem

`01-features/01-harness/01-advanced-examples/01-custom-containers` asks the agent to run three tools that are **not present in the container images the sample itself attaches**, and the README documents the resulting output as the expected behaviour.

| Preset | Image | Sample asks for | Actually in the image |
|---|---|---|---|
| `python` | `python:3.12-slim` | `curl localhost:3000` | no `curl`, no `wget` |
| `go` | `golang:1.24` | architecture "using `'file'` command" | no `file` |

The `go` case is visible in a live transcript. The agent tries `file`, fails, and recovers on its own:

> Now let's check the file size and architecture:
> **Let me try with readelf as an alternative to show the architecture:**

So the demo passes while doing something other than what [README.md](../blob/main/01-features/01-harness/01-advanced-examples/01-custom-containers/README.md) says it does, at the cost of a wasted turn.

The README's Architecture block also advertised "use curl" for *every* image and described the microVM as Node-only, and it documented **no python prompt at all** even though `--language python` is a supported preset.

## Changes

- **`python` prompt** → asks for `urllib` instead of `curl`, naming why.
- **`go` Part 5 prompt** → asks for `ls -lh` + `readelf -h` directly. Shell calls in that step drop from **3 to 2** and the fallback turn disappears.
- **README** → generalised the Architecture block, added a note that minimal images omit common tools, added the missing python prompt, corrected the cross-compile expected behaviour.
- **Bounded retry on the first `invoke_harness`** (3 attempts, 15 s apart, on `RuntimeClientError`). A harness reporting `READY` does not guarantee the container's microVM is answering health checks yet: one python run died with `Runtime health check failed or timed out` while that runtime's own CloudWatch log group recorded a clean startup and **zero** errors. Only the *call* is retried, never a stream that already emitted output, so no text can print twice. A genuinely broken image still fails, on every attempt, and raises.
- **Harness naming follows `--language`** — Go/Python runs no longer create resources labelled `NodeContainer_*`, which made leaked resources and their auto-named managed memory indistinguishable in the console.

## Testing

All three presets deployed, invoked and torn down live in `us-west-2`, each exit 0:

| Preset | Result | Evidence |
|---|---|---|
| `go` | PASS | `readelf` on the first try, no fallback turn; cross-compiled 8,454,144-byte ELF64 x86-64 |
| `python` | PASS | agent used `urllib.request`, HTTP 200, no `curl` attempt |
| `node` | PASS | unchanged default path; node v26.5.1 / npm 11.17.0; chalk installed and ran |

Retry logic additionally unit-tested on four paths: healthy first call (1 attempt, no retry), transient failure then success (output printed exactly once), recovery on the final attempt, and a permanently broken runtime (raises after exactly 3 attempts, no infinite loop).

Teardown verified after every run — harness, inline policy and role all deleted; `HarnessExecutionRole` confirmed absent afterwards.