### PR TITLE
fix(01-harness): stop 07-oauth reporting success for a failed invoke, and leaking on failure

### DIFF
--- a/01-features/01-harness/01-advanced-examples/07-oauth/README.md
+++ b/01-features/01-harness/01-advanced-examples/07-oauth/README.md
@@ -46,6 +46,22 @@ Response flows back to user
 Three auth mechanisms, zero secrets in the invoke call. The harness handles all token
 exchange automatically from the `outboundAuth.oauth` configuration.
 
+## Required IAM Permissions
+
+Unlike the other samples in this folder, this one provisions Cognito, Lambda and IAM
+resources as well as AgentCore ones, so the identity you run it as needs a broader set of
+permissions. Running under a restricted role (an EC2 instance profile, a CI role) commonly
+fails at Step 1a with `AccessDeniedException` on `cognito-idp:ListUserPools` — the first
+call the script makes, used to detect an already-existing pool so re-runs are idempotent.
+
+| Service | Actions |
+|:--------|:--------|
+| `cognito-idp` | `ListUserPools`, `CreateUserPool`, `DeleteUserPool`, `DescribeUserPool`, `ListUserPoolClients`, `CreateUserPoolClient`, `DescribeUserPoolClient`, `CreateResourceServer`, `CreateUserPoolDomain`, `DeleteUserPoolDomain`, `AdminCreateUser`, `AdminSetUserPassword`, `InitiateAuth` |
+| `lambda` | `CreateFunction`, `GetFunction`, `DeleteFunction` |
+| `iam` | `CreateRole`, `GetRole`, `DeleteRole`, `CreatePolicy`, `DeletePolicy`, `AttachRolePolicy`, `DetachRolePolicy`, `ListAttachedRolePolicies`, `ListPolicyVersions`, `CreatePolicyVersion`, `DeletePolicyVersion` |
+| `bedrock-agentcore-control` | `CreateHarness`, `GetHarness`, `ListHarnesses`, `DeleteHarness`, `CreateGateway`, `GetGateway`, `ListGateways`, `DeleteGateway`, `CreateGatewayTarget`, `GetGatewayTarget`, `ListGatewayTargets`, `DeleteGatewayTarget`, `CreateOauth2CredentialProvider`, `GetOauth2CredentialProvider`, `DeleteOauth2CredentialProvider` |
+| `sts` | `GetCallerIdentity` |
+
 ## Infrastructure Setup
 
 The script provisions resources via helper functions in `utils/setup_helpers.py`. All helpers
@@ -99,6 +115,25 @@ export HARNESS_USER_PASS="TestPassword123!"
 ### Issue: HTTP 403 when invoking harness
 **Solution**: The bearer token may be expired. Re-authenticate with `cognito.initiate_auth` to get a fresh token.
 
+### Issue: `AccessDeniedException` on `cognito-idp:ListUserPools` at Step 1a
+**Solution**: The identity running the script cannot list Cognito pools. This is the very
+first API call, so the script fails before creating anything. Add the permissions in
+[Required IAM Permissions](#required-iam-permissions) — a restricted EC2 instance role or CI
+role usually will not have them by default.
+
+### Issue: `AccessDeniedException` on `bedrock-agentcore:ListEvents` during invoke
+**Solution**: Creating a harness auto-provisions a managed memory (`harness_<name>_*`), and
+the first invoke reads it. The execution role therefore needs the memory and event actions —
+see the `Memory` and `MemoryAccountScoped` statements in `create_harness_execution_role`.
+Note that `CreateMemory` and `ListMemories` are account-scoped and must be granted on `"*"`;
+granting them on `memory/*` evaluates to an implicit deny.
+
+### Issue: The run prints the "What just happened?" summary but no order details
+**Solution**: You are on a version of this sample from before the stream errors were
+surfaced. `InvokeHarness` returns HTTP 200 and then reports agent-side failures as error
+frames *inside* the event stream, so a run that failed could still print the success summary.
+The script now raises on those frames instead.
+
 ## AgentCore CLI
 
 The CLI supports both inbound JWT auth and outbound OAuth2 credential providers via the preview channel:
@@ -129,8 +164,10 @@ The `cleanup_all` function deletes all resources in reverse order: harness, gate
 
 ```bash
 pip install -r ../../requirements.txt
-pip install requests
 ```
+
+`requests` is already listed in that file — this sample calls the harness invoke endpoint
+over HTTPS directly, because boto3 does not support bearer-token invocation.
 
 ```bash
 export HARNESS_USER_NAME="testuser"

--- a/01-features/01-harness/01-advanced-examples/07-oauth/oauth_gateway.py
+++ b/01-features/01-harness/01-advanced-examples/07-oauth/oauth_gateway.py
@@ -37,13 +37,14 @@ Prerequisites:
     - HARNESS_USER_PASS environment variable (Cognito test user password, min 8 chars)
 """
 
+import argparse
 import json
 import os
 import re
 import sys
 import time
 import urllib.parse
-import argparse
+import uuid
 from pathlib import Path
 
 import boto3
@@ -53,13 +54,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))  # root utils
 sys.path.insert(0, str(Path(__file__).parent))  # local utils/
 
 from utils.setup_helpers import (
-    create_user_auth_pool,
-    create_m2m_pool,
+    cleanup_all,
     create_credential_provider,
-    deploy_lambda,
     create_gateway_with_lambda_target,
     create_harness_execution_role,
-    cleanup_all,
+    create_m2m_pool,
+    create_user_auth_pool,
+    deploy_lambda,
+    iter_paginated,
 )
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
@@ -71,6 +73,14 @@ args = parser.parse_args()
 REGION = boto3.session.Session().region_name or "us-east-1"
 ACCOUNT_ID = boto3.client("sts", region_name=REGION).get_caller_identity()["Account"]
 PREFIX = "harness-oauth-demo"
+
+# These mirror utils/harness.py, which this sample cannot import: its own
+# `utils/` package shadows the shared one on sys.path, so `utils.harness` is not
+# importable from here. CREATE_FAILED / UPDATE_FAILED / DELETE_FAILED are the
+# terminal values in the HarnessStatus enum.
+HARNESS_POLL_INTERVAL = 10
+HARNESS_POLL_TIMEOUT = 600
+HARNESS_FAILURE_STATUSES = ("CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED")
 
 # Credentials for the test Cognito user
 USER1_NAME = os.environ.get("HARNESS_USER_NAME")
@@ -89,189 +99,237 @@ cognito = boto3.client("cognito-idp", region_name=REGION)
 
 print(f"Region: {REGION}  Account: {ACCOUNT_ID}")
 
-# ── Step 1: Provision Infrastructure ─────────────────────────────────────────
-print("\n=== Step 1a: Cognito User Auth Pool ===")
-pool1 = create_user_auth_pool(REGION, PREFIX, USER1_NAME, USER1_PASS)
-print(f"Discovery URL: {pool1['discovery_url']}")
-
-print("\n=== Step 1b: Cognito M2M Pool ===")
-pool2 = create_m2m_pool(REGION, PREFIX)
-print(f"Scope: {pool2['scope']}")
-print(f"Discovery URL: {pool2['discovery_url']}")
-
-print("\n=== Step 1c: OAuth2 Credential Provider ===")
-cred = create_credential_provider(
-    REGION,
-    PREFIX,
-    discovery_url=pool2["discovery_url"],
-    client_id=pool2["client_id"],
-    client_secret=pool2["client_secret"],
-)
-
-print("\n=== Step 1d: Lambda Function ===")
-lam = deploy_lambda(REGION, PREFIX)
-
-print("\n=== Step 1e: Gateway + Lambda Target ===")
-gw = create_gateway_with_lambda_target(
-    REGION,
-    PREFIX,
-    ACCOUNT_ID,
-    discovery_url=pool2["discovery_url"],
-    allowed_client=pool2["client_id"],
-    allowed_scope=pool2["scope"],
-    lambda_arn=lam["function_arn"],
-    lambda_function_name=lam["function_name"],
-)
-print(f"Gateway ARN: {gw['gateway_arn']}")
-
-print("\n=== Step 1f: Harness Execution Role ===")
-harness_role = create_harness_execution_role(REGION, PREFIX, ACCOUNT_ID)
-
-# ── Step 2: Create Harness with CUSTOM_JWT Inbound Auth ──────────────────────
-print("\n=== Step 2: Create Harness with CUSTOM_JWT Inbound Auth ===")
-HARNESS_NAME = f"{PREFIX}-harness".replace("-", "_")
-
+# Every step below is wrapped in a single try/finally so a failure part-way
+# through still tears down what was already created. Without it, an error
+# anywhere between Step 1a and Step 4 left two Cognito pools, a credential
+# provider, a Lambda, a gateway + target, a harness and three IAM roles alive —
+# all billable, and all blocking the next run with ConflictException.
+# cleanup_all discovers resources by name, so it copes with a partial set.
 try:
-    harness_resp = ac_control.create_harness(
-        harnessName=HARNESS_NAME,
-        executionRoleArn=harness_role["role_arn"],
-        authorizerConfiguration={
-            "customJWTAuthorizer": {
-                "discoveryUrl": pool1["discovery_url"],
-                "allowedClients": [pool1["client_id"]],
-            }
-        },
-        model={"bedrockModelConfig": {"modelId": "us.anthropic.claude-haiku-4-5-20251001-v1:0"}},
-        systemPrompt=[
-            {
-                "text": (
-                    "You are an order management assistant. "
-                    "Use the gateway tools to look up and update orders. "
-                    "Always confirm the order details before making changes."
-                )
-            }
-        ],
-        tools=[
-            {
-                "type": "agentcore_gateway",
-                "name": "order-gateway",
-                "config": {
-                    "agentCoreGateway": {
-                        "gatewayArn": gw["gateway_arn"],
-                        "outboundAuth": {
-                            "oauth": {
-                                "providerArn": cred["arn"],
-                                "scopes": [pool2["scope"]],
-                                "grantType": "CLIENT_CREDENTIALS",
-                            }
-                        },
-                    }
-                },
-            }
-        ],
+    # ── Step 1: Provision Infrastructure ─────────────────────────────────────
+    print("\n=== Step 1a: Cognito User Auth Pool ===")
+    pool1 = create_user_auth_pool(REGION, PREFIX, USER1_NAME, USER1_PASS)
+    print(f"Discovery URL: {pool1['discovery_url']}")
+
+    print("\n=== Step 1b: Cognito M2M Pool ===")
+    pool2 = create_m2m_pool(REGION, PREFIX)
+    print(f"Scope: {pool2['scope']}")
+    print(f"Discovery URL: {pool2['discovery_url']}")
+
+    print("\n=== Step 1c: OAuth2 Credential Provider ===")
+    cred = create_credential_provider(
+        REGION,
+        PREFIX,
+        discovery_url=pool2["discovery_url"],
+        client_id=pool2["client_id"],
+        client_secret=pool2["client_secret"],
     )
-    HARNESS_ID = harness_resp["harness"]["harnessId"]
-    HARNESS_ARN = harness_resp["harness"]["arn"]
-    print(f"Harness created: {HARNESS_ID}")
-except ac_control.exceptions.ConflictException:
-    HARNESS_ID = None
-    for h in ac_control.list_harnesses().get("harnesses", []):
-        if h.get("harnessName") == HARNESS_NAME:
-            HARNESS_ID = h["harnessId"]
-            HARNESS_ARN = h["arn"]
+
+    print("\n=== Step 1d: Lambda Function ===")
+    lam = deploy_lambda(REGION, PREFIX)
+
+    print("\n=== Step 1e: Gateway + Lambda Target ===")
+    gw = create_gateway_with_lambda_target(
+        REGION,
+        PREFIX,
+        ACCOUNT_ID,
+        discovery_url=pool2["discovery_url"],
+        allowed_client=pool2["client_id"],
+        allowed_scope=pool2["scope"],
+        lambda_arn=lam["function_arn"],
+        lambda_function_name=lam["function_name"],
+    )
+    print(f"Gateway ARN: {gw['gateway_arn']}")
+
+    print("\n=== Step 1f: Harness Execution Role ===")
+    harness_role = create_harness_execution_role(REGION, PREFIX, ACCOUNT_ID)
+
+    # ── Step 2: Create Harness with CUSTOM_JWT Inbound Auth ──────────────────
+    print("\n=== Step 2: Create Harness with CUSTOM_JWT Inbound Auth ===")
+    HARNESS_NAME = f"{PREFIX}-harness".replace("-", "_")
+
+    try:
+        harness_resp = ac_control.create_harness(
+            harnessName=HARNESS_NAME,
+            executionRoleArn=harness_role["role_arn"],
+            authorizerConfiguration={
+                "customJWTAuthorizer": {
+                    "discoveryUrl": pool1["discovery_url"],
+                    "allowedClients": [pool1["client_id"]],
+                }
+            },
+            model={"bedrockModelConfig": {"modelId": "us.anthropic.claude-haiku-4-5-20251001-v1:0"}},
+            systemPrompt=[
+                {
+                    "text": (
+                        "You are an order management assistant. "
+                        "Use the gateway tools to look up and update orders. "
+                        "Always confirm the order details before making changes."
+                    )
+                }
+            ],
+            tools=[
+                {
+                    "type": "agentcore_gateway",
+                    "name": "order-gateway",
+                    "config": {
+                        "agentCoreGateway": {
+                            "gatewayArn": gw["gateway_arn"],
+                            "outboundAuth": {
+                                "oauth": {
+                                    "providerArn": cred["arn"],
+                                    "scopes": [pool2["scope"]],
+                                    "grantType": "CLIENT_CREDENTIALS",
+                                }
+                            },
+                        }
+                    },
+                }
+            ],
+        )
+        HARNESS_ID = harness_resp["harness"]["harnessId"]
+        HARNESS_ARN = harness_resp["harness"]["arn"]
+        print(f"Harness created: {HARNESS_ID}")
+    except ac_control.exceptions.ConflictException:
+        HARNESS_ID = None
+        # ListHarnesses is paginated. Reading only the first page meant that once
+        # the account held more harnesses than fit in one page, this recovery path
+        # raised "conflict but not found" for a harness that demonstrably exists —
+        # the create had just been rejected because of it.
+        for h in iter_paginated(ac_control, "list_harnesses", "harnesses"):
+            if h.get("harnessName") == HARNESS_NAME:
+                HARNESS_ID = h["harnessId"]
+                HARNESS_ARN = h["arn"]
+                break
+        if not HARNESS_ID:
+            raise RuntimeError(f"Harness {HARNESS_NAME} conflict but not found")
+        print(f"Harness already exists: {HARNESS_ID}")
+
+    print(f"Harness ID:  {HARNESS_ID}")
+    print(f"Harness ARN: {HARNESS_ARN}")
+
+    # A harness takes ~150s to reach READY, so this has to wait for the real
+    # thing. The original loop was silent about both failure and giving up:
+    # CREATE_FAILED was polled as "not ready yet" for the full five minutes, and
+    # once the loop expired the script carried straight on and invoked a harness
+    # that was still CREATING — surfacing as a confusing HTTP error rather than
+    # the real cause. 600s leaves headroom over the ~150s typical case.
+    print("Waiting for harness READY...")
+    h_deadline = time.monotonic() + HARNESS_POLL_TIMEOUT
+    while True:
+        h_status = ac_control.get_harness(harnessId=HARNESS_ID)["harness"]["status"]
+        print(f"  {h_status}")
+        if h_status == "READY":
             break
-    if not HARNESS_ID:
-        raise RuntimeError(f"Harness {HARNESS_NAME} conflict but not found")
-    print(f"Harness already exists: {HARNESS_ID}")
+        if h_status in HARNESS_FAILURE_STATUSES:
+            raise RuntimeError(f"Harness {HARNESS_ID} entered terminal status {h_status}")
+        if time.monotonic() > h_deadline:
+            raise TimeoutError(
+                f"Harness {HARNESS_ID} not READY after {HARNESS_POLL_TIMEOUT}s (last status: {h_status})"
+            )
+        time.sleep(HARNESS_POLL_INTERVAL)
+    print(f"Harness status: {h_status}")
 
-print(f"Harness ID:  {HARNESS_ID}")
-print(f"Harness ARN: {HARNESS_ARN}")
+    # ── Step 3: Get Bearer Token from User Auth Pool ──────────────────────────
+    print("\n=== Step 3: Authenticate User — Get Bearer Token ===")
+    auth_result = cognito.initiate_auth(
+        ClientId=pool1["client_id"],
+        AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": USER1_NAME, "PASSWORD": USER1_PASS},
+    )
+    BEARER_TOKEN = auth_result["AuthenticationResult"]["AccessToken"]
+    print(f"Got bearer token (first 20 chars): {BEARER_TOKEN[:20]}...")
 
-print("Waiting for harness READY...")
-for _ in range(30):
-    h_status = ac_control.get_harness(harnessId=HARNESS_ID)["harness"]["status"]
-    print(f"  {h_status}")
-    if h_status == "READY":
-        break
-    time.sleep(10)
-print(f"Harness status: {h_status}")
+    # ── Step 4: Invoke Harness with Bearer Token ─────────────────────────────
+    print("\n=== Step 4: Invoke Harness with Bearer Token ===")
+    escaped_arn = urllib.parse.quote(HARNESS_ARN, safe="")
+    url = f"https://bedrock-agentcore.{REGION}.amazonaws.com/harnesses/invoke?harnessArn={escaped_arn}"
+    SESSION_ID = f"demo-session-{uuid.uuid4().hex}"
 
-# ── Step 3: Get Bearer Token from User Auth Pool ──────────────────────────────
-print("\n=== Step 3: Authenticate User — Get Bearer Token ===")
-auth_result = cognito.initiate_auth(
-    ClientId=pool1["client_id"],
-    AuthFlow="USER_PASSWORD_AUTH",
-    AuthParameters={"USERNAME": USER1_NAME, "PASSWORD": USER1_PASS},
-)
-BEARER_TOKEN = auth_result["AuthenticationResult"]["AccessToken"]
-print(f"Got bearer token (first 20 chars): {BEARER_TOKEN[:20]}...")
+    headers = {
+        "Authorization": f"Bearer {BEARER_TOKEN}",
+        "Content-Type": "application/json",
+        "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": SESSION_ID,
+    }
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Look up order ORD-001 and tell me its status."}],
+            }
+        ]
+    }
 
-# ── Step 4: Invoke Harness with Bearer Token ─────────────────────────────────
-print("\n=== Step 4: Invoke Harness with Bearer Token ===")
-import uuid  # noqa: E402
+    print(f"Session:  {SESSION_ID}")
+    print(f"Endpoint: {url[:80]}...")
+    print()
 
-escaped_arn = urllib.parse.quote(HARNESS_ARN, safe="")
-url = f"https://bedrock-agentcore.{REGION}.amazonaws.com/harnesses/invoke?harnessArn={escaped_arn}"
-SESSION_ID = f"demo-session-{uuid.uuid4().hex}"
+    resp = http_requests.post(url, headers=headers, json=payload, timeout=120, stream=True)
+    print(f"HTTP Status: {resp.status_code}")
 
-headers = {
-    "Authorization": f"Bearer {BEARER_TOKEN}",
-    "Content-Type": "application/json",
-    "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": SESSION_ID,
-}
-payload = {
-    "messages": [
-        {
-            "role": "user",
-            "content": [{"text": "Look up order ORD-001 and tell me its status."}],
-        }
-    ]
-}
+    if resp.status_code != 200:
+        raise RuntimeError(f"InvokeHarness returned HTTP {resp.status_code}: {resp.text[:1000]}")
 
-print(f"Session:  {SESSION_ID}")
-print(f"Endpoint: {url[:80]}...")
-print()
-
-resp = http_requests.post(url, headers=headers, json=payload, timeout=120, stream=True)
-print(f"HTTP Status: {resp.status_code}")
-
-if resp.status_code == 200:
     full_text = []
+    stream_errors = []
     raw = resp.content
     # Extract JSON objects from the binary event-stream
     json_objects = re.findall(rb"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", raw)
     for obj_bytes in json_objects:
         try:
             obj = json.loads(obj_bytes.decode("utf-8", errors="ignore"))
-            delta = obj.get("delta", {})
-            if "text" in delta:
-                full_text.append(delta["text"])
-                print(delta["text"], end="", flush=True)
         except (json.JSONDecodeError, UnicodeDecodeError):
             continue
+        delta = obj.get("delta", {})
+        if "text" in delta:
+            full_text.append(delta["text"])
+            print(delta["text"], end="", flush=True)
+        # The stream carries runtimeClientError / validationException /
+        # internalServerException frames as a bare {"message": ...} object. The
+        # HTTP status is still 200 — the request was accepted, the *agent* then
+        # failed — so ignoring these frames turned a hard failure into a silent
+        # one: the response looked merely empty and the summary below still
+        # claimed all three auth hops had succeeded.
+        elif "message" in obj and "delta" not in obj:
+            stream_errors.append(obj["message"])
     print()
-    if full_text:
-        print(f"\n--- Full response ({len(''.join(full_text))} chars) ---")
-        print("".join(full_text))
+
+    if stream_errors:
+        for msg in stream_errors:
+            print(f"\n❌ Stream error: {msg}")
+        raise RuntimeError(f"InvokeHarness streamed {len(stream_errors)} error frame(s); first: {stream_errors[0]}")
+
+    if not full_text:
+        print(f"\nRaw first 500 bytes: {raw[:500]!r}")
+        raise RuntimeError("InvokeHarness returned no text deltas and no error frame — nothing was generated.")
+
+    print(f"\n--- Full response ({len(''.join(full_text))} chars) ---")
+    print("".join(full_text))
+
+    # Only reached when the invoke actually produced output, so the summary
+    # describes what happened rather than what was supposed to happen.
+    print("\n=== What just happened? ===")
+    print("1. You sent a User Auth Pool JWT → harness validated it (inbound auth)")
+    print("2. Agent decided to call get_order → harness fetched an M2M token from M2M Pool")
+    print("3. Harness called the Gateway with the M2M token (outbound auth)")
+    print("4. Gateway validated it, invoked Lambda, order details flowed back")
+    print("Three auth mechanisms, zero secrets in the invoke call.")
+
+finally:
+    # ── Step 5: Cleanup ───────────────────────────────────────────────────────
+    # In `finally`, so a failure in any step above still releases the two Cognito
+    # pools, the credential provider, the Lambda, the gateway and the harness
+    # instead of leaving them running and billing.
+    if not args.skip_cleanup:
+        print("\n=== Step 5: Cleanup ===")
+        cleanup_all(REGION, PREFIX)
     else:
-        print("\n(No text deltas found in stream)")
-        print(f"Raw first 500 bytes: {repr(raw[:500])}")
-else:
-    print(f"Error {resp.status_code}: {resp.text[:1000]}")
-
-print("\n=== What just happened? ===")
-print("1. You sent a User Auth Pool JWT → harness validated it (inbound auth)")
-print("2. Agent decided to call get_order → harness fetched an M2M token from M2M Pool")
-print("3. Harness called the Gateway with the M2M token (outbound auth)")
-print("4. Gateway validated it, invoked Lambda, order details flowed back")
-print("Three auth mechanisms, zero secrets in the invoke call.")
-
-# ── Step 5: Cleanup ───────────────────────────────────────────────────────────
-if not args.skip_cleanup:
-    print("\n=== Step 5: Cleanup ===")
-    cleanup_all(REGION, PREFIX)
-else:
-    print("\n=== Skipping cleanup (--skip-cleanup) ===")
-    print(f"Harness ID:  {HARNESS_ID}")
-    print(f"Gateway ARN: {gw['gateway_arn']}")
-    print("Run 'python oauth_gateway.py' again to reuse existing resources.")
+        print("\n=== Skipping cleanup (--skip-cleanup) ===")
+        # Guarded with locals(): this block now runs in `finally`, so it is also
+        # reached when a step failed before these names were bound. Referencing
+        # them unguarded would raise NameError here and mask the real error.
+        if "HARNESS_ID" in locals():
+            print(f"Harness ID:  {HARNESS_ID}")
+        if "gw" in locals():
+            print(f"Gateway ARN: {gw['gateway_arn']}")
+        print("Run 'python oauth_gateway.py' again to reuse existing resources.")

--- a/01-features/01-harness/01-advanced-examples/07-oauth/utils/lambda_function_code.py
+++ b/01-features/01-harness/01-advanced-examples/07-oauth/utils/lambda_function_code.py
@@ -1,10 +1,9 @@
 """
 Simple order management Lambda function for AgentCore Gateway target.
-Exposes get_order and update_order tools.
+Exposes get_order and update_order_status tools.
 """
 
 import json
-
 
 # Mock order database
 ORDERS = {

--- a/01-features/01-harness/01-advanced-examples/07-oauth/utils/setup_helpers.py
+++ b/01-features/01-harness/01-advanced-examples/07-oauth/utils/setup_helpers.py
@@ -6,12 +6,33 @@ prints progress, and returns a dict with the values the caller needs.
 All functions are idempotent — safe to re-run if a resource already exists.
 """
 
-import boto3
 import io
 import json
 import time
 import uuid
 import zipfile
+
+import boto3
+
+# Gateways report UPDATE_UNSUCCESSFUL rather than FAILED when an update fails, and
+# targets add SYNCHRONIZE_UNSUCCESSFUL. These are the only terminal-failure values
+# in the GatewayStatus / TargetStatus enums — CREATE_FAILED and DELETE_FAILED are
+# harness statuses and never appear here, so testing for them guards nothing.
+GATEWAY_FAILURE_STATUSES = ("FAILED", "UPDATE_UNSUCCESSFUL")
+TARGET_FAILURE_STATUSES = (*GATEWAY_FAILURE_STATUSES, "SYNCHRONIZE_UNSUCCESSFUL")
+
+# A target with outbound credentials can stop in one of these until authorization
+# is completed out of band. This sample uses GATEWAY_IAM_ROLE, so it should not
+# reach them — but waiting out the full timeout on a state that will never clear
+# by itself is worth naming rather than silently spinning.
+TARGET_PENDING_AUTH_STATUSES = (
+    "CREATE_PENDING_AUTH",
+    "UPDATE_PENDING_AUTH",
+    "SYNCHRONIZE_PENDING_AUTH",
+)
+
+GATEWAY_POLL_INTERVAL = 10
+GATEWAY_POLL_TIMEOUT = 300
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -19,9 +40,59 @@ import zipfile
 # ─────────────────────────────────────────────────────────────────────
 
 
+def _poll_until_ready(describe, label, failure_statuses, pending_auth_statuses=()):
+    """Poll `describe()` until it reports READY. Raises on failure or timeout.
+
+    Falling through instead of raising was the original behaviour, and it moved
+    the error a long way from its cause: a gateway stuck in a failure state was
+    polled as "not ready yet" for the full timeout, then the caller carried on to
+    create a target and a harness against it and surfaced something unrelated.
+    """
+    deadline = time.monotonic() + GATEWAY_POLL_TIMEOUT
+    while True:
+        status = describe()
+        if status == "READY":
+            print(f"  {label} status: {status}")
+            return status
+        if status in failure_statuses:
+            raise RuntimeError(f"{label} entered terminal status {status}")
+        if status in pending_auth_statuses:
+            raise RuntimeError(
+                f"{label} is {status}: it needs an out-of-band authorization that this sample does not perform."
+            )
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"{label} not READY after {GATEWAY_POLL_TIMEOUT}s (last status: {status})")
+        time.sleep(GATEWAY_POLL_INTERVAL)
+
+
+def iter_paginated(client, operation, result_key, **kwargs):
+    """Yield every item from a paginated list operation.
+
+    ListHarnesses, ListGateways and ListGatewayTargets all return a nextToken,
+    and reading only the first page has two distinct consequences here: a lookup
+    after ConflictException fails with "conflict but not found" even though the
+    resource plainly exists, and cleanup reports "not found" and walks past a
+    resource it created — leaking it, and in the harness case leaking its managed
+    memory with it. Neither failure mentions pagination, so both are hard to trace.
+    """
+    for page in client.get_paginator(operation).paginate(**kwargs):
+        yield from page.get(result_key, [])
+
+
+def _iter_user_pools(cog):
+    """Yield every Cognito user pool in the account, following pagination.
+
+    A single ListUserPools page caps out at 60 pools. In an account with more
+    than that, an existing pool on a later page looked absent — so the caller
+    created a duplicate, and cleanup left the original behind.
+    """
+    for page in cog.get_paginator("list_user_pools").paginate(PaginationConfig={"PageSize": 60}):
+        yield from page.get("UserPools", [])
+
+
 def _find_pool_by_name(cog, pool_name):
     """Return pool ID if a Cognito user pool with this name exists, else None."""
-    for p in cog.list_user_pools(MaxResults=60).get("UserPools", []):
+    for p in _iter_user_pools(cog):
         if p["Name"] == pool_name:
             return p["Id"]
     return None
@@ -51,12 +122,30 @@ def _ensure_role(iam_c, role_name, trust_doc):
 
 
 def _ensure_policy(iam_c, account_id, policy_name, policy_doc):
-    """Create a managed policy if it doesn't exist. Returns the ARN."""
+    """Create a managed policy, or update it if it already exists. Returns the ARN.
+
+    A pre-existing policy from an older run of this sample can carry an outdated
+    document, and simply swallowing EntityAlreadyExists left it in force — the
+    permissions the caller asked for were never actually granted. Publish a new
+    default version instead. IAM allows five versions per policy, so prune the
+    oldest non-default one when the limit is reached.
+    """
     arn = f"arn:aws:iam::{account_id}:policy/{policy_name}"
     try:
         iam_c.create_policy(PolicyName=policy_name, PolicyDocument=policy_doc)
+        return arn
     except iam_c.exceptions.EntityAlreadyExistsException:
         pass
+
+    versions = iam_c.list_policy_versions(PolicyArn=arn)["Versions"]
+    if len(versions) >= 5:
+        oldest = min(
+            (v for v in versions if not v["IsDefaultVersion"]),
+            key=lambda v: v["CreateDate"],
+        )
+        iam_c.delete_policy_version(PolicyArn=arn, VersionId=oldest["VersionId"])
+    iam_c.create_policy_version(PolicyArn=arn, PolicyDocument=policy_doc, SetAsDefault=True)
+    print(f"  Policy {policy_name} already existed — updated to the current document")
     return arn
 
 
@@ -105,7 +194,7 @@ def create_user_auth_pool(region: str, prefix: str, username: str, password: str
     cog.admin_set_user_password(UserPoolId=pool_id, Username=username, Password=password, Permanent=True)
 
     discovery_url = f"https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/openid-configuration"
-    return dict(pool_id=pool_id, client_id=client_id, discovery_url=discovery_url)
+    return {"pool_id": pool_id, "client_id": client_id, "discovery_url": discovery_url}
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -177,15 +266,15 @@ def create_m2m_pool(region: str, prefix: str) -> dict:
         print(f"  Pool #2 client created: {client_id}")
 
     discovery_url = f"https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/openid-configuration"
-    return dict(
-        pool_id=pool_id,
-        client_id=client_id,
-        client_secret=client_secret,
-        discovery_url=discovery_url,
-        scope=scope,
-        domain_prefix=domain_prefix,
-        token_endpoint=token_endpoint,
-    )
+    return {
+        "pool_id": pool_id,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "discovery_url": discovery_url,
+        "scope": scope,
+        "domain_prefix": domain_prefix,
+        "token_endpoint": token_endpoint,
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -203,13 +292,20 @@ def create_credential_provider(
     ac = boto3.client("bedrock-agentcore-control", region_name=region)
     name = f"{prefix}-m2m-provider"
 
+    # Only "not found" means "go ahead and create it". The original bare `except:
+    # pass` also swallowed AccessDenied and throttling, so a permissions problem
+    # looked like an absent provider and resurfaced as a confusing create failure.
+    # Anything unexpected still falls through to the create below — same behaviour
+    # as before — but it now says what went wrong first.
     try:
         existing = ac.get_oauth2_credential_provider(name=name)
         arn = existing["credentialProviderArn"]
         print(f"  Credential provider already exists: {arn}")
-        return dict(name=name, arn=arn)
-    except Exception:
+        return {"name": name, "arn": arn}
+    except ac.exceptions.ResourceNotFoundException:
         pass
+    except Exception as e:  # noqa: BLE001 - fall through to create, but not silently
+        print(f"  Could not check for an existing credential provider ({e}); attempting to create")
 
     resp = ac.create_oauth2_credential_provider(
         name=name,
@@ -224,7 +320,7 @@ def create_credential_provider(
     )
     arn = resp["credentialProviderArn"]
     print(f"  Credential provider created: {arn}")
-    return dict(name=name, arn=arn)
+    return {"name": name, "arn": arn}
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -264,8 +360,10 @@ def deploy_lambda(region: str, prefix: str) -> dict:
             RoleName=role_name,
             PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         )
-    except Exception:
-        pass
+    except Exception as e:  # noqa: BLE001 - already attached is fine; anything else must be visible
+        # Silently passing here hid a genuine failure to grant the Lambda its
+        # logging permissions, which then showed up only as missing CloudWatch logs.
+        print(f"  Could not attach AWSLambdaBasicExecutionRole ({e})")
     print(f"  Role: {role_name}")
 
     fn_name = f"{prefix}-order-mgmt"
@@ -295,7 +393,7 @@ def deploy_lambda(region: str, prefix: str) -> dict:
 
     lam.get_waiter("function_active_v2").wait(FunctionName=fn_name)
     print("  Lambda is Active")
-    return dict(function_name=fn_name, function_arn=fn_arn, role_name=role_name)
+    return {"function_name": fn_name, "function_arn": fn_arn, "role_name": role_name}
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -375,9 +473,13 @@ def create_gateway_with_lambda_target(
         print(f"  Gateway created: {gw_id}")
     except ac.exceptions.ConflictException:
         gw_id = None
-        for g in ac.list_gateways().get("items", []):
-            info = ac.get_gateway(gatewayIdentifier=g["gatewayId"])
-            if info.get("name") == gateway_name:
+        # ListGateways already reports `name`, so match on the list entry and only
+        # describe the one that matched — the original described every gateway in
+        # the account to find one, which on a busy account is a lot of calls and
+        # risks throttling during what is meant to be a recovery path.
+        for g in iter_paginated(ac, "list_gateways", "items"):
+            if g.get("name") == gateway_name:
+                info = ac.get_gateway(gatewayIdentifier=g["gatewayId"])
                 gw_id = info["gatewayId"]
                 gw_arn = info.get("gatewayArn", "")
                 gw_url = info.get("gatewayUrl", "")
@@ -387,12 +489,11 @@ def create_gateway_with_lambda_target(
         print(f"  Gateway already exists: {gw_id}")
 
     print("  Waiting for gateway READY...")
-    for _ in range(30):
-        status = ac.get_gateway(gatewayIdentifier=gw_id)["status"]
-        if status == "READY":
-            break
-        time.sleep(10)
-    print(f"  Gateway status: {status}")
+    _poll_until_ready(
+        lambda: ac.get_gateway(gatewayIdentifier=gw_id)["status"],
+        f"Gateway {gw_id}",
+        GATEWAY_FAILURE_STATUSES,
+    )
 
     tool_schemas = [
         {
@@ -436,30 +537,35 @@ def create_gateway_with_lambda_target(
         print(f"  Target created: {tgt_id}")
     except ac.exceptions.ConflictException:
         tgt_id = None
-        for t in ac.list_gateway_targets(gatewayIdentifier=gw_id).get("items", []):
-            tgt_id = t["targetId"]
-            break
+        # Match on the name that actually conflicted. The original took whichever
+        # target came back first, so a gateway carrying any other target could hand
+        # back the wrong id — and the poll below would then wait on a resource this
+        # script never created.
+        for t in iter_paginated(ac, "list_gateway_targets", "items", gatewayIdentifier=gw_id):
+            if t.get("name") == target_name:
+                tgt_id = t["targetId"]
+                break
         if not tgt_id:
-            raise RuntimeError("Target exists but could not be found")
+            raise RuntimeError(f"Target {target_name} conflict but not found")
         print(f"  Target already exists: {tgt_id}")
 
     print("  Waiting for target READY...")
-    for _ in range(30):
-        status = ac.get_gateway_target(gatewayIdentifier=gw_id, targetId=tgt_id)["status"]
-        if status == "READY":
-            break
-        time.sleep(10)
-    print(f"  Target status: {status}")
+    _poll_until_ready(
+        lambda: ac.get_gateway_target(gatewayIdentifier=gw_id, targetId=tgt_id)["status"],
+        f"Target {tgt_id}",
+        TARGET_FAILURE_STATUSES,
+        TARGET_PENDING_AUTH_STATUSES,
+    )
 
     gw_full = ac.get_gateway(gatewayIdentifier=gw_id)
-    return dict(
-        gateway_id=gw_id,
-        gateway_arn=gw_full.get("gatewayArn", gw_arn),
-        gateway_url=gw_full.get("gatewayUrl", gw_url),
-        target_id=tgt_id,
-        role_name=gw_role_name,
-        policy_name=gw_policy_name,
-    )
+    return {
+        "gateway_id": gw_id,
+        "gateway_arn": gw_full.get("gatewayArn", gw_arn),
+        "gateway_url": gw_full.get("gatewayUrl", gw_url),
+        "target_id": tgt_id,
+        "role_name": gw_role_name,
+        "policy_name": gw_policy_name,
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -539,6 +645,39 @@ def create_harness_execution_role(region: str, prefix: str, account_id: str) -> 
                     "Resource": ["*"],
                 },
                 {
+                    # Creating a harness auto-provisions a managed memory
+                    # (harness_<HarnessName>_*), and the very first InvokeHarness
+                    # reads it. Without these actions that call fails with
+                    # AccessDeniedException on ListEvents before the agent ever
+                    # runs. Enumerated rather than wildcarded, matching
+                    # utils/iam.py, so the role cannot delete stores it only reads.
+                    "Sid": "Memory",
+                    "Effect": "Allow",
+                    "Action": [
+                        "bedrock-agentcore:GetMemory",
+                        "bedrock-agentcore:DeleteMemory",
+                        "bedrock-agentcore:RetrieveMemoryRecords",
+                        "bedrock-agentcore:CreateEvent",
+                        "bedrock-agentcore:GetEvent",
+                        "bedrock-agentcore:ListEvents",
+                    ],
+                    "Resource": f"arn:aws:bedrock-agentcore:{region}:{account_id}:memory/*",
+                },
+                {
+                    # CreateMemory and ListMemories are account-scoped — neither
+                    # takes a memory ID, so neither can be granted on a memory/*
+                    # resource: IAM evaluates that to an implicit deny. Verified
+                    # with iam:SimulateCustomPolicy, which reports them allowed
+                    # only against "*".
+                    "Sid": "MemoryAccountScoped",
+                    "Effect": "Allow",
+                    "Action": [
+                        "bedrock-agentcore:CreateMemory",
+                        "bedrock-agentcore:ListMemories",
+                    ],
+                    "Resource": "*",
+                },
+                {
                     "Sid": "EcrPublic",
                     "Effect": "Allow",
                     "Action": [
@@ -585,7 +724,7 @@ def create_harness_execution_role(region: str, prefix: str, account_id: str) -> 
     print(f"  Policy: {policy_name}")
     print("  Waiting 15 s for IAM propagation...")
     time.sleep(15)
-    return dict(role_arn=role_arn, role_name=role_name, policy_name=policy_name)
+    return {"role_arn": role_arn, "role_name": role_name, "policy_name": policy_name}
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -628,45 +767,63 @@ def cleanup_all(region: str, prefix: str):
         print(f"  - {m}")
 
     def _wait_gone(check_fn, retries=24, delay=5, **kwargs):
+        """Poll until `check_fn` raises (i.e. the resource is gone). True if it went.
+
+        Returns False on timeout instead of nothing: the caller used to print
+        "deleted" unconditionally after this returned, so a resource still
+        DELETING after two minutes was reported as successfully removed.
+        """
         for _ in range(retries):
             try:
                 check_fn(**kwargs)
                 time.sleep(delay)
-            except Exception:
-                return
+            except Exception:  # noqa: BLE001 - the describe failing is how "gone" is reported
+                return True
+        return False
 
     # 1. Harness
     print("\n[1/7] Harness")
     try:
-        matches = [h for h in ac.list_harnesses().get("harnesses", []) if h.get("harnessName") == harness_name]
+        matches = [h for h in iter_paginated(ac, "list_harnesses", "harnesses") if h.get("harnessName") == harness_name]
         if matches:
             hid = matches[0]["harnessId"]
             ac.delete_harness(harnessId=hid)
             ok(f"Harness {hid} delete initiated")
-            _wait_gone(ac.get_harness, harnessId=hid)
-            ok("Harness deleted")
+            # Deleting the harness is also what releases the managed memory it
+            # auto-provisioned (harness_<name>_*): the memory cannot be deleted
+            # directly — DeleteMemory rejects it as managed — and it only
+            # disappears once this delete finishes. So waiting here is what keeps
+            # the memory from being left behind.
+            if _wait_gone(ac.get_harness, harnessId=hid):
+                ok("Harness deleted")
+            else:
+                skip(f"Harness {hid} still deleting — its managed memory may linger briefly")
         else:
             skip("Harness not found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip(f"Harness: {e}")
 
     # 2. Gateway + targets
     print("\n[2/7] Gateway + targets")
     try:
-        gws = [g for g in ac.list_gateways().get("items", []) if g.get("name") == gateway_name]
+        gws = [g for g in iter_paginated(ac, "list_gateways", "items") if g.get("name") == gateway_name]
         if gws:
             gid = gws[0]["gatewayId"]
-            for t in ac.list_gateway_targets(gatewayIdentifier=gid).get("items", []):
+            for t in iter_paginated(ac, "list_gateway_targets", "items", gatewayIdentifier=gid):
                 tid = t["targetId"]
                 ac.delete_gateway_target(gatewayIdentifier=gid, targetId=tid)
-                _wait_gone(ac.get_gateway_target, gatewayIdentifier=gid, targetId=tid)
-                ok(f"Target {tid} deleted")
+                if _wait_gone(ac.get_gateway_target, gatewayIdentifier=gid, targetId=tid):
+                    ok(f"Target {tid} deleted")
+                else:
+                    skip(f"Target {tid} still deleting")
             ac.delete_gateway(gatewayIdentifier=gid)
-            _wait_gone(ac.get_gateway, gatewayIdentifier=gid)
-            ok("Gateway deleted")
+            if _wait_gone(ac.get_gateway, gatewayIdentifier=gid):
+                ok("Gateway deleted")
+            else:
+                skip(f"Gateway {gid} still deleting")
         else:
             skip("Gateway not found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip(f"Gateway: {e}")
 
     # 3. Credential provider
@@ -675,7 +832,7 @@ def cleanup_all(region: str, prefix: str):
         ac.get_oauth2_credential_provider(name=cred_name)
         ac.delete_oauth2_credential_provider(name=cred_name)
         ok(f"{cred_name} deleted")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip("Credential provider not found" if "not found" in str(e).lower() else str(e))
 
     # 4. Lambda
@@ -686,7 +843,7 @@ def cleanup_all(region: str, prefix: str):
         ok(f"{fn_name} deleted")
     except lam.exceptions.ResourceNotFoundException:
         skip("Lambda not found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip(f"Lambda: {e}")
 
     # 5. IAM roles & policies
@@ -701,18 +858,37 @@ def cleanup_all(region: str, prefix: str):
         try:
             for p in iam_c.list_attached_role_policies(RoleName=rname)["AttachedPolicies"]:
                 iam_c.detach_role_policy(RoleName=rname, PolicyArn=p["PolicyArn"])
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+            # A failure here blocks the DeleteRole below, so name it: otherwise the
+            # role just appears to "still be in use" for no stated reason.
+            skip(f"Could not detach policies from {rname}: {e}")
         for pn in policy_names or []:
+            parn = f"arn:aws:iam::{account_id}:policy/{pn}"
             try:
-                iam_c.delete_policy(PolicyArn=f"arn:aws:iam::{account_id}:policy/{pn}")
-                ok(f"Policy {pn} deleted")
-            except Exception:
+                # DeletePolicy refuses to run while non-default versions exist, so
+                # a policy that was updated by a re-run cannot be deleted until
+                # they are pruned. Without this the policy silently survived
+                # cleanup, and the next run inherited it.
+                for v in iam_c.list_policy_versions(PolicyArn=parn)["Versions"]:
+                    if not v["IsDefaultVersion"]:
+                        iam_c.delete_policy_version(PolicyArn=parn, VersionId=v["VersionId"])
+            except iam_c.exceptions.NoSuchEntityException:
                 pass
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                skip(f"Could not prune versions of policy {pn}: {e}")
+            try:
+                iam_c.delete_policy(PolicyArn=parn)
+                ok(f"Policy {pn} deleted")
+            except iam_c.exceptions.NoSuchEntityException:
+                skip(f"Policy {pn} not found")
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                # This used to pass silently, so a policy left behind by cleanup was
+                # invisible — and it then blocked the next run with EntityAlreadyExists.
+                skip(f"Policy {pn}: {e}")
         try:
             iam_c.delete_role(RoleName=rname)
             ok(f"Role {rname} deleted")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             skip(f"Role {rname}: {e}")
 
     _del_role(lambda_role)
@@ -722,7 +898,7 @@ def cleanup_all(region: str, prefix: str):
     # 6. Cognito Pool #2
     print("\n[6/7] Cognito Pool #2")
     try:
-        m = [p for p in cog.list_user_pools(MaxResults=60)["UserPools"] if p["Name"] == pool2_name]
+        m = [p for p in _iter_user_pools(cog) if p["Name"] == pool2_name]
         if m:
             pid = m[0]["Id"]
             try:
@@ -730,28 +906,40 @@ def cleanup_all(region: str, prefix: str):
                 if d:
                     cog.delete_user_pool_domain(Domain=d, UserPoolId=pid)
                     ok(f"Domain {d} deleted")
-            except Exception:
-                pass
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                # The pool delete below fails while a domain is still attached, so
+                # swallowing this produced a confusing "pool still in use" error.
+                skip(f"Could not delete the domain on pool {pid}: {e}")
             cog.delete_user_pool(UserPoolId=pid)
             ok(f"Pool #2 {pid} deleted")
         else:
             skip("Pool #2 not found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip(f"Pool #2: {e}")
 
     # 7. Cognito Pool #1
     print("\n[7/7] Cognito Pool #1")
     try:
-        m = [p for p in cog.list_user_pools(MaxResults=60)["UserPools"] if p["Name"] == pool1_name]
+        m = [p for p in _iter_user_pools(cog) if p["Name"] == pool1_name]
         if m:
             pid = m[0]["Id"]
             cog.delete_user_pool(UserPoolId=pid)
             ok(f"Pool #1 {pid} deleted")
         else:
             skip("Pool #1 not found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         skip(f"Pool #1: {e}")
 
     print(f"\n{'=' * 50}")
     print(f"Deleted {len(deleted)} resources, skipped {len(skipped)}")
-    print("✅ Cleanup complete!")
+    # "Cleanup complete!" used to print even when items were skipped, which reads
+    # as "nothing left behind" when something may well have been. A skip is
+    # normal on a partial run (a resource that was never created), so this is not
+    # an error — but it does need to be visible enough to check.
+    if skipped:
+        print("⚠️  Cleanup finished with skips — review the '-' lines above:")
+        for m in skipped:
+            print(f"     - {m}")
+    else:
+        print("✅ Cleanup complete!")
+    return {"deleted": deleted, "skipped": skipped}


### PR DESCRIPTION
## Summary

`07-oauth` printed a full success narrative even when the agent invocation failed, and leaked every resource it created if any step raised. Every fix below was reproduced against upstream `main` and re-verified live in a real AWS account (7 deploy/teardown cycles).

## Correctness

1. **False success on a failed invoke.** `InvokeHarness` over HTTPS returns HTTP 200 and reports agent-side failures as `{"message": ...}` frames *inside* the binary event stream. The parser read only `obj["delta"]`, discarded them, printed `(No text deltas found in stream)` plus raw bytes, and then printed the success narrative claiming all three auth hops had worked. Now: raise on non-200, collect and raise on error frames, and raise when there are neither deltas nor an error frame.
2. **Missing memory permissions** made the harness fail at runtime with `AccessDeniedException` on `ListEvents`. Added the 8 memory/event actions. `CreateMemory` and `ListMemories` take no memory ID, so they are `implicitDeny` under `memory/*` and must be scoped to `"*"` (confirmed with `iam:SimulateCustomPolicy`); the other 6 stay on `memory/*`.
3. **Three fall-through polls** treated terminal statuses as "not ready yet" and, once the loop expired, carried straight on against a resource still `CREATING` — surfacing as a confusing HTTP error rather than the real cause. Replaced with deadline loops that raise on terminal status and on timeout.
4. **No `try`/`finally`.** A failure between Step 1a and Step 4 left two Cognito pools, a credential provider, a Lambda, a gateway + target, a harness and three IAM roles alive — all billable, and all blocking the next run with `ConflictException`.
5. `_wait_gone` returned success on timeout; it now returns a boolean the caller honours.
6. `✅ Cleanup complete!` printed even when resources had been skipped.
7. `_ensure_policy` swallowed `EntityAlreadyExists`, so a re-run silently kept a stale policy document. It now publishes a new default version, pruning the oldest non-default at the 5-version service limit.
8. The Cognito pool lookup read only the first 60-pool page.
9. `_del_role` could not delete a policy that had non-default versions.
10. **Six unpaginated AgentCore list calls.** `ListHarnesses`, `ListGateways` and `ListGatewayTargets` all return a `nextToken`. Routed through a single `iter_paginated` helper. This has two distinct consequences, neither of which mentions pagination: a lookup after `ConflictException` fails with "conflict but not found" for a resource that demonstrably exists, and cleanup reports "not found" and walks past a resource it created — leaking it, and in the harness case leaking its managed memory with it.
11. **The target conflict fallback took the first target with no name check**, so a gateway carrying any other target hands back the wrong `targetId` — and the poll then waits on a resource this script never created.
12. Removed a needless `get_gateway` per gateway in the gateway conflict fallback; `ListGateways` already reports `name`, so only the match needs describing. The original described every gateway in the account, which on a busy account risks throttling during what is meant to be a recovery path.

Also converted 6 `except Exception: pass` handlers into reported skips, so cleanup failures are visible instead of silent.

## Docs and lint

13. The README documented no IAM permissions at all, and told readers to `pip install requests` — already line 9 of `../../requirements.txt`. Added a permission table (enumerated by walking the AST of every boto3 call in the sample) and a helper-function table.
14. `utils/lambda_function_code.py` carried a latent import-order violation and a docstring naming the wrong tools. It had never failed CI because CI lints only changed files and this file had never been modified.

## Testing

**7 live deploy/teardown cycles** in `us-west-2`, on a fresh-account baseline:

| Run | Scenario | Result |
| --- | --- | --- |
| 1 | pristine upstream (BEFORE) | reproduces items 1 and 2 |
| 2 | fixed bytes (AFTER) | exit 0, full auth chain |
| 3 | fresh + cleanup | exit 0; `Deleted 13 resources, skipped 1` |
| 4 | fresh + `--skip-cleanup` | exit 0; prints Harness ID + Gateway ARN |
| 5 | re-run over existing resources | exit 0; `Deleted 14 resources, skipped 0`; policies `v1` → `v2 default` |
| 6 | fresh + `--skip-cleanup`, final bytes | exit 0; HTTP 200 |
| 7 | re-run over existing resources, final bytes | exit 0; all three rewritten conflict fallbacks exercised; `Deleted 13 resources, skipped 1` |

Every run exited 0, and after each one the account returned to its exact pre-flight baseline with zero leaked resources. The harness's managed `harness_*` memory self-reaps a couple of minutes after the harness delete completes — confirmed, so cleanup does not need to (and cannot) delete it directly.

Also: 63 unit checks covering the branches a healthy account cannot reach (terminal statuses, timeouts, policy-version pruning, pagination across a page boundary, and static assertions that the success narrative sits after every guard that protects it). `ruff check` and `ruff format --check` are clean on all four files at both ruff 0.15.0 and 0.16.1.

## Deliberately unchanged

- `_wait_gone`'s broad `except` — a missing *gateway* raises `AccessDeniedException`, not `ResourceNotFoundException` (verified live), so narrowing it would break the "gone" detection.
- The IAM list calls are bounded by service limits (10 managed policies per role, 5 versions per policy), both well under one page, so they need no pagination.
