### PR TITLE
fix(harness/13-aws-skills): handle transport and throttling stream errors, document boto3 floor and flags

### DIFF
--- a/01-features/01-harness/01-advanced-examples/13-aws-skills/README.md
+++ b/01-features/01-harness/01-advanced-examples/13-aws-skills/README.md
@@ -53,6 +53,25 @@ skills=[
 set on the harness resource (so they apply to every invocation) or passed per
 `invoke_harness` call.
 
+Each `skills` entry is a *tagged union*, so set exactly one of `path`, `s3`, `git`
+or `awsSkills` per entry — combining two in one entry is rejected before the call
+is sent. To use several sources, add one entry each, as `--mode mixed` does.
+
+`paths` accepts `*` as a wildcard; `?` and character classes such as `[abc]` are
+not part of the accepted pattern.
+
+## Prerequisites
+
+- **AWS credentials** for a region where AgentCore Harness is available, and
+  **model access** to `global.anthropic.claude-haiku-4-5-20251001-v1:0` (or pass
+  another model with `--model`).
+- **boto3 ≥ 1.43.32** — the first release whose `bedrock-agentcore` model knows
+  the `awsSkills` skill source. On anything older this sample fails with
+  `ParamValidationError: Unknown parameter in skills[0]: "awsSkills"`.
+  `../../requirements.txt` already pins this floor.
+- The script creates the shared `HarnessExecutionRole` and deletes it again on
+  exit, unless you pass `--role-arn` (a role you supply is never deleted).
+
 ## Sample Prompts
 
 **Prompt** (`--mode glob`, default): "What AWS skills do you have available? Give a short bulleted summary by category."
@@ -99,4 +118,17 @@ python aws_skills.py --mode specific \
 # Combine serverless + CDK skills with a build task
 python aws_skills.py --mode mixed \
     -m "Design a Step Functions state machine for order processing and outline the CDK stack."
+
+# Reuse an existing execution role (it is then left in place on cleanup)
+python aws_skills.py --role-arn arn:aws:iam::111122223333:role/MyHarnessRole
+
+# Print the raw streaming events instead of just the assistant text
+python aws_skills.py --raw-events
+
+# Keep the harness after the demo
+python aws_skills.py --skip-cleanup
 ```
+
+A harness that enables AWS Skills takes roughly **2–3 minutes** to reach `READY`
+while the runtime loads them, so expect a wait on `Step 1` before the agent
+replies. `python aws_skills.py --help` lists every option.

--- a/01-features/01-harness/01-advanced-examples/13-aws-skills/aws_skills.py
+++ b/01-features/01-harness/01-advanced-examples/13-aws-skills/aws_skills.py
@@ -59,23 +59,18 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
 import time
 import uuid
 from pathlib import Path
 
-import boto3
-import botocore.exceptions
+from botocore.exceptions import BotoCoreError, ClientError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from utils.client import get_agentcore_client, get_agentcore_control_client
 from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
-
-REGION = os.getenv("AWS_DEFAULT_REGION")
-
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -174,10 +169,24 @@ def stream_response(client, harness_arn, session_id, message, model_id, raw=Fals
     )
 
     full_text = ""
+    # A failure mid-stream is raised out of the iterator by botocore, not
+    # delivered as an {"internalServerException": ...} event. It can be a modeled
+    # service error (EventStreamError/ClientError — throttling, access denied) or
+    # a transport error (ReadTimeoutError, connection reset — a BotoCoreError,
+    # which the agent can trigger just by going quiet during a long tool call).
+    # Catch both base classes: EventStreamError alone let a read timeout or a
+    # throttle abort the script before the `finally` in main() had reported the
+    # partial answer, and the traceback said nothing about the real cause.
     try:
         for event in response["stream"]:
             if raw:
                 print(json.dumps(event, default=str))
+                # Keep accumulating text in raw mode too. Skipping it left
+                # full_text empty, so the error handling below could not tell a
+                # stream that had produced content from one that had not.
+                delta = event.get("contentBlockDelta", {}).get("delta", {})
+                if "text" in delta:
+                    full_text += delta["text"]
                 continue
 
             if "contentBlockStart" in event:
@@ -193,9 +202,11 @@ def stream_response(client, harness_arn, session_id, message, model_id, raw=Fals
                 print()
             elif "internalServerException" in event:
                 print(f"\n  Error: {event['internalServerException']}")
-    except botocore.exceptions.EventStreamError:
-        # The stream may send an empty error event on close; safe to ignore
-        # if we already received content.
+    except (BotoCoreError, ClientError) as e:
+        # The stream may fail on close after delivering the whole answer. Report
+        # it either way, but only re-raise when nothing arrived — otherwise a
+        # cosmetic close error would throw away a complete, correct response.
+        print(f"\n  Stream error: {e}")
         if not full_text:
             raise
 
@@ -240,8 +251,9 @@ def main(args=None):
             harnessName=harness_name,
             executionRoleArn=role_arn,
             skills=skills,
-            # Smaller models benefit most from skills; allow the agent to use
-            # its default tools (fs/shell) so it can act on what the skill teaches.
+            # No `tools`/`allowedTools` is set, so the harness keeps its built-in
+            # toolset (fs/shell) — that is what lets the agent read the skill
+            # files it was given and act on what they teach.
             systemPrompt=[{"text": "You are a helpful AWS engineering assistant."}],
         )
         harness_id = resp["harness"]["harnessId"]


### PR DESCRIPTION
## Summary

`13-aws-skills` aborted with a traceback when the invoke stream failed on transport or throttling — including cases where the agent's complete answer had already been printed — and carried three pieces of dead or misleading code. The README documented neither the boto3 floor the sample requires nor three of its flags. Every change below was verified against upstream `main` and re-checked with 6 live deploy/teardown cycles in a real AWS account.

## Correctness

1. **A mid-stream failure aborted the run even after the full answer had arrived.** `stream_response` caught only `botocore.exceptions.EventStreamError`. That covers modeled stream errors, but a **transport** failure mid-stream (`ReadTimeoutError`, `ConnectionClosedError`) is a `BotoCoreError`, and a `ThrottlingException` arrives as a plain `ClientError` — neither was caught, so both escaped as an unhandled traceback that said nothing about the cause. The agent can trigger this simply by going quiet during a long tool call, which is normal for a skills-driven run. Now catches `(BotoCoreError, ClientError)`, prints the cause (the old handler swallowed it entirely, so even a real error left no trace), and re-raises only when nothing was received. Verified across 4 exception types in both directions (8 cases): all handled when content had arrived, all re-raised when it had not — a genuine failure must not read as success.

2. **`--raw-events` discarded good responses.** In raw mode the `continue` skipped text accumulation, so `full_text` stayed empty and the "did we receive anything?" guard re-raised even a cosmetic close error, throwing away a complete answer. Raw mode now accumulates text as well.

3. **Dead `REGION` variable.** `REGION = os.getenv("AWS_DEFAULT_REGION")` was assigned and never read — the only mention of `REGION` in the file. Beyond being dead it was misleading: it implies this module resolves the region, when the region actually resolves in `utils/client.py`, which correctly honours `AWS_DEFAULT_REGION` *or* `AWS_REGION`. Removed, with the now-unused `import os`.

4. **`import boto3` was entirely unused** — the sample only uses the `utils.client` factories. Removed. Worth noting for future reviews: the repo's ruff config ignores `F401`, so unused imports are not flagged here.

5. **A comment described an argument that isn't passed.** It read "allow the agent to use its default tools (fs/shell)", implying a `tools`/`allowedTools` value that does not appear in the call. Reworded to say that *omitting* them is what keeps the harness's built-in toolset — the actual mechanism that lets the agent read its skill files.

## Docs

6. **No Prerequisites section, and no mention of the boto3 floor.** The sample cannot work on older SDKs: `awsSkills` is absent from the `bedrock-agentcore` model before boto3/botocore 1.43.32, so a reader on an older pin fails with `ParamValidationError: Unknown parameter in skills[0]: "awsSkills"`. Confirmed by unpacking both wheels — `HarnessSkill` members are `['path','s3','git']` in 1.43.31 and gain `awsSkills` in 1.43.32. Added a Prerequisites section covering credentials, model access, that floor, and the shared-role lifecycle.

7. **Undocumented flags.** `--role-arn` and `--raw-events` appeared in `--help` but nowhere in the README, and `--skip-cleanup` was mentioned in prose without an example. All three now have one, including the fact that a role supplied via `--role-arn` is never deleted on cleanup. Also noted that `READY` takes roughly **2–3 minutes** while the runtime loads skills (measured 21–29 poll cycles across runs), so the wait doesn't read as a hang.

8. **`skills` entry semantics were unstated.** Documented that each entry is a *tagged union* — exactly one of `path`/`s3`/`git`/`awsSkills` — since setting two is rejected client-side with `Invalid number of parameters set for tagged union structure skills[0]`. Also documented that `paths` supports `*` but not `?` or character classes such as `[abc]`, per the model's `([^*?\[\]]|\*)+` pattern.

## Testing

**6 live deploy/teardown cycles** in `us-west-2`, each from a clean baseline (no `HarnessExecutionRole`, no sample harness):

| Run | Scenario | Result |
| --- | --- | --- |
| 1 | pristine upstream (BEFORE) | passes; agent enumerates 19 `core-skills`; clean teardown |
| 2 | fixed bytes, `--mode glob` (default) | 19 skills enumerated, no stream errors, `EXIT=0` |
| 3 | `--mode specific --raw-events` | 6 raw events; agent names `troubleshooting-application-failures`, confirming the single skill really loaded |
| 4 | `--mode mixed` | agent replies "the two skills loaded are **aws-serverless** and **aws-cdk**" |
| 5 | `--mode all` | sends `skills=[{"awsSkills": {}}]`, `EXIT=0` |
| 6 | final shipped bytes | `EXIT=0`, clean teardown |

The stream-error paths were exercised with injected failures rather than left to chance: `EventStreamError`, `ReadTimeoutError`, `ClientError`/throttle and `ConnectionClosedError`, each with and without prior content.

All three cleanup branches were verified: `--role-arn` deletes the harness but **not** the caller's role; the default path deletes the role it created; `--skip-cleanup` keeps both.

After every cycle the account returned to its pre-flight baseline — no harness, no `HarnessExecutionRole`, no `harness_AwsSkills_*` memory, no `harness_AwsSkills-*` workload identity.

Static gates on the shipped bytes: `ruff check` and `ruff format --check` clean under the repo config, `py_compile` OK. Every skill path the sample and README name was confirmed to exist in `aws/agent-toolkit-for-aws`.
