### PR TITLE
fix(01-harness): stop 04-mcp-integration reporting success for a report it never retrieved

### DIFF
--- a/01-features/01-harness/01-advanced-examples/04-mcp-integration/README.md
+++ b/01-features/01-harness/01-advanced-examples/04-mcp-integration/README.md
@@ -45,18 +45,31 @@ The agent automatically discovers available tools from the MCP server and uses t
 
 **Prompt**: "Research 'Generative AI trends in enterprise 2024' and save a JSON report."
 **Expected Behavior**: Agent searches, structures data into JSON, writes `/tmp/ai_trends_report.json`.
+The sample then reads that file back off the VM. Writing it is up to the model, so a run
+that answers in prose instead reports the file as missing rather than claiming success.
 
 **Prompt**: "Compare search results about 'AWS re:Invent 2024' from different sources."
 **Expected Behavior**: Agent uses multiple MCP tools (if configured), compares results.
 
 **Prompt (error handling)**: "Search using an invalid MCP URL."
-**Expected Behavior**: Agent receives an error event, reports gracefully without crashing.
+**Expected Behavior**: The harness rejects the tool before the agent runs, and the failure
+arrives as a raised `EventStreamError` wrapping `runtimeClientError` — not as an event in the
+stream. The sample catches it, records it, and carries on to the next part.
 
 ## Key Concepts
 
 **MCP tool discovery**: When the agent invokes an MCP tool, it first calls `tools/list` on the MCP server to discover available sub-tools. This happens automatically.
 
-**Authentication**: Pass API keys via environment variables, never hardcode. For servers requiring headers, use the `headers` field in `remoteMcp` config (check latest API docs for your server).
+**Authentication**: Pass API keys via environment variables, never hardcode. For servers requiring headers, use the `headers` field in `remoteMcp` — a map of string to string sent when connecting to the MCP server:
+
+```python
+"config": {"remoteMcp": {
+    "url": "https://your-server.example.com/mcp",
+    "headers": {"Authorization": f"Bearer {api_key}"},   # or {"x-api-key": api_key}
+}}
+```
+
+Which header name to use is the MCP server's choice, not AgentCore's — check your server's docs. Whatever you pick, redact the value before printing the config; secrets in sample output end up in scrollback, CI logs and screenshots.
 
 **Multiple MCP tools**: Pass multiple tools in the same `invoke_harness` call. The agent decides which to use based on the task.
 
@@ -95,12 +108,18 @@ for event in response["stream"]:
             print(f"Tool used: {tool_name}")
 ```
 
-**5. Test MCP servers independently** before integrating with harness:
+**5. Test MCP servers independently** before integrating with harness. Streamable-HTTP MCP
+servers require an `Accept` header covering both content types, and the body has to be a
+complete JSON-RPC request — `jsonrpc` and `id` included, or the server answers `-32700 Parse
+error`:
 ```bash
 curl -X POST https://mcp.exa.ai/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/list"}'
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 ```
+The reply comes back as an SSE frame (`event: message` / `data: {...}`) listing the tools the
+agent will discover.
 
 **6. Combine MCP with other harness tools** — MCP tools work alongside built-in capabilities:
 ```python
@@ -114,10 +133,13 @@ tools=[
 ## Troubleshooting
 
 ### Issue: MCP tool call produces no results
-**Solution**: The MCP server may be unavailable or require authentication. Check the server URL and any required API keys. Test with `curl -X POST <url> -H "Content-Type: application/json" -d '{"method": "tools/list"}'`.
+**Solution**: The MCP server may be unavailable or require authentication. Check the server URL and any required API keys, then test the server directly with the `curl` command in Best Practice 5 above.
 
-### Issue: `internalServerException` in the stream
-**Solution**: This usually means the MCP server returned an error. Check the error message and verify the server is accessible from AWS.
+### Issue: The run stops with `EventStreamError` partway through
+**Solution**: This is how the stream reports a failure. `internalServerException`, `validationException` and `runtimeClientError` are modelled as exceptions, so botocore raises them out of the event iterator instead of yielding them as events — a handler that only matches event keys will never see them. The message names the underlying code: `runtimeClientError` for a tool the harness could not load (a bad MCP URL), `internalServerException` for a server-side failure. Wrap the iteration, as `stream_invoke` does here, so one failed tool call does not end the whole script.
+
+### Issue: Part 5 reports the report file was not retrieved
+**Solution**: Not a failure of the sample. Whether `/tmp/ai_trends_report.json` gets written is the model's decision, and it sometimes answers in prose instead. Re-run, or make the instruction more explicit. The exit code and stderr from the `cat` are printed so you can tell "the agent skipped the file" from "the file is there but unreadable."
 
 ### Issue: Research task times out
 **Solution**: Increase `timeoutSeconds` to 300-600 for complex research tasks involving multiple searches and file generation.

--- a/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
+++ b/01-features/01-harness/01-advanced-examples/04-mcp-integration/mcp_integration.py
@@ -18,6 +18,7 @@ Prerequisites:
     - (Optional) MCP_API_KEY environment variable for authenticated examples
 """
 
+import copy
 import json
 import os
 import sys
@@ -26,6 +27,7 @@ import uuid
 from pathlib import Path
 
 import boto3
+import botocore.exceptions
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -83,24 +85,36 @@ try:
             timeoutSeconds=timeout,
         )
         result = {"text": "", "tool_uses": [], "errors": []}
-        for event in response["stream"]:
-            if "contentBlockStart" in event:
-                start = event["contentBlockStart"].get("start", {})
-                if "toolUse" in start:
-                    tool_name = start["toolUse"].get("name", "?")
-                    result["tool_uses"].append(tool_name)
-                    print(f"\n[Tool: {tool_name}]", flush=True)
-            elif "contentBlockDelta" in event:
-                delta = event["contentBlockDelta"].get("delta", {})
-                if "text" in delta:
-                    result["text"] += delta["text"]
-                    print(delta["text"], end="", flush=True)
-            elif "messageStop" in event:
-                print("\n")
-            elif "internalServerException" in event:
-                error = event["internalServerException"]
-                result["errors"].append(error)
-                print(f"\n❌ Error: {error}")
+        # A mid-stream failure does not arrive as an event this loop can match on.
+        # internalServerException, validationException and runtimeClientError are
+        # modelled with `exception: true`, so botocore marks the frame 400 and raises
+        # EventStreamError out of the iterator instead of yielding a dict (see
+        # botocore/eventstream.py, EventStream._parse_event). Without a catch here a
+        # single failed tool call aborts the whole demo at Part 1 and the reader never
+        # sees Parts 2-5 — Part 4 deliberately triggers exactly that failure. Record
+        # it and let the demo go on.
+        try:
+            for event in response["stream"]:
+                if "contentBlockStart" in event:
+                    start = event["contentBlockStart"].get("start", {})
+                    if "toolUse" in start:
+                        tool_name = start["toolUse"].get("name", "?")
+                        result["tool_uses"].append(tool_name)
+                        print(f"\n[Tool: {tool_name}]", flush=True)
+                elif "contentBlockDelta" in event:
+                    delta = event["contentBlockDelta"].get("delta", {})
+                    if "text" in delta:
+                        result["text"] += delta["text"]
+                        print(delta["text"], end="", flush=True)
+                elif "messageStop" in event:
+                    print("\n")
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            # Both base classes are needed, and neither covers the other:
+            # EventStreamError subclasses ClientError, while transport failures such as
+            # ReadTimeoutError subclass BotoCoreError. Part 4 below relies on this —
+            # an invalid MCP URL surfaces as EventStreamError.
+            result["errors"].append(str(e))
+            print(f"\n❌ Stream error: {type(e).__name__}: {e}")
         return result
 
     # ── Part 1: Basic MCP Integration — Exa Search ────────────────────────────────
@@ -156,8 +170,14 @@ try:
     api_key = os.getenv("MCP_API_KEY", "")
 
     if api_key:
-        # Example: authenticated MCP server with bearer token in headers
-        # Header format may vary — check latest API docs for your MCP server
+        # `headers` is a real member of remoteMcp (a map of string to string, for
+        # "custom headers to include when connecting to the remote MCP server"), so
+        # pass the key rather than leaving the line commented out — a config printed
+        # with no credential in it under the heading "configured with the API key" is
+        # the one thing this part exists to show.
+        # Which header to use is the server's choice, not AgentCore's: bearer tokens go
+        # in Authorization, while many MCP servers want x-api-key instead. Check your
+        # server's docs and adjust the name below.
         tools_config = [
             {
                 "type": "remote_mcp",
@@ -165,7 +185,7 @@ try:
                 "config": {
                     "remoteMcp": {
                         "url": EXA_MCP_URL,
-                        # "headers": {"Authorization": f"Bearer {api_key}"}
+                        "headers": {"Authorization": f"Bearer {api_key}"},
                     }
                 },
             }
@@ -173,8 +193,18 @@ try:
         # Never echo the key itself, not even a prefix — sample output routinely
         # ends up in terminal scrollback, CI logs and screenshots. Confirm that
         # the variable was picked up and stop there.
+        #
+        # That applies to the config dump below too, now that it carries a real
+        # credential. Print a deep copy with every header value replaced — the shape
+        # of the request stays visible, the secret does not leave the process. Every
+        # value is masked regardless of header name, so switching to x-api-key below
+        # needs no matching change here.
+        redacted = copy.deepcopy(tools_config)
+        redacted_headers = redacted[0]["config"]["remoteMcp"]["headers"]
+        for header_name in redacted_headers:
+            redacted_headers[header_name] = "<redacted>"
         print(f"✅ MCP configured with the API key from MCP_API_KEY ({len(api_key)} chars, value not logged)")
-        print(f"Tool config: {json.dumps(tools_config, indent=2)}")
+        print(f"Tool config: {json.dumps(redacted, indent=2)}")
     else:
         print("⚠️  No MCP_API_KEY found. Skipping authenticated example.")
         print("   Set it with: export MCP_API_KEY='your-key-here'")
@@ -197,10 +227,23 @@ try:
             ],
             timeout=60,
         )
-        print(f"Errors encountered: {len(result['errors'])}")
+        # This is where the expected failure lands now. stream_invoke records a
+        # mid-stream error instead of letting it abort the demo, so a bad URL comes
+        # back as an entry in result["errors"] with no answer text — which is also
+        # what makes the count below worth printing. Before, the exception escaped
+        # stream_invoke and this line was unreachable: every real run went to the
+        # except clause, so `Errors encountered:` could only ever have printed 0.
+        if result["errors"]:
+            print(f"✅ Expected error for invalid MCP URL ({len(result['errors'])}):")
+            for err in result["errors"]:
+                print(f"   {err[:200]}")
+        else:
+            print("⚠️  No error surfaced — the invalid URL was accepted. Response:")
+            print(f"   {result['text'][:200]}")
     except Exception as e:  # noqa: BLE001 - demo deliberately surfaces any error type
-        # Expected: invalid MCP URL raises runtimeClientError — the harness rejects it
-        # before the agent ever runs. This demonstrates graceful error surfacing.
+        # Still a live path, just not the usual one: invoke_harness can reject the
+        # request before the stream opens (a malformed tool config, a throttle), and
+        # that raises out of the call itself rather than out of the iterator.
         print(f"✅ Expected error for invalid MCP URL: {type(e).__name__}")
         print(f"   {str(e)[:200]}")
 
@@ -243,27 +286,50 @@ try:
         timeout=300,
     )
 
-    # Retrieve the report from the agent's VM
+    # Retrieve the report from the agent's VM.
+    # `cat ... 2>/dev/null || echo '{}'` used to hide the only failure that matters
+    # here: if the agent never wrote the file, cat's error was discarded and the
+    # fallback emitted `{}`, which is valid JSON. json.loads then succeeded, the
+    # JSONDecodeError branch never ran, and the sample printed "Research Report
+    # Generated:" followed by an empty object — a green tick for a report that does
+    # not exist. Ask for the file plainly instead and keep both halves of the answer:
+    # stderr says why it is missing, and the exit code says whether to trust stdout.
     print("\n--- Retrieving research report from VM ---")
     report_data = ""
+    report_stderr = ""
+    report_exit_code = None
     resp = client.invoke_agent_runtime_command(
         agentRuntimeArn=harness_arn,
         runtimeSessionId=research_session,
-        body={"command": "cat /tmp/ai_trends_report.json 2>/dev/null || echo '{}'"},
+        body={"command": "cat /tmp/ai_trends_report.json"},
     )
     for event in resp["stream"]:
         if "chunk" in event:
             chunk = event["chunk"]
-            if "contentDelta" in chunk and "stdout" in chunk["contentDelta"]:
-                report_data += chunk["contentDelta"]["stdout"]
+            if "contentDelta" in chunk:
+                delta = chunk["contentDelta"]
+                if "stdout" in delta:
+                    report_data += delta["stdout"]
+                if "stderr" in delta:
+                    report_stderr += delta["stderr"]
+            elif "contentStop" in chunk:
+                report_exit_code = chunk["contentStop"].get("exitCode")
 
-    try:
-        report = json.loads(report_data)
-        print("✅ Research Report Generated:")
-        print(json.dumps(report, indent=2)[:2000])  # show first 2000 chars
-    except json.JSONDecodeError:
-        print("⚠️  Could not parse as JSON.")
-        print(f"Raw output (first 500 chars): {report_data[:500]}")
+    if report_exit_code:
+        # Non-zero: the file is missing or unreadable. Common and not fatal — the
+        # agent may have answered in prose without writing the file it was asked for.
+        print(f"⚠️  Report file not retrieved (exit {report_exit_code}).")
+        if report_stderr.strip():
+            print(f"   {report_stderr.strip()}")
+        print("   The agent may have answered inline instead of writing the file.")
+    else:
+        try:
+            report = json.loads(report_data)
+            print("✅ Research Report Generated:")
+            print(json.dumps(report, indent=2)[:2000])  # show first 2000 chars
+        except json.JSONDecodeError as e:
+            print(f"⚠️  Report file retrieved but is not valid JSON: {e}")
+            print(f"Raw output (first 500 chars): {report_data[:500]}")
 
 finally:
     # ── Cleanup ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Concise description of the PR

The `04-mcp-integration` sample runs to completion, but Part 5 can print a green tick for a report it never retrieved, one failed tool call ends the run before the reader sees Parts 2-5, and Part 3 — titled "MCP with Authentication" — never passes the API key anywhere.

**Code**

- **Part 5 reported success for a missing report.** Retrieval ran `cat ... 2>/dev/null || echo '{}'`. Whether the agent writes that file is the model's decision, and answering in prose instead is normal — but the fallback emitted `{}`, which is **valid JSON**, so `json.loads` succeeded and the `JSONDecodeError` branch never ran. Now the file is asked for plainly: stderr says why it is missing, the exit code says whether to trust stdout. A truncated file no longer reports identically to one never written.
- **The stream was iterated without a `try`.** `internalServerException`, `validationException` and `runtimeClientError` are modelled `exception: true`, so botocore sets a 400 and raises `EventStreamError` out of the iterator rather than yielding a dict (`botocore/eventstream.py`, `EventStream._parse_event`). So the `elif "internalServerException" in event:` branch could never run, and any stream failure escaped into `finally`, ending the demo at Part 1. Now catches `(ClientError, BotoCoreError)`: both are needed and neither covers the other, since `EventStreamError` subclasses `ClientError` while `ReadTimeoutError` subclasses `BotoCoreError`.
- **Part 4's `Errors encountered:` line was unreachable** — it sat above the `except` every real run took, and could only have printed `0` anyway, since the sole thing appending to that list was the dead branch above. It now prints the service's own message, with an explicit `else` so a bad URL that starts succeeding surfaces instead of passing silently.
- **Part 3 demonstrated nothing.** It printed "configured with the API key" while the only line that would use the key was commented out. `headers` is a real member of `remoteMcp` (`map<string,string>`), so the line is now live; what is server-specific is the header *name*, not whether AgentCore supports headers. That makes the config dump below it carry a secret, so it prints a deep copy with every header **value** masked, honouring the comment already there forbidding echoing the key.

**Documentation**

- **The `curl` for testing an MCP server failed against a healthy one.** It appeared twice, once as the first troubleshooting step, so it pointed the reader at the server when the problem was their request. Two defects: no `Accept` header (406) and a body that isn't a complete JSON-RPC request (`-32700 Parse error`). Fixed once, cross-referenced from troubleshooting.
- **"Issue: `internalServerException` in the stream"** described an event that never arrives, for the reason above. Replaced with one keyed on the `EventStreamError` that does.
- **`headers` is now documented** under Key Concepts, with both header forms and a note to redact the value before printing.
- **Two expectations corrected** — the invalid-URL behaviour, and that writing the report file is the model's choice — plus an entry for Part 5's new missing-report message so it isn't mistaken for a bug.

### User experience

**Before** — Part 5 on unmodified `main`, no report file on the VM:

```
--- Retrieving research report from VM ---
✅ Research Report Generated:
{}
```

**After** — same VM, same session, the discarded information recovered:

```
--- Retrieving research report from VM ---
⚠️  Report file not retrieved (exit 1).
   cat: /tmp/ai_trends_report.json: No such file or directory
   The agent may have answered inline instead of writing the file.
```

Part 4 now records the failure instead of raising past it, so the demo continues to Part 5, and Part 3 prints `"headers": { "Authorization": "<redacted>" }` — shape visible, credential not.

### Testing

**Two live end-to-end runs in `us-west-2`**, plus one on unmodified `upstream/main` to capture the shipped behaviour above. The final run was on the exact committed bytes (md5-verified before, after, and against `git show HEAD:`). Every run: all five parts executed, Parts 1-2 made real Exa tool calls, Part 4's previously-unreachable branch fired, Part 5 returned a real JSON report, cleanup deleted harness, inline policy and role. Post-run sweeps confirmed a clean account, including the auto-provisioned managed memory, which drains on its own. In both runs the agent *did* write the report, so the output above comes from a separate live run driving old and new logic back to back on one VM in a session where no agent ever ran — the only way to see both on identical input.

**Redaction was verified live:** both runs exported a sentinel `MCP_API_KEY`, and neither value appears anywhere in its run's output.

**35 unit checks against stubbed streams**, for branches a healthy account can't reach: redaction in both header forms (key absent, real config unmutated by the deep copy); the six subclass assertions behind the `except`; the stream loop (happy path, failure at open, mid-stream failure after partial text, `ReadTimeoutError`, `ValueError` still propagating); both Part 4 branches; and retrieval across missing / valid / truncated / absent `contentStop`. The missing-file case replays the exact stderr and exit code captured live.

Both `curl` failures and the corrected form were run against the live Exa endpoint. Both CI lint gates pass.
