### PR TITLE
fix(06-async-step-function): report failures instead of SUCCEEDED, and fix the sample test path

### DIFF
--- a/01-features/01-harness/01-advanced-examples/06-async-step-function/README.md
+++ b/01-features/01-harness/01-advanced-examples/06-async-step-function/README.md
@@ -33,9 +33,22 @@ Trigger → Step Functions → Invoke Harness → Exa MCP Search
 1. Receive input: `{city, date}`
 2. Invoke harness: "Get weather for {city} on {date}"
 3. Harness uses Exa MCP (https://mcp.exa.ai/mcp) to search web
-4. Extract JSON from markdown using `States.StringSplit()` + `States.Format()`
-5. Parse with `States.StringToJson()`
+4. Extract the JSON object from the reply with a JSONata regex match
+5. Parse it with JSONata `$parse()`
 6. Store in DynamoDB with GSI for city queries
+
+## Prerequisites
+
+- **AWS credentials** with permission to create CloudFormation stacks, IAM roles,
+  DynamoDB tables, Step Functions state machines and AgentCore harnesses. The
+  deploy uses `--capabilities CAPABILITY_NAMED_IAM` because the roles are named.
+- **[jq](https://jqlang.github.io/jq/)** — all three scripts use it to read
+  `deployment_info.json` and the sample inputs.
+- **AWS CLI v2**, configured for a region where AgentCore Harness is available.
+  `deploy.sh` honours `AWS_DEFAULT_REGION`, then `AWS_REGION`, then your
+  configured default, falling back to `us-west-2`.
+- **Model access** to `global.anthropic.claude-haiku-4-5-20251001-v1:0` in that
+  region.
 
 ## Quick Start
 
@@ -89,40 +102,47 @@ aws dynamodb query --table-name weather-data \
 
 ## Key Features
 
-✅ **No Lambda required** - JSON parsing with Step Functions intrinsic functions  
+✅ **No Lambda required** - JSON parsing with JSONata inside Step Functions  
 ✅ **MCP integration** - Exa search for real-time data  
-✅ **Error handling** - 3x retry with exponential backoff  
+✅ **Error handling** - 3x retry with exponential backoff on transient errors;
+caller-fault errors (access denied, validation) fail fast, and a failed
+invocation ends the execution as `FAILED` rather than reporting success  
 ✅ **Structured storage** - DynamoDB with city GSI  
 ✅ **Cost effective** - ~$0.27 per 1000 executions  
 
 ## How JSON Extraction Works
 
-Step Functions extracts JSON from agent's markdown response without Lambda:
+Step Functions extracts the JSON object from the agent's reply without Lambda,
+using a JSONata regex match in a `Pass` state:
 
-```javascript
-// Agent returns: "Here's the weather:\n```json\n{\"city\":\"Tokyo\",...}\n```"
-
-// Step 1: Split by '{' and '}'
-parts = text.split('{')  // ["Here's...", "\"city\":\"Tokyo\",...}\n```"]
-body = parts[1].split('}')[0]  // "\"city\":\"Tokyo\",..."
-
-// Step 2: Reconstruct JSON
-jsonString = '{' + body + '}'  // "{\"city\":\"Tokyo\",...}"
-
-// Step 3: Parse
-data = JSON.parse(jsonString)
-```
-
-Implemented as:
 ```json
 {
   "Type": "Pass",
-  "Parameters": {
-    "reconstructed.$": "States.Format('{...}', 
-      States.ArrayGetItem(States.StringSplit(...), 0))"
+  "QueryLanguage": "JSONata",
+  "Output": {
+    "jsonText": "{% $match($states.input....Text, /\\{[\\s\\S]*\\}/).match %}"
   }
 }
 ```
+
+The pattern is greedy from the first `{` to the last `}`, so all three shapes a
+model realistically returns work:
+
+| Agent reply                                  | Extracted            |
+|:---------------------------------------------|:---------------------|
+| `{"city":"Tokyo",...}`                       | the whole object     |
+| `Here's the weather: {"city":"Tokyo",...}`    | the whole object     |
+| ` ```json\n{"city":"Tokyo",...}\n``` `       | the whole object     |
+
+Nested objects survive too — `{"city":"Tokyo","detail":{"wind_kph":5}}` is
+matched intact.
+
+A `Choice` state then checks whether anything was matched at all. If the reply
+contained no JSON object, the execution ends in the `AgentResponseNotJson`
+`Fail` state rather than continuing with empty data.
+
+`ParseJson` turns the matched text into real JSON with `$parse()`, and
+`StoreToDynamoDB` writes the fields.
 
 ## DynamoDB Schema
 

--- a/01-features/01-harness/01-advanced-examples/06-async-step-function/cleanup.sh
+++ b/01-features/01-harness/01-advanced-examples/06-async-step-function/cleanup.sh
@@ -38,11 +38,16 @@ echo ""
 
 # Optional: Empty DynamoDB first
 if [ ! -z "$DYNAMO_TABLE" ] && [ "$DYNAMO_TABLE" != "null" ]; then
+  # `jq` on empty stdin exits 0, so `|| echo 0` never fires when the scan
+  # itself fails — that would leave ITEM_COUNT empty and make the numeric
+  # test below abort with "integer expected". Default any empty/non-numeric
+  # result to 0 explicitly.
   ITEM_COUNT=$(aws dynamodb scan \
     --table-name "$DYNAMO_TABLE" \
     --region $REGION \
     --select COUNT \
-    --output json 2>/dev/null | jq -r '.Count' || echo "0")
+    --output json 2>/dev/null | jq -r '.Count // 0')
+  [[ "$ITEM_COUNT" =~ ^[0-9]+$ ]] || ITEM_COUNT=0
 
   if [ "$ITEM_COUNT" -gt 0 ]; then
     echo "DynamoDB table has $ITEM_COUNT items"
@@ -69,14 +74,16 @@ aws cloudformation delete-stack \
   --region $REGION
 
 echo "Waiting for deletion..."
-aws cloudformation wait stack-delete-complete \
+# `set -e` would abort here on a failed wait, so the `[ $? -eq 0 ]` check that
+# used to follow could only ever see 0 — the "check the console" branch was
+# unreachable. Test the command inline and keep going either way, so the local
+# state file is still cleaned up and the warning is really shown.
+if aws cloudformation wait stack-delete-complete \
   --stack-name "$STACK_NAME" \
-  --region $REGION 2>&1
-
-if [ $? -eq 0 ]; then
+  --region $REGION 2>&1; then
   echo -e "${GREEN}✓ Stack deleted${NC}"
 else
-  echo -e "${YELLOW}⚠ Check AWS Console for status${NC}"
+  echo -e "${YELLOW}⚠ Stack deletion did not complete — check the AWS Console for status${NC}"
 fi
 
 # Clean up local files

--- a/01-features/01-harness/01-advanced-examples/06-async-step-function/cloudformation.yaml
+++ b/01-features/01-harness/01-advanced-examples/06-async-step-function/cloudformation.yaml
@@ -131,7 +131,10 @@ Resources:
                   - bedrock-agentcore:GetWorkloadAccessTokenForJWT
                 Resource:
                   - !Sub arn:aws:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:workload-identity-directory/default
-                  - !Sub arn:aws:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:workload-identity-directory/default/workload-identity/harness_harness_*
+                  # The identity a harness gets is named `harness_<HarnessName>-<suffix>`
+                  # (e.g. harness_WeatherHarness-JhUExN3fko), so the doubled
+                  # `harness_harness_*` prefix here matched nothing.
+                  - !Sub arn:aws:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:workload-identity-directory/default/workload-identity/harness_*
               - Sid: AgentCoreBrowserDefault
                 Effect: Allow
                 Action:
@@ -152,6 +155,34 @@ Resources:
                   - bedrock-agentcore:ListCodeInterpreterSessions
                   - bedrock-agentcore:InvokeCodeInterpreter
                 Resource: !Sub arn:aws:bedrock-agentcore:${AWS::Region}:aws:code-interpreter/*
+              # Creating a harness auto-provisions a managed memory
+              # (harness_<HarnessName>_*). Without these actions the very first
+              # InvokeHarness fails with AccessDeniedException on ListEvents —
+              # and because the Step Functions Catch routes that to a
+              # success-shaped result, executions report SUCCEEDED while nothing
+              # is ever written to DynamoDB. These mirror the shared
+              # utils/iam.py policy the Python samples use.
+              - Sid: AgentCoreMemoryAccess
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:GetMemory
+                  - bedrock-agentcore:DeleteMemory
+                  - bedrock-agentcore:CreateEvent
+                  - bedrock-agentcore:GetEvent
+                  - bedrock-agentcore:ListEvents
+                  - bedrock-agentcore:RetrieveMemoryRecords
+                Resource:
+                  - !Sub arn:aws:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:memory/*
+              # CreateMemory and ListMemories act on the account, not on a memory
+              # that exists yet, so they cannot be scoped to `memory/*` — doing so
+              # leaves them implicitly denied (confirmed with
+              # iam:SimulateCustomPolicy). They must sit in their own statement.
+              - Sid: AgentCoreMemoryAccountScoped
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:CreateMemory
+                  - bedrock-agentcore:ListMemories
+                Resource: '*'
               - Sid: EFSClientAccess
                 Effect: Allow
                 Action:
@@ -298,6 +329,16 @@ Resources:
               "TimeoutSeconds": 300,
               "Retry": [
                 {
+                  "Comment": "Caller-fault errors are never fixed by trying again. Retriers are evaluated in order, so matching these first with MaxAttempts 0 makes them fail fast. Without this, the States.TaskFailed retrier below matched every failure and a bad IAM policy or harness ARN was billed as four identical invocations before surfacing.",
+                  "ErrorEquals": [
+                    "BedrockAgentCore.AccessDeniedException",
+                    "BedrockAgentCore.ValidationException",
+                    "BedrockAgentCore.ResourceNotFoundException",
+                    "BedrockAgentCore.RuntimeClientErrorException"
+                  ],
+                  "MaxAttempts": 0
+                },
+                {
                   "ErrorEquals": ["States.Timeout", "States.TaskFailed"],
                   "IntervalSeconds": 2,
                   "MaxAttempts": 3,
@@ -311,23 +352,38 @@ Resources:
                   "Next": "HandleError"
                 }
               ],
-              "Next": "ExtractBetweenBraces"
+              "Next": "ExtractJson"
             },
-            "ExtractBetweenBraces": {
+            "ExtractJson": {
+              "Comment": "Pull the JSON object out of the agent's reply with a single JSONata regex match. The previous version split the text on '{' and took element 1, which crashed with States.Runtime/Invalid arguments in States.ArrayGetItem whenever the model replied with bare JSON (no leading prose, so no element 1), and silently truncated any nested object at its first '}'. Matching greedily from the first '{' to the last '}' handles bare, prose-wrapped and ```json-fenced replies, and keeps nested objects intact. The $exists guard turns 'no JSON at all' into an empty string so the Choice below can report it clearly instead of failing with an opaque JSONata error.",
               "Type": "Pass",
-              "Parameters": {
-                "fullText.$": "$.harnessOutput.Output.Message.Content[0].Text",
-                "reconstructed.$": "States.Format('\\{{}\\}', States.ArrayGetItem(States.StringSplit(States.ArrayGetItem(States.StringSplit($.harnessOutput.Output.Message.Content[0].Text, '{'), 1), '}'), 0))"
+              "QueryLanguage": "JSONata",
+              "Output": {
+                "city": "{% $states.input.city %}",
+                "date": "{% $states.input.date %}",
+                "jsonText": "{% ( $m := $match($states.input.harnessOutput.Output.Message.Content[0].Text, /\\{[\\s\\S]*\\}/).match; $exists($m) ? $m : '' ) %}"
               },
-              "ResultPath": "$.extracted",
-              "Next": "ParseJSON"
+              "Next": "CheckJsonFound"
             },
-            "ParseJSON": {
+            "CheckJsonFound": {
+              "Type": "Choice",
+              "QueryLanguage": "JSONata",
+              "Choices": [
+                {
+                  "Condition": "{% $states.input.jsonText != '' %}",
+                  "Next": "ParseJson"
+                }
+              ],
+              "Default": "HandleUnparseableResponse"
+            },
+            "ParseJson": {
               "Type": "Pass",
-              "Parameters": {
-                "data.$": "States.StringToJson($.extracted.reconstructed)"
+              "QueryLanguage": "JSONata",
+              "Output": {
+                "city": "{% $states.input.city %}",
+                "date": "{% $states.input.date %}",
+                "parsed": "{% $parse($states.input.jsonText) %}"
               },
-              "ResultPath": "$.parsed",
               "Next": "StoreToDynamoDB"
             },
             "StoreToDynamoDB": {
@@ -337,25 +393,25 @@ Resources:
                 "TableName": "${TableName}",
                 "Item": {
                   "id": {
-                    "S.$": "$.parsed.data.id"
+                    "S.$": "$.parsed.id"
                   },
                   "timestamp": {
-                    "S.$": "States.Format('{}', $.parsed.data.timestamp)"
+                    "S.$": "States.Format('{}', $.parsed.timestamp)"
                   },
                   "city": {
-                    "S.$": "$.parsed.data.city"
+                    "S.$": "$.parsed.city"
                   },
                   "date": {
-                    "S.$": "$.parsed.data.date"
+                    "S.$": "$.parsed.date"
                   },
                   "temperature_c": {
-                    "N.$": "States.Format('{}', $.parsed.data.temperature_c)"
+                    "N.$": "States.Format('{}', $.parsed.temperature_c)"
                   },
                   "temperature_f": {
-                    "N.$": "States.Format('{}', $.parsed.data.temperature_f)"
+                    "N.$": "States.Format('{}', $.parsed.temperature_f)"
                   },
                   "conditions": {
-                    "S.$": "$.parsed.data.conditions"
+                    "S.$": "$.parsed.conditions"
                   },
                   "input_city": {
                     "S.$": "$.city"
@@ -367,13 +423,17 @@ Resources:
               },
               "End": true
             },
+            "HandleUnparseableResponse": {
+              "Comment": "The harness answered, but the answer contained no JSON object to store.",
+              "Type": "Fail",
+              "Error": "AgentResponseNotJson",
+              "Cause": "The harness reply contained no parseable JSON object, so there was nothing to write to DynamoDB. Inspect the InvokeHarness output text in the execution history."
+            },
             "HandleError": {
-              "Type": "Pass",
-              "Parameters": {
-                "error": "Harness invocation failed",
-                "details.$": "$.error"
-              },
-              "End": true
+              "Comment": "Fail the execution so a caught harness error surfaces as FAILED. A Pass/End here would report SUCCEEDED while nothing was written to DynamoDB, hiding the failure behind a green checkmark.",
+              "Type": "Fail",
+              "Error": "HarnessInvocationFailed",
+              "Cause": "The harness invocation did not complete successfully. See the InvokeHarness task error in the execution history for the underlying cause. No item was written to DynamoDB."
             }
           }
         }
@@ -405,6 +465,9 @@ Outputs:
 
   HarnessId:
     Description: AgentCore harness ID
-    Value: !Ref WeatherHarness
+    # !Ref on AWS::BedrockAgentCore::Harness returns the ARN, not the ID, so this
+    # output used to duplicate HarnessArn. Take the last path segment of the ARN
+    # to get the real harness ID that GetHarness/DeleteHarness expect.
+    Value: !Select [1, !Split ['harness/', !GetAtt WeatherHarness.Arn]]
     Export:
       Name: !Sub ${AWS::StackName}-HarnessId

--- a/01-features/01-harness/01-advanced-examples/06-async-step-function/deploy.sh
+++ b/01-features/01-harness/01-advanced-examples/06-async-step-function/deploy.sh
@@ -12,20 +12,24 @@ echo -e "${BLUE}=====================================${NC}"
 echo ""
 
 STACK_NAME="weather-workflow-stack"
-REGION=$(aws configure get region || echo "us-west-2")
+# Honour the standard AWS environment variables first — every other sample in
+# this folder reads them, and `aws configure get region` ignores them, so a
+# caller who only exports AWS_DEFAULT_REGION was silently deployed elsewhere.
+REGION="${AWS_DEFAULT_REGION:-${AWS_REGION:-$(aws configure get region || echo "us-west-2")}}"
 
 echo "Region: $REGION"
 echo "Stack: $STACK_NAME"
 echo ""
 
 echo "Deploying CloudFormation stack..."
-aws cloudformation deploy \
+# `set -e` aborts the script the moment deploy fails, so a `[ $? -ne 0 ]` check
+# after it can never run. Handle the failure inline instead, so the error message
+# is actually printed.
+if ! aws cloudformation deploy \
   --template-file cloudformation.yaml \
   --stack-name $STACK_NAME \
   --capabilities CAPABILITY_NAMED_IAM \
-  --region $REGION
-
-if [ $? -ne 0 ]; then
+  --region $REGION; then
   echo -e "${RED}✗ Deployment failed${NC}"
   exit 1
 fi
@@ -77,7 +81,9 @@ echo ""
 echo "📝 Configuration:"
 echo "  Harness ID: $HARNESS_ID"
 echo "  DynamoDB: $DYNAMODB_TABLE"
-echo "  State Machine: $(basename $STATE_MACHINE_ARN)"
+# `basename` splits on '/', but a state machine ARN is colon-delimited, so it
+# returned the whole ARN unchanged. Take the field after the last colon.
+echo "  State Machine: ${STATE_MACHINE_ARN##*:}"
 echo ""
 echo "🚀 Next steps:"
 echo "  ./test_workflow.sh              # Interactive test"

--- a/01-features/01-harness/01-advanced-examples/06-async-step-function/test_workflow.sh
+++ b/01-features/01-harness/01-advanced-examples/06-async-step-function/test_workflow.sh
@@ -23,8 +23,17 @@ STATE_MACHINE_ARN=$(jq -r '.stateMachineArn' deployment_info.json)
 TABLE_NAME=$(jq -r '.dynamoTableName' deployment_info.json)
 REGION=$(jq -r '.region' deployment_info.json)
 
+# How long to wait for an execution before giving up. The state machine allows
+# InvokeHarness 300s per attempt and retries transient errors up to 3 times with
+# exponential backoff, so a worst-case run is a little over 1200s. Wait past
+# that, otherwise a slow-but-healthy run gets reported as a timeout.
+POLL_INTERVAL=2
+POLL_ATTEMPTS=650   # 650 x 2s = 1300s
+
 echo "Region: $REGION"
-echo "State Machine: $(basename $STATE_MACHINE_ARN)"
+# A state machine ARN is colon-delimited, so `basename` left it untouched and
+# this line printed the full ARN. Take the field after the last colon.
+echo "State Machine: ${STATE_MACHINE_ARN##*:}"
 echo "DynamoDB Table: $TABLE_NAME"
 echo ""
 
@@ -33,11 +42,15 @@ if [ "$1" == "--use-samples" ]; then
   echo -e "${BLUE}Using sample data from example_inputs.json${NC}"
   echo ""
 
-  # Read samples
-  SAMPLES=$(jq -r '.examples[0:3] | .[] | .input | @json' example_inputs.json)
+  # Read samples. Emit one compact JSON object per line and iterate with
+  # `while read`, NOT `for SAMPLE in $SAMPLES`: the inputs contain spaces
+  # (e.g. {"city":"New York",...}), so word-splitting an unquoted $SAMPLES
+  # would break each object apart and feed jq a fragment — the classic
+  # "jq: parse error: Unfinished string at EOF" that aborted this whole test.
   COUNT=0
 
-  for SAMPLE in $SAMPLES; do
+  while IFS= read -r SAMPLE; do
+    [ -z "$SAMPLE" ] && continue
     COUNT=$((COUNT+1))
     CITY=$(echo "$SAMPLE" | jq -r '.city')
     DATE=$(echo "$SAMPLE" | jq -r '.date')
@@ -54,8 +67,11 @@ if [ "$1" == "--use-samples" ]; then
     echo "  Execution ARN: $EXEC_ARN"
     echo "  Waiting for completion..."
 
-    # Wait for result
-    for i in {1..60}; do
+    # Wait for result. Handle every terminal status, and treat running-out
+    # of attempts as a timeout instead of silently falling through to the
+    # results section as if the run had succeeded.
+    SETTLED=""
+    for _ in $(seq 1 $POLL_ATTEMPTS); do
       STATUS=$(aws stepfunctions describe-execution \
         --execution-arn "$EXEC_ARN" \
         --region $REGION \
@@ -64,9 +80,10 @@ if [ "$1" == "--use-samples" ]; then
 
       if [ "$STATUS" == "SUCCEEDED" ]; then
         echo -e "  ${GREEN}✓ Success${NC}"
+        SETTLED="$STATUS"
         break
-      elif [ "$STATUS" == "FAILED" ]; then
-        echo -e "  ${RED}✗ Failed${NC}"
+      elif [ "$STATUS" == "FAILED" ] || [ "$STATUS" == "TIMED_OUT" ] || [ "$STATUS" == "ABORTED" ]; then
+        echo -e "  ${RED}✗ $STATUS${NC}"
         aws stepfunctions describe-execution \
           --execution-arn "$EXEC_ARN" \
           --region $REGION \
@@ -74,10 +91,15 @@ if [ "$1" == "--use-samples" ]; then
           --output text
         exit 1
       fi
-      sleep 2
+      sleep $POLL_INTERVAL
     done
+
+    if [ -z "$SETTLED" ]; then
+      echo -e "  ${RED}✗ Gave up after $((POLL_ATTEMPTS * POLL_INTERVAL))s waiting for the execution to finish${NC}"
+      exit 1
+    fi
     echo ""
-  done
+  done < <(jq -c '.examples[0:3] | .[] | .input' example_inputs.json)
 
 else
   # Interactive mode
@@ -113,23 +135,22 @@ else
   echo ""
   echo "Monitoring execution..."
 
-  for i in {1..60}; do
+  SETTLED=""
+  for _ in $(seq 1 $POLL_ATTEMPTS); do
     STATUS=$(aws stepfunctions describe-execution \
       --execution-arn "$EXEC_ARN" \
       --region $REGION \
       --query 'status' \
       --output text)
 
-    if [ "$STATUS" == "RUNNING" ]; then
-      echo -n "."
-      sleep 2
-    elif [ "$STATUS" == "SUCCEEDED" ]; then
+    if [ "$STATUS" == "SUCCEEDED" ]; then
       echo ""
       echo -e "${GREEN}✓ Execution succeeded!${NC}"
+      SETTLED="$STATUS"
       break
-    elif [ "$STATUS" == "FAILED" ]; then
+    elif [ "$STATUS" == "FAILED" ] || [ "$STATUS" == "TIMED_OUT" ] || [ "$STATUS" == "ABORTED" ]; then
       echo ""
-      echo -e "${RED}✗ Execution failed${NC}"
+      echo -e "${RED}✗ Execution $STATUS${NC}"
       ERROR=$(aws stepfunctions describe-execution \
         --execution-arn "$EXEC_ARN" \
         --region $REGION \
@@ -144,7 +165,16 @@ else
       echo "Cause: $CAUSE"
       exit 1
     fi
+    # Any non-terminal status (RUNNING, PENDING_REDRIVE): keep waiting.
+    echo -n "."
+    sleep $POLL_INTERVAL
   done
+
+  if [ -z "$SETTLED" ]; then
+    echo ""
+    echo -e "${RED}✗ Gave up after $((POLL_ATTEMPTS * POLL_INTERVAL))s waiting for the execution to finish${NC}"
+    exit 1
+  fi
 
   echo ""
 fi


### PR DESCRIPTION
## Summary

`06-async-step-function` reported `SUCCEEDED` for executions in which the agent invocation had failed and nothing was written to DynamoDB, and its documented test path (`./test_workflow.sh --use-samples`) aborted on the first sample. Every fix below was reproduced against upstream `main` and re-verified live in a real AWS account (3 deploy/teardown cycles).

## Correctness

1. **`SUCCEEDED` reported on a failed invoke.** `HandleError` was a `Pass` state with `"End": true`, so a caught harness error ended the execution green. Reproduced live: an execution whose `InvokeHarness` failed with `AccessDeniedException` finished `SUCCEEDED` with DynamoDB `Count = 0`. It is now a `Fail` state (`HarnessInvocationFailed`), and the same negative test reports `FAILED`.
2. **Missing memory permissions** made that first invoke fail in the first place: `AccessDeniedException … bedrock-agentcore:ListEvents on … memory/harness_WeatherHarness_…`. Creating a harness auto-provisions a managed memory that the first invoke reads, and the role granted no memory or event actions. Combined with item 1 this was invisible — the run went green over an empty table.
3. **The memory grant cannot all live on `memory/*`.** `CreateMemory` and `ListMemories` take no memory ID, so they evaluate to `implicitDeny` under `memory/*` (confirmed with `iam:SimulateCustomPolicy`) and need their own statement on `"*"`; the other 6 stay on `memory/*`. Re-verified after deploy with `simulate-principal-policy` against the real auto-created memory ARN — all 8 actions `allowed`.
4. **The documented test path aborted on sample 1.** `for SAMPLE in $SAMPLES` word-splits multi-line JSON, and the first example is `New York`, so `./test_workflow.sh --use-samples` died with `jq: parse error: Unfinished string at EOF` before starting a single execution. Now `while IFS= read -r` over `jq -c`.
5. **Both poll loops fell through as success.** Step Functions has 6 execution statuses; the loops handled 3. Reproduced live against a genuinely `ABORTED` execution: the loop matched no branch, spun 60× with no `sleep`, then continued to the results section as if the run had succeeded. Exhausting the attempts did the same. All terminal statuses are now handled, and exhaustion is reported as a timeout rather than ignored.
6. **JSON extraction crashed on bare JSON and silently corrupted nested objects.** `ExtractBetweenBraces` split the reply on `{` and took element 1. With no leading prose there is no element 1 — `aws stepfunctions test-state` returns `States.Runtime: Invalid arguments in States.ArrayGetItem`. It also truncated any nested object at its first `}` (`{"a":1,"b":{"c":2}}` → `"c":2}}`), which then stored wrong data rather than failing. Replaced with a single JSONata regex match plus `$parse`, verified against the live service on all five reply shapes (bare, prose-wrapped, ```json-fenced, nested, and no JSON at all).
7. **A reply containing no JSON now fails by name.** A new `CheckJsonFound` Choice routes it to `AgentResponseNotJson` instead of surfacing an opaque `States.QueryEvaluationError … returned nothing (undefined)`.
8. **Caller-fault errors were retried and billed 4×.** `Retry` listed `States.TaskFailed`, which matches them. Execution history showed 4 `TaskFailed` events (`BedrockAgentCore.RuntimeClientErrorException`, HTTP 424, `senderFault: True`) for one non-transient failure. A fail-fast retrier (`MaxAttempts: 0`) now precedes the transient one; retriers are evaluated in order, so the same test after the fix shows 1.
9. **The workload-identity ARN pattern matched nothing.** It was `harness_harness_*`; a harness's identity is named `harness_<HarnessName>-<suffix>`. Confirmed on the live deploy: `harness_WeatherHarness-NENgT77zMJ`.
10. **The `HarnessId` output duplicated `HarnessArn`.** `!Ref` on `AWS::BedrockAgentCore::Harness` returns the ARN — the CFN schema's `primaryIdentifier` is `/properties/Arn` and `HarnessId` is `readOnly`. `deploy.sh` printed the full ARN under `Harness ID:` and wrote it to `deployment_info.json`. It now yields the real ID (live: `WeatherHarness-lJRPmDVFo1`).
11. **Three unreachable error handlers.** Two `if [ $? -ne 0 ]` blocks follow commands running under `set -e` (`deploy.sh`, `cleanup.sh`), so the script has already exited and the branch can never run; both are now inline tests. And `jq -r '.Count' || echo "0"` never fires its fallback, because `jq` exits 0 on empty stdin — leaving `ITEM_COUNT` empty and aborting the next numeric test with `integer expected`. After the fix cleanup correctly reports `DynamoDB table has 4 items` and the delete branch actually runs. Both `SC2181` warnings are gone, with no new shellcheck classes introduced.

Also: `basename` on a colon-delimited state-machine ARN is a no-op, so both scripts printed the whole ARN where they meant `WeatherWorkflow`; and `deploy.sh` read the region with `aws configure get region`, which ignores `AWS_DEFAULT_REGION` and `AWS_REGION`, so a caller who exported either was silently deployed elsewhere.

## Docs

12. The README had **no Prerequisites section**, though all three scripts call `jq` (13 times) and the deploy needs `CAPABILITY_NAMED_IAM`. Added one covering credentials, `jq`, region precedence and model access.
13. Its "How JSON Extraction Works" section documented the split-on-`{` algorithm from item 6 in pseudocode, including an "Implemented as" block that no longer matched the template. Rewritten to describe the JSONata match, with a table of the reply shapes it handles and a note on the no-JSON failure path.

## Testing

**3 live deploy/teardown cycles** in `us-west-2`, from a fresh-account baseline:

| Run | Scenario | Result |
| --- | --- | --- |
| 1 | pristine upstream (BEFORE) | reproduces items 1, 2, 4, 5, 8, 10 and the `basename` no-op |
| 2 | fixed bytes (AFTER) | `--use-samples` 3/3 `SUCCEEDED` with real weather stored; interactive mode passes; negative test `FAILED` with 1 `TaskFailed`; no-JSON path fails as `AgentResponseNotJson` |
| 3 | final bytes, re-verified after reverting an unjustified `TimeoutSeconds` bump | `--use-samples` 3/3 `SUCCEEDED`; negative test `FAILED` with 1 `TaskFailed`; deployed `TimeoutSeconds` confirmed `300` |

After each cycle the account returned to its exact pre-flight baseline — no stack, no `Weather*` roles, no `weather-data` table, no orphaned harness, no `harness_WeatherHarness_*` memory, no `harness_WeatherHarness-*` workload identity, no log group. In run 2 the live agent replied with prose plus a ```json fence, so the extraction was exercised on a real model response as well as on the five synthetic shapes.

Static gates on the shipped bytes: `bash -n` clean on all three scripts, `shellcheck` free of the two `SC2181` findings with no new classes, `aws cloudformation validate-template` OK, and the embedded ASL extracted and passed through `aws stepfunctions validate-state-machine-definition` (OK). Individual states were checked with `aws stepfunctions test-state` before deploying.
