### PR TITLE
fix(01-harness): correct the gateway docs, harden the pollers, stop leaking the role

### DIFF
--- a/01-features/01-harness/01-advanced-examples/02-gateway-integration/README.md
+++ b/01-features/01-harness/01-advanced-examples/02-gateway-integration/README.md
@@ -18,30 +18,40 @@ discovers and calls tools via the gateway.
 ## What is AgentCore gateway?
 
 AgentCore gateway is a managed proxy between your agent and external tool servers (MCP, HTTP).
-It provides centralized auth, routing rules, and observability for all tool traffic — without
+It gives you one place to handle auth, routing and observability for all tool traffic — without
 changing your agent code.
 
 ```
 [harness] → tools=[{type: "agentcore_gateway", gatewayArn: ...}]
                 │
-                ▼
-            [gateway] ── auth + routing + observability
+                ▼   inbound auth: authorizerType (NONE here)
+            [gateway] ── routing + observability
                 │
-                ▼
+                ▼   outbound auth: credentialProviderConfigurations (unset here)
             [MCP Target] ── external MCP server
 ```
 
 ## End-to-End Flow
 
+The step numbers match the ones the script prints:
+
 ```
-1. Create IAM execution role   (reuses utils/iam.py helper)
-2. Create gateway              → IAM auth + MCP protocol
-3. Add MCP target              → remote MCP server endpoint (default: Exa)
-4. Create routing rule         → directs traffic to the target
-5. Create harness              → wired to the gateway's ARN
-6. invoke_harness              → agent discovers tools via gateway and calls them
-7. Cleanup                     → delete harness, target, gateway, IAM role
+Step 0. Create IAM execution role   (reuses utils/iam.py helper)
+Step 1. Create gateway              → MCP protocol, no inbound authorizer
+Step 2. Add MCP target              → remote MCP server endpoint (default: Exa)
+Step 3. Create harness              → plain harness; it holds no gateway reference
+Step 4. invoke_harness              → passes the gateway ARN in `tools`, agent calls them
+Then    Cleanup                     → delete harness, target, gateway, IAM role
 ```
+
+The harness and the gateway are not bound to each other. `create_harness` takes no
+gateway parameter — the gateway ARN travels per-invoke in the `tools` argument to
+`invoke_harness`, so one harness can be pointed at different gateways on different
+calls, and deleting either resource has no effect on the other.
+
+A gateway routes to its targets as soon as they are `READY`, so no routing rule is
+needed to run this sample. Rules (`CreateGatewayRule`) are a separate, optional
+feature for shaping traffic across multiple targets.
 
 ## Sample Prompts
 
@@ -63,15 +73,42 @@ changing your agent code.
 
 **Target routing**: Targets can be MCP servers, Lambda functions, or HTTP endpoints. A single gateway can have multiple targets.
 
-**IAM auth (`NONE` type)**: This example uses `authorizerType=NONE` for simplicity. For production, use `CUSTOM_JWT` with a Cognito user pool (see `07-oauth/`).
+**Two independent authorization sides**: a gateway controls inbound and outbound auth separately, and this sample uses neither, to keep the focus on the plumbing.
+
+| | Parameter | Values | This sample |
+|:--|:--|:--|:--|
+| **Inbound** — who may call the gateway | `authorizerType` on `create_gateway` | `NONE`, `AWS_IAM`, `CUSTOM_JWT`, `AUTHENTICATE_ONLY` | `NONE` |
+| **Outbound** — how the gateway authenticates to the tool server | `credentialProviderConfigurations` on `create_gateway_target` | `GATEWAY_IAM_ROLE`, `OAUTH`, `API_KEY`, `CALLER_IAM_CREDENTIALS`, `JWT_PASSTHROUGH` | not set |
+
+`NONE` means no inbound authorizer — it is not "IAM auth"; `AWS_IAM` is a separate value this sample does not use. For production, use `CUSTOM_JWT` with a Cognito user pool (see `07-oauth/`, which configures both sides).
 
 ## Troubleshooting
 
 ### Issue: gateway stays in `CREATING` for >2 minutes
-**Solution**: gateway provisioning can take up to 2-3 minutes. The polling loop handles this — just wait.
+**Solution**: gateway provisioning can take up to 2-3 minutes, and the polling loop allows 300s, so just wait. In practice both the gateway and the target reach `READY` within about 5 seconds.
 
 ### Issue: Target `FAILED` status
-**Solution**: Check the MCP endpoint is reachable. The default Exa endpoint (`https://mcp.exa.ai/mcp`) requires public internet access from the gateway.
+**Solution**: Check the MCP endpoint is reachable. The default Exa endpoint (`https://mcp.exa.ai/mcp`) requires public internet access from the gateway. The poller raises with the service's `statusReasons`, which names the actual cause.
+
+### Issue: `Gateway UPDATE_UNSUCCESSFUL` or `Target SYNCHRONIZE_UNSUCCESSFUL`
+**Solution**: These are the failure statuses for updates rather than creates — a gateway reports `UPDATE_UNSUCCESSFUL`, not `FAILED`, and a target adds `SYNCHRONIZE_UNSUCCESSFUL`. Both are treated as terminal so the run stops with `statusReasons` instead of polling until it times out.
+
+### Issue: Target stuck in `CREATE_PENDING_AUTH`
+**Solution**: The target is waiting on an outbound authorization that will not complete by itself — normally an OAuth credential provider whose consent flow has not been finished. This sample sets no credential provider, so it should not reach this state; if it does, check the `credentialProviderConfigurations` on the target.
+
+### Issue: the tool call fails with HTTP 429
+**Solution**: The default Exa endpoint is anonymous, and its free tier is rate limited and shared, so a busy account can exhaust it. Supply your own Exa API key as an outbound credential on the target — store the key in the token vault as an API-key credential provider, then pass it to `create_gateway_target`:
+
+```python
+credentialProviderConfigurations=[{
+    "credentialProviderType": "API_KEY",
+    "credentialProvider": {"apiKeyCredentialProvider": {
+        "providerArn": "<token-vault api-key provider arn>",
+        "credentialLocation": "HEADER",
+        "credentialParameterName": "x-api-key",
+    }},
+}]
+```
 
 ### Issue: `Harness not READY after 600s`
 **Solution**: Harness provisioning is measured at ~150s on the public network and ~255s in VPC mode, so the shared poller in `utils/harness.py` allows 600s. Exceeding that usually means the harness is genuinely stuck rather than slow — check `get_harness` for a `CREATE_FAILED` status and its `failureReason`.
@@ -99,16 +136,23 @@ agentcore invoke --harness mygwagent \
 
 ## Clean Up
 
-Gateway targets must be deleted before the gateway:
+A target must be deleted before the gateway that owns it. The harness is
+independent of both, so its position in the sequence does not matter — the script
+deletes it first only so a long `ConflictException` wait cannot delay the rest.
 
 ```python
+harness_control.delete_harness(harnessId=harness_id)
 gw_control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id)
 time.sleep(10)
 gw_control.delete_gateway(gatewayIdentifier=gateway_id)
-harness_control.delete_harness(harnessId=harness_id)
+
+from utils.iam import delete_harness_role
+delete_harness_role()
 ```
 
-The script handles this automatically unless `--skip-cleanup` is passed.
+The script handles this automatically unless `--skip-cleanup` is passed. It only
+deletes the IAM role when it created the role itself — pass `--role-arn` and your
+own role is left alone.
 
 ## Running the Python Scripts
 

--- a/01-features/01-harness/01-advanced-examples/02-gateway-integration/gateway_integration.py
+++ b/01-features/01-harness/01-advanced-examples/02-gateway-integration/gateway_integration.py
@@ -1,17 +1,31 @@
 """
 AgentCore Gateway Integration with Harness.
 
-Demonstrates the full lifecycle of an AgentCore Gateway:
-  1. Create an IAM execution role
-  2. Create a Gateway with IAM auth and MCP protocol
-  3. Add an MCP target (remote MCP server endpoint)
-  4. Create a Harness wired to the Gateway
-  5. Invoke the agent — it discovers and calls tools via the Gateway
-  6. Clean up all resources
+Demonstrates the full lifecycle of an AgentCore Gateway (the step numbers below
+match the ones this script prints):
+  Step 0. Create an IAM execution role
+  Step 1. Create a Gateway with the MCP protocol and no inbound authorizer
+  Step 2. Add an MCP target (remote MCP server endpoint)
+  Step 3. Create a Harness (a plain Harness — it holds no Gateway reference)
+  Step 4. Invoke the agent, passing the Gateway ARN in `tools`
+  Then:   Clean up all resources
 
 AgentCore Gateway is a managed proxy between your agent and external tool servers
-(MCP, HTTP). It provides centralized auth, routing rules, and observability for
+(MCP, HTTP). It gives you one place to handle auth, routing and observability for
 all tool traffic.
+
+The Harness and the Gateway are not bound to each other: create_harness takes no
+Gateway parameter, and the Gateway ARN is supplied per-invoke in the `tools`
+argument to invoke_harness. So one Harness can be pointed at different Gateways on
+different calls, and deleting either resource does not affect the other.
+
+A Gateway has two independent authorization sides, and this sample deliberately
+uses neither, to keep the focus on the plumbing:
+  - Inbound (`authorizerType` on create_gateway): who is allowed to call the
+    Gateway. Set to NONE here. See 07-oauth for CUSTOM_JWT.
+  - Outbound (`credentialProviderConfigurations` on create_gateway_target): how
+    the Gateway authenticates to the tool server behind it. Not set here, because
+    the default Exa endpoint serves anonymous callers on a free tier.
 
 Usage:
     # Basic — uses the default Exa MCP search endpoint
@@ -34,7 +48,6 @@ Prerequisites:
 
 import argparse
 import json
-import os
 import sys
 import time
 import uuid
@@ -45,11 +58,9 @@ import botocore.exceptions
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from utils.iam import create_harness_role
-from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.client import REGION, get_agentcore_client, get_agentcore_control_client
 from utils.harness import HARNESS_POLL_INTERVAL, HARNESS_POLL_TIMEOUT, poll_harness_status
-
-REGION = os.getenv("AWS_DEFAULT_REGION")
+from utils.iam import create_harness_role, delete_harness_role
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 DEFAULT_MCP_ENDPOINT = "https://mcp.exa.ai/mcp"
@@ -62,7 +73,28 @@ DEFAULT_PROMPT = (
 )
 
 GATEWAY_POLL_INTERVAL = 5
-GATEWAY_POLL_TIMEOUT = 120
+# 300s to match 07-oauth's budget for the same two operations, and the "2-3
+# minutes" the README tells the reader to expect. The old 120s contradicted both:
+# gateway and target reach READY in ~5s in practice, so a run that is slow enough
+# to matter is one this poller would have abandoned right as it got going.
+GATEWAY_POLL_TIMEOUT = 300
+
+# Gateways report UPDATE_UNSUCCESSFUL rather than FAILED when an update fails, and
+# targets add SYNCHRONIZE_UNSUCCESSFUL. Polling for READY without treating these as
+# terminal burns the full timeout and then reports a TimeoutError, hiding the
+# statusReasons the service already returned.
+GATEWAY_FAILURE_STATUSES = ("FAILED", "UPDATE_UNSUCCESSFUL")
+TARGET_FAILURE_STATUSES = (*GATEWAY_FAILURE_STATUSES, "SYNCHRONIZE_UNSUCCESSFUL")
+
+# A target configured with outbound credentials can stop in one of these until the
+# authorization is completed out of band. This sample sets no credential provider,
+# so it cannot reach them — but waiting out the timeout on a state that will never
+# clear by itself is worth calling out rather than silently spinning.
+TARGET_PENDING_AUTH_STATUSES = (
+    "CREATE_PENDING_AUTH",
+    "UPDATE_PENDING_AUTH",
+    "SYNCHRONIZE_PENDING_AUTH",
+)
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 parser = argparse.ArgumentParser(
@@ -88,8 +120,8 @@ def poll_gateway_status(control, gateway_id, target_status="READY", timeout=GATE
         print(f"  Gateway status: {status}")
         if status == target_status:
             return resp
-        if status == "FAILED":
-            raise RuntimeError(f"Gateway FAILED: {resp.get('statusReasons', [])}")
+        if status in GATEWAY_FAILURE_STATUSES:
+            raise RuntimeError(f"Gateway {status}: {resp.get('statusReasons', [])}")
         if time.monotonic() > deadline:
             raise TimeoutError(f"Gateway not {target_status} after {timeout}s")
         time.sleep(GATEWAY_POLL_INTERVAL)
@@ -103,8 +135,13 @@ def poll_target_status(control, gateway_id, target_id, target_status="READY", ti
         print(f"  Target status: {status}")
         if status == target_status:
             return resp
-        if status in ("FAILED", "DELETE_FAILED"):
+        if status in TARGET_FAILURE_STATUSES:
             raise RuntimeError(f"Target {status}: {resp.get('statusReasons', [])}")
+        if status in TARGET_PENDING_AUTH_STATUSES:
+            raise RuntimeError(
+                f"Target {status}: it is waiting on an outbound authorization that will not "
+                f"complete on its own. {resp.get('statusReasons', [])}"
+            )
         if time.monotonic() > deadline:
             raise TimeoutError(f"Target not {target_status} after {timeout}s")
         time.sleep(GATEWAY_POLL_INTERVAL)
@@ -141,8 +178,16 @@ def stream_response(client, harness_arn, session_id, message, model_id, gateway_
                     full_text += delta["text"]
             elif "messageStop" in event:
                 print()
+            # internalServerException is not the only error the stream can carry:
+            # validationException and runtimeClientError are modelled events too, and
+            # falling through them printed nothing at all, so a rejected invoke looked
+            # like an agent that simply had no answer.
             elif "internalServerException" in event:
                 print(f"\n  Error: {event['internalServerException']}")
+            elif "validationException" in event:
+                print(f"\n  Validation error: {event['validationException']}")
+            elif "runtimeClientError" in event:
+                print(f"\n  Runtime error: {event['runtimeClientError']}")
     except botocore.exceptions.EventStreamError:
         if not full_text:
             raise
@@ -175,7 +220,7 @@ def _delete_harness(harness_control, harness_id, timeout=HARNESS_POLL_TIMEOUT):
             time.sleep(HARNESS_POLL_INTERVAL)
 
 
-def _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id):
+def _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id, created_role=False):
     if harness_id:
         _delete_harness(harness_control, harness_id)
     if gateway_id and target_id:
@@ -183,14 +228,20 @@ def _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id):
             gw_control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id)
             print(f"  Deleted target: {target_id}")
             time.sleep(10)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
     if gateway_id:
         try:
             gw_control.delete_gateway(gatewayIdentifier=gateway_id)
             print(f"  Deleted gateway: {gateway_id}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
+    # Delete the execution role too, but only the one we created — the role name
+    # is shared by every sample in this folder, so deleting a role the caller
+    # passed in with --role-arn would destroy something we don't own. Without
+    # this the role outlived the script and had to be removed by hand.
+    if created_role:
+        delete_harness_role()
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -204,6 +255,7 @@ def main(args=None):
     client = get_agentcore_client()
 
     gateway_id = target_id = harness_id = None
+    created_role = False
 
     try:
         # Step 0: IAM role
@@ -215,6 +267,7 @@ def main(args=None):
             print(f"  Using provided role: {role_arn}")
         else:
             role_arn = create_harness_role()
+            created_role = True
             print("  Waiting for IAM propagation...")
             time.sleep(10)
 
@@ -223,6 +276,11 @@ def main(args=None):
         print("Step 1: Create Gateway")
         print("=" * 60)
         gateway_name = f"GatewayDemo-{uuid.uuid4().hex[:8]}"
+        # authorizerType is the INBOUND control: who may call this Gateway. The
+        # full set is NONE | AWS_IAM | CUSTOM_JWT | AUTHENTICATE_ONLY. NONE keeps
+        # the sample to one moving part; it is not "IAM auth" — AWS_IAM is a
+        # separate value this sample does not use. Use CUSTOM_JWT in production
+        # (07-oauth shows it end to end with a Cognito user pool).
         resp = gw_control.create_gateway(
             name=gateway_name,
             roleArn=role_arn,
@@ -239,6 +297,19 @@ def main(args=None):
         print("\n" + "=" * 60)
         print(f"Step 2: Add MCP target ({args.mcp_endpoint})")
         print("=" * 60)
+        # No credentialProviderConfigurations here: that is the OUTBOUND control
+        # (how the Gateway authenticates to the tool server), and the default Exa
+        # endpoint serves anonymous callers. Exa's free tier is rate limited and
+        # shared, so a busy account can see the tool call fail with HTTP 429; pass
+        # your own key to lift it, e.g.
+        #   credentialProviderConfigurations=[{
+        #       "credentialProviderType": "API_KEY",
+        #       "credentialProvider": {"apiKeyCredentialProvider": {
+        #           "providerArn": "<token-vault api-key provider arn>",
+        #           "credentialLocation": "HEADER",
+        #           "credentialParameterName": "x-api-key",
+        #       }},
+        #   }]
         resp = gw_control.create_gateway_target(
             gatewayIdentifier=gateway_id,
             name=args.target_name,
@@ -287,7 +358,7 @@ def main(args=None):
     finally:
         if not args.skip_cleanup:
             print("\nCleaning up...")
-            _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id)
+            _cleanup(gw_control, harness_control, gateway_id, target_id, harness_id, created_role)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Concise description of the PR

The `02-gateway-integration` sample works end to end, but the README describes a different sample than the one that ships, the gateway pollers can't report the failures the service actually returns, and every run leaves the IAM execution role behind.

This builds on #1863 (this branch's direct parent), which fixed the *harness* poller in this file. The gateway pollers a few lines above it have the same two defects — a timeout shorter than the documented wait, and status checks against values the API never returns — and neither was in scope there.

**Documentation**

- **A "Create routing rule" step the sample never performs.** A gateway routes to its targets as soon as they report `READY`. Rules are real (`CreateGatewayRule` exists) but are a separate, optional feature for shaping traffic across multiple targets. Replaced with a note saying so.
- **"IAM auth (`NONE` type)" contradicts itself.** `NONE` means *no* inbound authorizer; `AWS_IAM` is a distinct value this sample doesn't use. It also collapsed two independent controls into one — the distinction `07-oauth` gets right, so the two samples disagreed. Replaced with a "Two independent authorization sides" section and an inbound/outbound table.
- **A harness "wired to the gateway's ARN" — no such binding exists.** `CreateHarness` takes no gateway parameter; the ARN travels per-invoke in `tools`. Stated the decoupling explicitly.
- **Step numbers didn't match the output** — README and docstring numbered 1–7, the script prints `Step 0`–`Step 4` plus cleanup.
- **The flow list promised cleanup would delete the IAM role**, which appears nowhere in the code, and the Clean Up snippet omits it too.
- **Three new troubleshooting entries:** HTTP 429 from Exa's shared free tier (with the outbound `API_KEY` config), the `UPDATE_UNSUCCESSFUL`/`SYNCHRONIZE_UNSUCCESSFUL` statuses, and a target stuck in `CREATE_PENDING_AUTH`.

**Code**

- **`GATEWAY_POLL_TIMEOUT` was 120s while the README promised "2-3 minutes."** Raised to 300s, matching `07-oauth`'s budget for these same operations. Both resources actually reach `READY` in ~5s, so the old ceiling only bit on the slow runs it was least able to survive.
- **The pollers checked for statuses the API never returns.** A gateway reports `UPDATE_UNSUCCESSFUL`, not `FAILED`, when an update fails; a target adds `SYNCHRONIZE_UNSUCCESSFUL`. Neither was terminal, so a failed resource was polled until timeout and `statusReasons` never surfaced. The target poller also tested `DELETE_FAILED`, which isn't in the target enum at all — a dead branch. The three `*_PENDING_AUTH` states now fail fast instead of spinning on a state that can't clear by itself.
- **The stream handler named only `internalServerException`.** `validationException` and `runtimeClientError` are modelled members of the same event-stream union, so the handler now names them too. Being precise about what this does and does not do, because my first draft of this description overstated it: with standard AWS exception framing (`:message-type: exception`) botocore sets a 400 and raises `EventStreamError` before the loop ever sees a dict, so these two branches are defensive completeness rather than a fix for a failure I reproduced. The live path for a rejected invoke is the `EventStreamError` catch already in `stream_response`. I was unable to trigger either event against a real harness.
- **`REGION` read `AWS_DEFAULT_REGION` alone**, while `utils/client.py` honours `AWS_REGION` too and treats `""` as unset. A shell exporting `AWS_DEFAULT_REGION=""` built a working `harness_control` and a `gw_control` that died on `Invalid endpoint: https://bedrock-agentcore-control..amazonaws.com`. Now imports the shared `REGION`.
- **`_cleanup` deletes the execution role**, guarded by `created_role` so a role passed via `--role-arn` is never touched — the name is shared by all 8 samples in this folder. Mirrors the guard merged in #1864.

Also annotated the `create_gateway` / `create_gateway_target` call sites with which authorization side each parameter controls, dropped the unused `os` import, and restored alphabetical import order.

### User experience

**Before** — a successful run on unmodified `main`:

```
Cleaning up...
  Deleted harness: GatewayHarness_81cc1fb4-Ow49bI1ek1
  Deleted target: FMBJ1RTMRS
  Deleted gateway: gatewaydemo-f5c5ed82-ilqcro0d78

$ aws iam get-role --role-name HarnessExecutionRole
HarnessExecutionRole    2026-08-01T00:01:09+00:00     <- left behind
```

**After:** the same three deletes, followed by `Deleted inline policy: HarnessExecutionPolicy` and `Deleted role: HarnessExecutionRole`.

A reader following the README no longer looks for a routing-rule step that doesn't exist, and a failed gateway or target stops the run with the service's own reason instead of timing out silently.

### Testing

**Live end-to-end runs in `us-west-2`** — one on unmodified `upstream/main` to capture the shipped behaviour above, one on the exact bytes committed here (md5-verified before and after). Every run: gateway and target `READY`, the agent called `exa-search___web_search_exa` through the gateway and returned real results, exit 0. Post-run sweeps confirmed a clean account, including the auto-provisioned managed memory, which drains on its own.

**Unit-checked against stubbed clients**, since most new branches can't be reached from a healthy account: both pollers (happy path, every terminal and pending-auth status, transient passthrough, timeout); the stream handler (tool-use, raw mode, `tools` payload shape, and each error event injected as a plain dict); `_cleanup` (`created_role` true/false/default, and failure before any resource exists). The empty-region regression was reproduced before the fix and confirmed resolved after.

Worth a reviewer's attention: the two new stream-error branches are exercised only by injected dicts. Against the real service these exceptions arrive as `:message-type: exception`, which botocore turns into a raised `EventStreamError`, so the branches are unreachable on that path. They are cheap and consistent with the other samples in the folder, but I would rather flag that than let the diff imply I had reproduced them.

**Every API-shape claim above was asserted against the botocore 1.43.59 service model** — both enums for authorization, `apiKeyCredentialProvider` members, both status enums (including `DELETE_FAILED`'s absence from the target enum), the `InvokeHarness` stream events, and the absence of any gateway parameter on `CreateHarness`.

Both CI gates pass. Ruff findings on this file go from 3 to 0 — the `I001` came from #1863's own new import, and the two `BLE001`s were already failing on `main`.
