### PR TITLE
fix(01-harness): stop 05-agent-skills reporting success it never checked, and leaking on failure

### DIFF
--- a/01-features/01-harness/01-advanced-examples/05-agent-skills/README.md
+++ b/01-features/01-harness/01-advanced-examples/05-agent-skills/README.md
@@ -65,6 +65,34 @@ client.invoke_harness(
 
 **File download**: Generated files live on the agent's remote VM. Use `invoke_agent_runtime_command` with `base64` to transfer them locally.
 
+**Read all three outputs of a command**: `invoke_agent_runtime_command` streams `stdout`,
+`stderr` *and* `contentStop.exitCode`. Check the exit code before treating the output as
+good — a command that failed still streams whatever it managed to write, so stdout alone
+cannot tell success from failure:
+
+```python
+for event in resp["stream"]:
+    if "chunk" in event:
+        chunk = event["chunk"]
+        if "contentDelta" in chunk:
+            stdout += chunk["contentDelta"].get("stdout", "")
+            stderr += chunk["contentDelta"].get("stderr", "")
+        elif "contentStop" in chunk:
+            exit_code = chunk["contentStop"].get("exitCode")
+```
+
+**`node:slim` has no LibreOffice, and the skill wants one**: the xlsx skill recalculates a
+finished workbook so that each formula also carries its *cached result* — the value
+`openpyxl(data_only=True)` and pandas read without opening Excel. That step needs
+LibreOffice (`soffice`), which the Node image does not ship. In practice the agent notices
+and `apt-get install`s LibreOffice mid-run, so the downloaded files do come back fully
+recalculated (`docProps/app.xml` names LibreOffice as the generating application). It works,
+but it is a large package to install on every fresh session — expect the first spreadsheet
+prompt to take noticeably longer. If the install is skipped or fails, the formulas are still
+correct; only their cached values are missing, and `data_only=True` reads `None` until Excel
+or LibreOffice opens the file. Attach an image that already includes `soffice` to avoid the
+download entirely.
+
 ## Troubleshooting
 
 ### Issue: `npx skills add` command hangs
@@ -73,8 +101,24 @@ client.invoke_harness(
 ### Issue: Skill not found error during invocation
 **Solution**: Verify the path exists: `ls -la .agents/skills/xlsx/`. Run the installation in the same session you're invoking from.
 
+### Issue: `ConflictException: Cannot update agent ... while it is CREATING`
+**Solution**: The harness was not READY before the next call was made. Creating a harness
+takes ~150s on the public network and longer when a container image has to be pulled on top,
+so poll to `READY` before calling `update_harness` or running a command. Use
+`poll_harness_status` from `utils/harness.py`, which raises on timeout and on
+`CREATE_FAILED`/`UPDATE_FAILED` instead of falling through silently.
+
 ### Issue: Generated xlsx file is empty or corrupted
-**Solution**: Check that the agent's file path matches the base64 read command. The file must exist on the VM before you can download it.
+**Solution**: Check that the agent's file path matches the base64 read command. The file must
+exist on the VM before you can download it. This sample validates the transfer: it reports the
+`base64` exit code and stderr when the file is missing, and verifies that what arrived is a zip
+container (an `.xlsx` is a zip) before reporting a sheet count read from the file itself.
+
+### Issue: The script reports the skill install failed
+**Solution**: Read the command output above the error. The install runs
+`apt-get update && apt-get install git -y && npx skills add ...`, so it needs a Debian-based
+container (the `node:slim` image this sample attaches in Part 1) and outbound network access.
+The script stops here deliberately — every later part depends on the skill being present.
 
 ## AgentCore CLI
 

--- a/01-features/01-harness/01-advanced-examples/05-agent-skills/agent_skills.py
+++ b/01-features/01-harness/01-advanced-examples/05-agent-skills/agent_skills.py
@@ -27,6 +27,7 @@ import os
 import sys
 import time
 import uuid
+import zipfile
 from pathlib import Path
 
 import boto3
@@ -34,8 +35,9 @@ from botocore.config import Config
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
+from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -49,234 +51,293 @@ client = get_agentcore_client(config=Config(read_timeout=360))
 account_id = boto3.client("sts").get_caller_identity()["Account"]
 print(f"Account: {account_id}")
 
+
+# ── Helper: run a shell command on the agent's VM ─────────────────────────────
+# ExecuteCommand reports three things, and every one of them matters here:
+# stdout, stderr, and contentStop.exitCode. Reading only stdout — as this sample
+# used to — throws away both halves of the answer when something fails: stderr
+# says *why*, and the exit code says whether to trust stdout at all.
+def run_command(session_id, command):
+    """Run `command` on the VM and return (stdout, stderr, exit_code)."""
+    stdout = stderr = ""
+    exit_code = None
+    resp = client.invoke_agent_runtime_command(
+        agentRuntimeArn=harness_arn,
+        runtimeSessionId=session_id,
+        body={"command": command},
+    )
+    for event in resp["stream"]:
+        if "chunk" in event:
+            chunk = event["chunk"]
+            if "contentDelta" in chunk:
+                delta = chunk["contentDelta"]
+                stdout += delta.get("stdout", "")
+                stderr += delta.get("stderr", "")
+            elif "contentStop" in chunk:
+                exit_code = chunk["contentStop"].get("exitCode")
+    return stdout, stderr, exit_code
+
+
+def download_xlsx(session_id, path, description):
+    """Copy an .xlsx off the VM, refusing to claim success for a file that is not one.
+
+    `base64 <path>` used to run with `2>/dev/null` and only stdout was read, so a
+    missing file and an unreadable one produced the same empty string, and any
+    non-empty stdout was treated as a valid spreadsheet. Keep stderr and the exit
+    code, then check that what arrived is actually a zip container — .xlsx is a
+    zip, so a corrupt or truncated transfer is detectable before anything claims
+    the file is a workbook.
+    """
+    print(f"Downloading {os.path.basename(path)} from agent VM...")
+    b64_data, err, exit_code = run_command(session_id, f"base64 {path}")
+
+    if exit_code:
+        print(f"⚠️  {description} not retrieved (exit {exit_code}).")
+        if err.strip():
+            print(f"   {err.strip()}")
+        print("   The agent may have answered inline instead of writing the file.")
+        return None
+
+    try:
+        # binascii.Error subclasses ValueError, so this covers both a malformed
+        # payload and bad padding.
+        blob = base64.b64decode(b64_data.strip().replace("\n", ""), validate=True)
+    except ValueError as e:
+        print(f"⚠️  {description} came back but is not valid base64: {e}")
+        return None
+
+    with open(path, "wb") as f:
+        f.write(blob)
+
+    if not zipfile.is_zipfile(path):
+        # .xlsx is a zip container. Anything else here means the agent wrote
+        # something that is not a workbook (an error message, a partial file),
+        # and calling that a success is how the old code reported "3 sheets" for
+        # a file it had never looked at.
+        print(f"⚠️  Saved {path} ({os.path.getsize(path):,} bytes) but it is not a valid .xlsx.")
+        print(f"   First bytes: {blob[:80]!r}")
+        return None
+
+    with zipfile.ZipFile(path) as z:
+        sheets = [n for n in z.namelist() if n.startswith("xl/worksheets/sheet")]
+    print(f"✅ Saved to {path} ({os.path.getsize(path):,} bytes)")
+    print(f"   Sheets: {len(sheets)}")
+    return path
+
+
 # ── Create IAM Role & Harness ─────────────────────────────────────────────────
+# Everything from role creation onwards runs inside the try/finally below, so the
+# cleanup fires even when a step in between fails. Without it, a failure between
+# create and cleanup leaks a billable harness *and* the execution role — and the
+# role name is shared by every sample in this folder, so the leftovers also make
+# the next run of any of them behave unpredictably.
 print("\n=== Setup: IAM Role & Harness ===")
-role_arn = create_harness_role()
-print(f"Execution Role ARN: {role_arn}")
-print("Waiting for IAM propagation...")
-time.sleep(10)
+harness_id = None
 
-HARNESS_NAME = f"SkillsDemo_{uuid.uuid4().hex[:8]}"
-resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
-harness = resp["harness"]
-harness_id = harness["harnessId"]
-harness_arn = harness["arn"]
-print(f"Harness ID:  {harness_id}")
-print(f"Harness ARN: {harness_arn}")
+try:
+    role_arn = create_harness_role()
+    print(f"Execution Role ARN: {role_arn}")
+    print("Waiting for IAM propagation...")
+    time.sleep(10)
 
-for i in range(12):
-    status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-    print(f"  [{i + 1}] {status}")
-    if status == "READY":
-        print("✅ Harness is ready")
-        break
-    time.sleep(5)
+    HARNESS_NAME = f"SkillsDemo_{uuid.uuid4().hex[:8]}"
+    resp = control.create_harness(harnessName=HARNESS_NAME, executionRoleArn=role_arn)
+    harness = resp["harness"]
+    harness_id = harness["harnessId"]
+    harness_arn = harness["arn"]
+    print(f"Harness ID:  {harness_id}")
+    print(f"Harness ARN: {harness_arn}")
 
-# ── Attach Node.js Container (required for skill installation) ────────────────
-print(f"\n=== Part 1: Attach Node.js Container ({NODE_CONTAINER}) ===")
-control.update_harness(
-    harnessId=harness_id,
-    environmentArtifact={"optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}},
-)
-print("Waiting for container update...")
-for i in range(12):
-    status = control.get_harness(harnessId=harness_id)["harness"]["status"]
-    print(f"  [{i + 1}] {status}")
-    if status == "READY":
-        print("✅ Harness updated with Node.js container")
-        break
-    time.sleep(5)
+    # Use the shared poller rather than a local loop. The loop this replaces ran
+    # `for i in range(12)` with a 5s sleep — a 60s ceiling with no else clause and
+    # no raise, so on timeout it fell through *silently* and the next call ran
+    # against a harness that was still CREATING. Creation here routinely takes
+    # longer than that (~150s on the public network, more when pulling an image),
+    # so the very next statement, update_harness, failed with
+    # `ConflictException: Cannot update agent ... while it is CREATING`.
+    poll_harness_status(control, harness_id)
+    print("✅ Harness is ready")
 
-# ── Part 2: Install xlsx Skill ────────────────────────────────────────────────
-print("\n=== Part 2: Install xlsx Skill ===")
-session_id = str(uuid.uuid4()).upper()
-print(f"Session ID: {session_id}\n")
+    # ── Attach Node.js Container (required for skill installation) ────────────────
+    print(f"\n=== Part 1: Attach Node.js Container ({NODE_CONTAINER}) ===")
+    control.update_harness(
+        harnessId=harness_id,
+        environmentArtifact={"optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}},
+    )
+    print("Waiting for container update...")
+    # Same again: the update has to finish before any command can run on the VM,
+    # and pulling the Node image takes longer than the old 60s ceiling allowed.
+    poll_harness_status(control, harness_id)
+    print("✅ Harness updated with Node.js container")
 
-print("Installing git and xlsx skill (this may take a minute)...")
-resp = client.invoke_agent_runtime_command(
-    agentRuntimeArn=harness_arn,
-    runtimeSessionId=session_id,
-    body={
-        "command": "apt-get update && apt-get install git -y && "
-        "npx skills add https://github.com/anthropics/skills --skill xlsx --yes"
-    },
-)
+    # ── Part 2: Install xlsx Skill ────────────────────────────────────────────────
+    print("\n=== Part 2: Install xlsx Skill ===")
+    session_id = str(uuid.uuid4()).upper()
+    print(f"Session ID: {session_id}\n")
 
-output = ""
-for event in resp["stream"]:
-    if "chunk" in event and "contentDelta" in event["chunk"]:
-        delta = event["chunk"]["contentDelta"]
-        if "stdout" in delta:
-            output += delta["stdout"]
-        if "stderr" in delta:
-            output += delta["stderr"]
+    print("Installing git and xlsx skill (this may take a minute)...")
+    install_out, install_err, install_exit = run_command(
+        session_id,
+        "apt-get update && apt-get install git -y && "
+        "npx skills add https://github.com/anthropics/skills --skill xlsx --yes",
+    )
 
-# Show last 500 chars (installation is verbose)
-print(output[-500:] if len(output) > 500 else output)
-print("✅ xlsx skill installed")
+    # Show last 500 chars (installation is verbose). stdout and stderr are printed
+    # separately: the old code concatenated them into one string and showed only
+    # the tail, so an early apt-get failure scrolled out of view.
+    combined = install_out + install_err
+    print(combined[-500:] if len(combined) > 500 else combined)
 
-# Verify installation
-resp = client.invoke_agent_runtime_command(
-    agentRuntimeArn=harness_arn,
-    runtimeSessionId=session_id,
-    body={"command": "ls -la .agents/skills/xlsx/ 2>/dev/null && echo 'skill directory OK' || echo 'skill not found'"},
-)
-for event in resp["stream"]:
-    if "chunk" in event and "contentDelta" in event["chunk"]:
-        delta = event["chunk"]["contentDelta"]
-        if "stdout" in delta:
-            print(delta["stdout"], end="")
+    # Check the install before claiming it worked. `✅ xlsx skill installed` used
+    # to print unconditionally, immediately after a command whose exit code was
+    # never read — so a failed install still showed a tick.
+    if install_exit:
+        raise RuntimeError(
+            f"Skill installation failed (exit {install_exit}). See the output above. "
+            "Every later part of this demo depends on it."
+        )
 
-# ── Part 3: Create Travel Budget Spreadsheet ──────────────────────────────────
-print("\n=== Part 3: Travel Budget Spreadsheet ===")
+    # Verify the skill actually landed where the invocations below point.
+    # The old code ran this exact check, printed the answer, and then *discarded*
+    # it: there was no `if`, so a VM printing 'skill not found' went straight on
+    # to invoke the model with skills=[{'path': '.agents/skills/xlsx'}] anyway,
+    # turning a clear setup error into a confusing model response later.
+    verify_out, _, _ = run_command(
+        session_id,
+        "ls -la .agents/skills/xlsx/ 2>/dev/null && echo 'skill directory OK' || echo 'skill not found'",
+    )
+    print(verify_out, end="")
+    if "skill directory OK" not in verify_out:
+        raise RuntimeError(
+            "xlsx skill was not installed at .agents/skills/xlsx — see the install output above. "
+            "Every later part of this demo depends on it."
+        )
+    print("✅ xlsx skill installed")
 
-response = client.invoke_harness(
-    harnessArn=harness_arn,
-    runtimeSessionId=session_id,
-    skills=[{"path": ".agents/skills/xlsx"}],
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": (
-                        "Create an Excel spreadsheet with a 5-day Amsterdam trip budget. "
-                        "Include columns for: Day, Category, Item, Cost (EUR), Cost (USD). "
-                        "Add rows for accommodation, food, transport, museums, and activities for each day. "
-                        "Include a total row with SUM formulas for EUR and USD columns. "
-                        "Use currency conversion rate: 1 EUR = 1.10 USD. "
-                        "Apply nice formatting: bold headers, currency formatting, alternating row colors. "
-                        "Save it as /tmp/amsterdam_budget.xlsx"
-                    )
-                }
-            ],
-        }
-    ],
-    model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-)
+    # ── Part 3: Create Travel Budget Spreadsheet ──────────────────────────────────
+    print("\n=== Part 3: Travel Budget Spreadsheet ===")
 
-for event in response["stream"]:
-    if "contentBlockStart" in event:
-        start = event["contentBlockStart"].get("start", {})
-        if "toolUse" in start:
-            print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-    elif "contentBlockDelta" in event:
-        delta = event["contentBlockDelta"].get("delta", {})
-        if "text" in delta:
-            print(delta["text"], end="", flush=True)
-    elif "messageStop" in event:
-        print("\n")
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        skills=[{"path": ".agents/skills/xlsx"}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": (
+                            "Create an Excel spreadsheet with a 5-day Amsterdam trip budget. "
+                            "Include columns for: Day, Category, Item, Cost (EUR), Cost (USD). "
+                            "Add rows for accommodation, food, transport, museums, and activities for each day. "
+                            "Include a total row with SUM formulas for EUR and USD columns. "
+                            "Use currency conversion rate: 1 EUR = 1.10 USD. "
+                            "Apply nice formatting: bold headers, currency formatting, alternating row colors. "
+                            "Save it as /tmp/amsterdam_budget.xlsx"
+                        )
+                    }
+                ],
+            }
+        ],
+        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+    )
 
-# Download the spreadsheet
-print("Downloading amsterdam_budget.xlsx from agent VM...")
-b64_data = ""
-resp = client.invoke_agent_runtime_command(
-    agentRuntimeArn=harness_arn,
-    runtimeSessionId=session_id,
-    body={"command": "base64 /tmp/amsterdam_budget.xlsx 2>/dev/null"},
-)
-for event in resp["stream"]:
-    if "chunk" in event and "contentDelta" in event["chunk"]:
-        delta = event["chunk"]["contentDelta"]
-        if "stdout" in delta:
-            b64_data += delta["stdout"]
+    for event in response["stream"]:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+        elif "messageStop" in event:
+            print("\n")
 
-if b64_data.strip():
-    local_path = "/tmp/amsterdam_budget.xlsx"  # nosec B108
-    with open(local_path, "wb") as f:
-        f.write(base64.b64decode(b64_data.strip().replace("\n", "")))
-    print(f"✅ Saved to {local_path} ({os.path.getsize(local_path):,} bytes)")
-else:
-    print("⚠️  No file generated — check agent response above")
+    # Download the spreadsheet.
+    download_xlsx(session_id, "/tmp/amsterdam_budget.xlsx", "Budget spreadsheet")  # nosec B108
 
-# ── Part 4: Advanced — Quarterly Sales Report ────────────────────────────────
-print("\n=== Part 4: Quarterly Sales Report (3 sheets) ===")
+    # ── Part 4: Advanced — Quarterly Sales Report ────────────────────────────────
+    print("\n=== Part 4: Quarterly Sales Report (3 sheets) ===")
 
-response = client.invoke_harness(
-    harnessArn=harness_arn,
-    runtimeSessionId=session_id,
-    skills=[{"path": ".agents/skills/xlsx"}],
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": (
-                        "Create a professional quarterly sales report Excel file with 3 sheets:\n"
-                        "\n"
-                        "Sheet 1 - Summary:\n"
-                        "- Q1 2024 Sales Overview title\n"
-                        "- Table with: Region, Target (USD), Actual (USD), Variance (%), Status\n"
-                        "- 4 regions: North America, Europe, Asia Pacific, Latin America\n"
-                        "- Use realistic numbers (targets 1M-5M, actual should vary ±20%)\n"
-                        "- Variance formula: (Actual-Target)/Target * 100\n"
-                        "- Status formula: IF variance >= 0, 'On Track', 'Below Target'\n"
-                        "- Total row with SUM formulas\n"
-                        "\n"
-                        "Sheet 2 - Monthly Breakdown:\n"
-                        "- Table with: Month, Region, Sales (USD)\n"
-                        "- Data for Jan, Feb, Mar for each region\n"
-                        "- Total row\n"
-                        "\n"
-                        "Sheet 3 - Top Products:\n"
-                        "- Table with: Rank, Product, Category, Units Sold, Revenue (USD)\n"
-                        "- 10 products with realistic data\n"
-                        "\n"
-                        "Formatting:\n"
-                        "- Bold headers with background color\n"
-                        "- Currency formatting for USD columns\n"
-                        "- Percentage formatting for Variance column\n"
-                        "- Conditional formatting: green for positive variance, red for negative\n"
-                        "- Freeze top row in all sheets\n"
-                        "\n"
-                        "Save as /tmp/q1_sales_report.xlsx"
-                    )
-                }
-            ],
-        }
-    ],
-    model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-    timeoutSeconds=300,
-)
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        skills=[{"path": ".agents/skills/xlsx"}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": (
+                            "Create a professional quarterly sales report Excel file with 3 sheets:\n"
+                            "\n"
+                            "Sheet 1 - Summary:\n"
+                            "- Q1 2024 Sales Overview title\n"
+                            "- Table with: Region, Target (USD), Actual (USD), Variance (%), Status\n"
+                            "- 4 regions: North America, Europe, Asia Pacific, Latin America\n"
+                            "- Use realistic numbers (targets 1M-5M, actual should vary ±20%)\n"
+                            "- Variance formula: (Actual-Target)/Target * 100\n"
+                            "- Status formula: IF variance >= 0, 'On Track', 'Below Target'\n"
+                            "- Total row with SUM formulas\n"
+                            "\n"
+                            "Sheet 2 - Monthly Breakdown:\n"
+                            "- Table with: Month, Region, Sales (USD)\n"
+                            "- Data for Jan, Feb, Mar for each region\n"
+                            "- Total row\n"
+                            "\n"
+                            "Sheet 3 - Top Products:\n"
+                            "- Table with: Rank, Product, Category, Units Sold, Revenue (USD)\n"
+                            "- 10 products with realistic data\n"
+                            "\n"
+                            "Formatting:\n"
+                            "- Bold headers with background color\n"
+                            "- Currency formatting for USD columns\n"
+                            "- Percentage formatting for Variance column\n"
+                            "- Conditional formatting: green for positive variance, red for negative\n"
+                            "- Freeze top row in all sheets\n"
+                            "\n"
+                            "Save as /tmp/q1_sales_report.xlsx"
+                        )
+                    }
+                ],
+            }
+        ],
+        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+        timeoutSeconds=300,
+    )
 
-for event in response["stream"]:
-    if "contentBlockStart" in event:
-        start = event["contentBlockStart"].get("start", {})
-        if "toolUse" in start:
-            print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-    elif "contentBlockDelta" in event:
-        delta = event["contentBlockDelta"].get("delta", {})
-        if "text" in delta:
-            print(delta["text"], end="", flush=True)
-    elif "messageStop" in event:
-        print("\n")
+    for event in response["stream"]:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+        elif "messageStop" in event:
+            print("\n")
 
-# Download the report
-print("Downloading q1_sales_report.xlsx from agent VM...")
-b64_data = ""
-resp = client.invoke_agent_runtime_command(
-    agentRuntimeArn=harness_arn,
-    runtimeSessionId=session_id,
-    body={"command": "base64 /tmp/q1_sales_report.xlsx 2>/dev/null"},
-)
-for event in resp["stream"]:
-    if "chunk" in event and "contentDelta" in event["chunk"]:
-        delta = event["chunk"]["contentDelta"]
-        if "stdout" in delta:
-            b64_data += delta["stdout"]
+    # Download the report. The sheet count printed here is read back out of the
+    # file, not asserted: the old code printed a hardcoded
+    # "Sheets: 3 (Summary, Monthly Breakdown, Top Products)" without ever opening
+    # what it had written, so it said that even for a file that was not a workbook.
+    download_xlsx(session_id, "/tmp/q1_sales_report.xlsx", "Sales report")  # nosec B108
 
-if b64_data.strip():
-    local_path = "/tmp/q1_sales_report.xlsx"  # nosec B108
-    with open(local_path, "wb") as f:
-        f.write(base64.b64decode(b64_data.strip().replace("\n", "")))
-    print(f"✅ Saved to {local_path} ({os.path.getsize(local_path):,} bytes)")
-    print("   Sheets: 3 (Summary, Monthly Breakdown, Top Products)")
-else:
-    print("⚠️  No file generated")
+finally:
+    # ── Cleanup ────────────────────────────────────────────────────────────────────
+    # Runs even when a part above raised, so a failure cannot leave a billable
+    # harness behind. Each resource is deleted independently: harness_id is None if
+    # CreateHarness itself failed, and a delete_harness error must not skip the role
+    # deletion, because the role name is shared by every sample in this folder.
+    print("\n=== Cleanup ===")
+    if harness_id:
+        try:
+            control.delete_harness(harnessId=harness_id)
+            print(f"Deleted harness: {harness_id}")
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+            print(f"Warning: could not delete harness {harness_id}: {e}")
 
-# ── Cleanup ────────────────────────────────────────────────────────────────────
-print("\n=== Cleanup ===")
-control.delete_harness(harnessId=harness_id)
-print(f"Deleted harness: {harness_id}")
-delete_harness_role()
-print("Done.")
+    delete_harness_role()
+    print("Done.")


### PR DESCRIPTION
### Concise description of the PR

The `05-agent-skills` sample cannot finish a run on a fresh account, and when it fails it leaves billable resources behind. Underneath that, it prints four green ticks after commands whose exit codes are never read, and states a sheet count for a file nothing ever opened.

**Code**

- **Two hand-rolled polls capped waiting at 60s and fell through silently.** Both were `for i in range(12)` with a 5s sleep and — verified on the shipped bytes — **no `else` clause and no `raise`**, so a timeout wasn't an error but a silent fall-through into the next call. Measured create time in a real account is **~95-133s**, and this sample's own `utils/harness.py` documents ~150s public / ~255s VPC, so the ceiling sat below the operation it waited on. The very next statement, `update_harness`, then ran against a `CREATING` harness. Now uses the shared `poll_harness_status` — 600s, raising on timeout and on `CREATE_FAILED`/`UPDATE_FAILED`/`DELETE_FAILED` with the service's `failureReason`.
- **The file had zero `try` blocks, so that crash leaked.** Cleanup was straight-line code at the bottom, past four unprotected lifecycle calls, so anything raising before it skipped it — orphaning a billable harness *and* `HarnessExecutionRole` with its inline policy. That role name is shared by every sample in this folder, so the leftovers also make the next run of any neighbour behave unpredictably. Now one `try/finally` deleting each resource independently: `harness_id` is `None` if `CreateHarness` itself failed, and a `delete_harness` error must not skip the role deletion.
- **`✅ xlsx skill installed` printed unconditionally**, directly after a command whose exit code was never read. On a non-Debian image `apt-get` returns **127**; with a bad package name, **100**. The tick printed either way. Compounding it, stdout and stderr were concatenated and only the last 500 chars shown, so an early `apt-get` failure scrolled out of view. The exit code is now checked, the two streams print separately, and a failed install raises — every later part depends on it, so continuing is never useful.
- **The verification result was computed, printed, and thrown away.** The sample ran `ls .agents/skills/xlsx/ && echo 'skill directory OK' || echo 'skill not found'` — exactly the right question — with **no `if`** anywhere after it, so a VM printing `skill not found` went straight on to `invoke_harness(..., skills=[{"path": ".agents/skills/xlsx"}])`, turning a clear setup error into a confusing model response two parts later. Now gated on the string the command was written to emit.
- **All three retrievals discarded stderr and the exit code.** Each ran `... 2>/dev/null` and accumulated only `delta["stdout"]`; `contentStop` and `exitCode` appear **zero times** in the shipped file, though `InvokeAgentRuntimeCommand` streams all three signals. A missing file and an unreadable one produced the identical empty string, so the sample couldn't say *why*. Added a `run_command` helper returning `(stdout, stderr, exit_code)`.
- **A workbook was reported for bytes that were not one.** The gate was `if b64_data.strip():` — any non-empty stdout — and the sheet count was a string literal, `"   Sheets: 3 (Summary, Monthly Breakdown, Top Products)"`. Nothing opened the file. An `.xlsx` is a zip container, so `zipfile.is_zipfile` now rejects non-workbooks dependency-free and the count is read from the `xl/worksheets/sheet*` entries. The file is kept on disk when it fails the check, so the reader can inspect what actually arrived.

**Documentation**

- **The three command outputs are now documented** under Key Concepts with the stream-loop snippet, since reading only stdout is what made every false success above possible.
- **`node:slim` and LibreOffice.** The skill's recalc step needs `soffice`, which the Node image doesn't ship — but the agent notices and `apt-get install`s LibreOffice mid-run, so delivered workbooks *are* fully recalculated (`docProps/app.xml` names LibreOffice as the generating application). The real cost is latency on a fresh session, and attaching an image that already includes `soffice` avoids the download.
- **New troubleshooting entries** for the `ConflictException`, the corrupted-download message and the skill-install failure, so none of the new diagnostics reads as a bug.

### User experience

**Before** — unmodified `main`, fresh account:

```
  [10] CREATING
  [11] CREATING
  [12] CREATING
Traceback (most recent call last):
  ...
botocore.errorfactory.ConflictException: An error occurred (ConflictException) when
calling the UpdateHarness operation: Cannot update agent SkillsDemo_698c89f2 while
it is CREATING. Wait and try again.
```

The run ends there — no `=== Cleanup ===`, so `SkillsDemo_698c89f2-aKeMNZXGmj` and `arn:aws:iam::…:role/HarnessExecutionRole` are both left behind. Note the trap: you cannot `delete_harness` while it is `CREATING`, so cleaning up by hand means polling to `READY` first.

**After** — same account, same conditions:

```
  [19] READY
✅ Harness is ready
...
skill directory OK
✅ xlsx skill installed
...
   Sheets: 1
   Sheets: 3
Deleted harness: SkillsDemo_06208840-nFv9S0rKbD
Done.
```

`READY` arrived at poll 19, past where the old ceiling gave up.

**The worst false success**, driven on the same corrupt file at the same path — before, then after:

```
✅ Saved to /tmp/probe_d_corrupt.xlsx (36 bytes)
   Sheets: 3 (Summary, Monthly Breakdown, Top Products)
   -> is_zipfile = False        # both lines above were false
```

```
⚠️  Saved /tmp/probe_d_corrupt.xlsx (36 bytes) but it is not a valid .xlsx.
   First bytes: b'this is definitely not a spreadsheet'
```

A missing file now says why instead of going quiet:

```
⚠️  Budget spreadsheet not retrieved (exit 1).
   base64: /tmp/amsterdam_budget.xlsx: No such file or directory
   The agent may have answered inline instead of writing the file.
```

### Testing

**Live in `us-west-2`, on unmodified `main` first** to capture the shipped behaviour above. From a verified-clean baseline — no `HarnessExecutionRole`, no `SkillsDemo_*`, no managed memories — the leak reproduced end to end, and the orphans were cleaned up by hand afterwards.

**Then live end to end on the exact committed bytes** (md5-verified before the run, after it, and against `git show HEAD:`), `EXIT=0`: all parts ran, the container update polled `UPDATING`→`READY`, install exited 0 with the real skill directory listed, `Sheets: 1` and `Sheets: 3` were both read from the files, and cleanup deleted harness, inline policy and role. The post-run sweep was clean apart from the service's auto-provisioned managed memory, which drains on its own.

**Both delivered files were validated independently of the sample:** `is_zipfile` true and `testzip()` CRC-clean on each; 1 and 3 worksheet parts, matching what the script reported; sheet names `['Amsterdam Budget']` and `['Summary', 'Monthly Breakdown', 'Top Products']`; and 52 and 15 formulas respectively, each carrying its cached result (`=D2*1.1` → `132`, `=IF(D4>=0,…)` → `'Below Target'`). Part 4's sheet names match what the old code hardcoded, but they are now a measurement rather than a guess.

**Old and new logic were driven back to back on one VM in one session**, so no difference is attributable to a different environment: the discarded `skill not found` (model invoked anyway, now raises); `exit 100` on a bad package (tick, now `RuntimeError`); a missing file (`⚠️ No file generated` with no reason, now `exit 1` plus `No such file or directory`); and the corrupt-download pair shown above. A genuine 3-sheet workbook written to that same path still passes (`Sheets: 3`, `testzip()` `None`), which rules out the check being merely stricter, and a truncated zip — valid `PK\x03\x04` header, cut mid-stream — is also rejected.

**82 unit checks**, all passing, for branches a healthy account can't reach. The functions under test are extracted from the shipped file by AST and exec'd, so the checks run the real bytes rather than a retyped copy — the module cannot simply be imported, since it creates a harness at import time. Covered: `run_command` accumulating all three signals across chunks, a missing `stdout` key, an absent `contentStop`, non-chunk events; `download_xlsx` across missing file (replaying the exact stderr and exit code captured live), exit 127, non-zero exit with empty stderr, not-base64, bad padding, not-a-zip, an error-text payload, a truncated zip, line-wrapped base64, and valid workbooks at 1, 3 and 5 sheets; both Part 2 gates and that the tick prints after them; the `finally` block with `harness_id=None` and with `delete_harness` raising; and the structural invariants — no lifecycle call outside the `try`, two `poll_harness_status` calls, no `range(N)` poll left, the hardcoded sheet claim gone.

Both CI lint gates pass on the changed file.
