### PR TITLE
fix(harness/14-s3-filesystem): missing IAM permission, leaked execution role, and false-pass command guards

### DIFF
--- a/01-features/01-harness/01-advanced-examples/14-s3-filesystem/README.md
+++ b/01-features/01-harness/01-advanced-examples/14-s3-filesystem/README.md
@@ -57,16 +57,20 @@ environment={
 
 `mountPath` must look like `/mnt/<name>`. The execution role must be allowed to
 mount the access point — when this script creates the role, it attaches the
-required `s3files` permissions for you: `s3files:GetAccessPoint` (the runtime
-validates this at create time, so it stays unscoped) plus `s3files:ClientMount`
-and `s3files:ClientWrite` (scoped to the file system with an `AccessPointArn`
-condition, used when the microVM mounts the access point).
+required `s3files` permissions for you: `s3files:GetAccessPoint` **and
+`s3files:ListMountTargets`** (the runtime validates both at create time, so they
+stay unscoped — omitting `ListMountTargets` puts the harness straight into
+`CREATE_FAILED`) plus `s3files:ClientMount` and `s3files:ClientWrite` (scoped to
+the file system with an `AccessPointArn` condition, used when the microVM mounts
+the access point).
 
 ## Prerequisites
 
-- An **S3 Files access point** backed by a bucket, with a **mount target** in the
-  subnet you pass. Its ARN looks like:
+- An **S3 Files access point** backed by a **versioned** bucket, with a **mount
+  target** in the subnet you pass. Its ARN looks like:
   `arn:aws:s3files:<region>:<account>:file-system/fs-xxxx/access-point/fsap-xxxx`
+  Bucket **versioning is required** — `CreateFileSystem` rejects an unversioned
+  bucket with `Your bucket must have versioning enabled to create a file system.`
 - The **subnet(s) and security group(s)** that reach the mount target. The Harness
   must be in the **same VPC** as the mount target, the subnet(s) you pass must be
   in an **Availability Zone that has a mount target**, and the security group(s)
@@ -76,8 +80,16 @@ condition, used when the microVM mounts the access point).
   Harnesses run in private networking; public subnets do not give the microVM the
   connectivity it needs and the invoke will fail. See
   [Configure AgentCore for VPC](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-vpc.html).
+- **AWS credentials** for a region where AgentCore Harness is available, and
+  **model access** to `global.anthropic.claude-haiku-4-5-20251001-v1:0` (or pass
+  another model with `--model`).
 - If you bring your own execution role (`--role-arn`), it must already have the
-  `s3files` mount permissions above.
+  `s3files` mount permissions above. A role you supply is never deleted on
+  cleanup; the shared `HarnessExecutionRole` this script creates itself is.
+
+Creating the harness in VPC mode takes noticeably longer than the default network
+mode — expect **roughly 2–3 minutes** of `CREATING` before it reports `READY`, so
+the wait doesn't read as a hang.
 
 ## Sample Prompts
 
@@ -93,7 +105,7 @@ condition, used when the microVM mounts the access point).
 
 **Mount path format**: `mountPath` must match `/mnt/<name>` (validated by the script before the call).
 
-**IAM scope**: The execution role only needs access to the single access point — the script attaches a narrowly scoped policy.
+**IAM scope**: The mount permissions (`ClientMount`/`ClientWrite`) are scoped to the single access point with an `AccessPointArn` condition. The two the runtime checks at create time (`GetAccessPoint`, `ListMountTargets`) have to stay on `"*"`: `ListMountTargets` is authorized against the *file system* ID rather than the access point, so scoping it to the access point ARN denies it.
 
 ## Use case: a persistent LLM wiki
 
@@ -172,3 +184,17 @@ python s3_llm_wiki.py --access-point-arn arn:aws:s3files:... \
     --subnet-ids subnet-0abc1234 --security-group-ids sg-0def5678 \
     --op query -m "How does the LLM wiki pattern differ from RAG?"
 ```
+
+Other options (shared unless marked otherwise):
+
+| Flag | What it does |
+|---|---|
+| `--model MODEL_ID` | Use a different Bedrock model (default: Claude Haiku 4.5). |
+| `--message`/`-m` (wiki only) | The question for the `query` operation. |
+| `--op` (wiki only) | Run a single stage — `ingest`, `query` or `lint` — instead of `all`. |
+| `--filename` (mechanism only) | Name of the file written under the mount. |
+| `--role-arn ARN` | Reuse an existing execution role instead of creating one. It must already carry the `s3files` permissions, and it is **not** deleted on cleanup. |
+| `--skip-cleanup` | Keep the harness (and the role, if this run created it) after the demo. |
+| `--raw-events` | Print the raw JSON streaming events instead of formatted output — useful when debugging the stream. |
+
+`--help` lists every option for either script.

--- a/01-features/01-harness/01-advanced-examples/14-s3-filesystem/s3_filesystem.py
+++ b/01-features/01-harness/01-advanced-examples/14-s3-filesystem/s3_filesystem.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Mount S3 as the Harness Filesystem
 
@@ -78,24 +77,20 @@ Usage:
 
 import argparse
 import json
-import os
 import re
 import sys
 import time
 import uuid
-
 from pathlib import Path
 
 import boto3
-import botocore.exceptions
+from botocore.exceptions import BotoCoreError, ClientError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from utils.iam import create_harness_role, ROLE_NAME
 from utils.client import get_agentcore_client, get_agentcore_control_client
-
-REGION = os.getenv("AWS_DEFAULT_REGION")
-
+from utils.harness import poll_harness_status
+from utils.iam import ROLE_NAME, create_harness_role, delete_harness_role
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -107,9 +102,6 @@ S3_FILES_POLICY_NAME = "HarnessS3FilesAccess"
 
 # mountPath must match /mnt/<name> (see the service model: MountPath)
 MOUNT_PATH_PATTERN = re.compile(r"^/mnt/[a-zA-Z0-9._-]+/?$")
-
-HARNESS_POLL_INTERVAL = 5
-HARNESS_POLL_TIMEOUT = 180
 
 
 # ---------------------------------------------------------------------------
@@ -181,9 +173,12 @@ parser.add_argument(
 def attach_s3_files_policy(role_name, access_point_arn):
     """Allow the execution role to validate and mount the S3 Files access point.
 
-    * `s3files:GetAccessPoint` on `*` — the runtime validates this at harness
-      create time. Keep it unscoped; a scoped/conditioned form is rejected at
-      create with "Ensure the role has s3files:GetAccessPoint".
+    * `s3files:GetAccessPoint` **and `s3files:ListMountTargets`** on `*` — the
+      runtime validates both while creating the harness, so both must be
+      unscoped. `ListMountTargets` is easy to miss: it takes a file-system ID
+      rather than an access point, and without it CreateHarness accepts the
+      request and then lands in CREATE_FAILED with "Execution role is missing
+      required permissions. Ensure the role has s3files:ListMountTargets".
     * `s3files:ClientMount`/`ClientWrite` — used when the microVM mounts the
       access point; scoped to the file system with an AccessPointArn condition.
     """
@@ -195,7 +190,7 @@ def attach_s3_files_policy(role_name, access_point_arn):
             {
                 "Sid": "S3FilesValidate",
                 "Effect": "Allow",
-                "Action": ["s3files:GetAccessPoint"],
+                "Action": ["s3files:GetAccessPoint", "s3files:ListMountTargets"],
                 "Resource": "*",
             },
             {
@@ -215,23 +210,6 @@ def attach_s3_files_policy(role_name, access_point_arn):
     print(f"  Attached S3 Files access policy: {S3_FILES_POLICY_NAME}")
 
 
-def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
-    """Poll until a Harness reaches the target status or times out."""
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = control.get_harness(harnessId=harness_id)
-        status = resp["harness"]["status"]
-        print(f"  Harness status: {status}")
-        if status == target_status:
-            return resp
-        if status in ("FAILED", "DELETE_FAILED"):
-            reason = resp["harness"].get("failureReason", "")
-            raise RuntimeError(f"Harness entered {status}. {reason}")
-        if time.monotonic() > deadline:
-            raise TimeoutError(f"Harness not {target_status} after {timeout}s (current: {status})")
-        time.sleep(HARNESS_POLL_INTERVAL)
-
-
 def stream_response(client, harness_arn, session_id, message, model_id, raw=False):
     """Invoke a Harness and stream the response to stdout."""
     response = client.invoke_harness(
@@ -246,6 +224,11 @@ def stream_response(client, harness_arn, session_id, message, model_id, raw=Fals
         for event in response["stream"]:
             if raw:
                 print(json.dumps(event, default=str))
+                # Accumulate in raw mode too, so the guard below can tell a
+                # stream that produced content from one that produced none.
+                delta = event.get("contentBlockDelta", {}).get("delta", {})
+                if "text" in delta:
+                    full_text += delta["text"]
                 continue
 
             if "contentBlockStart" in event:
@@ -261,7 +244,14 @@ def stream_response(client, harness_arn, session_id, message, model_id, raw=Fals
                 print()
             elif "internalServerException" in event:
                 print(f"\n  Error: {event['internalServerException']}")
-    except botocore.exceptions.EventStreamError:
+    # A mid-stream failure is raised out of the iterator, not delivered as an
+    # event: a modeled service error (EventStreamError/ClientError — throttling,
+    # access denied) or a transport error (read timeout, connection reset — a
+    # BotoCoreError). Catching only EventStreamError let a read timeout abort the
+    # demo even after the answer had streamed, with a traceback that named
+    # nothing useful. Re-raise only when nothing arrived.
+    except (BotoCoreError, ClientError) as e:
+        print(f"\n  Stream error: {e}")
         if not full_text:
             raise
 
@@ -284,6 +274,7 @@ def main(args=None):
     mount = args.mount_path.rstrip("/")
     remote_file = f"{mount}/{args.filename}"
     harness_id = None
+    created_role = False
 
     try:
         # ── Step 0: IAM role (with S3 access) ─────────────────────────
@@ -296,6 +287,7 @@ def main(args=None):
             print("  (ensure it can access the S3 Files access point)")
         else:
             role_arn = create_harness_role()
+            created_role = True
             attach_s3_files_policy(ROLE_NAME, args.access_point_arn)
             print("  Waiting for IAM propagation...")
             time.sleep(10)
@@ -384,13 +376,21 @@ def main(args=None):
         print("=" * 60)
 
     finally:
-        if not args.skip_cleanup and harness_id:
+        if not args.skip_cleanup:
             print("\nCleaning up...")
-            try:
-                control.delete_harness(harnessId=harness_id)
-                print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"  Warning: failed to delete harness: {e}")
+            if harness_id:
+                try:
+                    control.delete_harness(harnessId=harness_id)
+                    print(f"  Deleted harness: {harness_id}")
+                except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                    print(f"  Warning: failed to delete harness: {e}")
+            # The role and its two inline policies were left behind on every run,
+            # including successful ones — and the role name is shared by every
+            # sample in this folder, so the leftovers broke the next sample too.
+            # Only delete the role when this run created it; a --role-arn passed
+            # in by the caller belongs to them.
+            if created_role:
+                delete_harness_role()
             print("  Note: the S3 bucket and access point are left intact.")
 
 

--- a/01-features/01-harness/01-advanced-examples/14-s3-filesystem/s3_llm_wiki.py
+++ b/01-features/01-harness/01-advanced-examples/14-s3-filesystem/s3_llm_wiki.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 S3-Backed LLM Wiki (a persistent, compounding markdown wiki)
 
@@ -59,8 +58,8 @@ Usage:
 """
 
 import argparse
+import base64
 import json
-import os
 import re
 import sys
 import time
@@ -68,24 +67,19 @@ import uuid
 from pathlib import Path
 
 import boto3
-import botocore.exceptions
+from botocore.exceptions import BotoCoreError, ClientError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from utils.iam import create_harness_role, ROLE_NAME
 from utils.client import get_agentcore_client, get_agentcore_control_client
-
-REGION = os.getenv("AWS_DEFAULT_REGION")
-
+from utils.harness import poll_harness_status
+from utils.iam import ROLE_NAME, create_harness_role, delete_harness_role
 
 # ── Constants ───────────────────────────────────────────────────────────────
 DEFAULT_MODEL = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_MOUNT_PATH = "/mnt/wiki"
 S3_FILES_POLICY_NAME = "HarnessS3FilesAccess"
 MOUNT_PATH_PATTERN = re.compile(r"^/mnt/[a-zA-Z0-9._-]+/?$")
-
-HARNESS_POLL_INTERVAL = 5
-HARNESS_POLL_TIMEOUT = 180
 
 # Two tiny "raw sources" the agent ingests. In a real wiki these are papers,
 # tickets, docs — here they're short so the demo runs fast.
@@ -112,22 +106,50 @@ parser = argparse.ArgumentParser(
     description="Build a persistent, S3-backed LLM wiki with the harness.",
     formatter_class=argparse.RawDescriptionHelpFormatter,
 )
-parser.add_argument("--access-point-arn", required=True, metavar="ARN",
-                    help="S3 Files access point ARN to mount (arn:aws:s3files:...:access-point/fsap-...)")
-parser.add_argument("--subnet-ids", required=True, nargs="+", metavar="SUBNET",
-                    help="VPC subnet(s) that can reach the access point's mount target (NFS/2049)")
-parser.add_argument("--security-group-ids", required=True, nargs="+", metavar="SG",
-                    help="Security group(s) allowing NFS (2049) to the mount target")
-parser.add_argument("--mount-path", default=DEFAULT_MOUNT_PATH, metavar="PATH",
-                    help=f"Where to mount the wiki inside the VM (default: {DEFAULT_MOUNT_PATH})")
-parser.add_argument("--op", choices=["all", "ingest", "query", "lint"], default="all",
-                    help="Which operation to run (default: all — bootstrap, ingest, query, lint)")
-parser.add_argument("--message", "-m", default="How does the LLM wiki pattern differ from RAG?",
-                    help="Question for the query operation")
-parser.add_argument("--model", default=DEFAULT_MODEL, metavar="MODEL_ID",
-                    help=f"Bedrock model ID (default: {DEFAULT_MODEL})")
-parser.add_argument("--role-arn", default=None, metavar="ARN",
-                    help="Use an existing IAM execution role (must already allow the access point)")
+parser.add_argument(
+    "--access-point-arn",
+    required=True,
+    metavar="ARN",
+    help="S3 Files access point ARN to mount (arn:aws:s3files:...:access-point/fsap-...)",
+)
+parser.add_argument(
+    "--subnet-ids",
+    required=True,
+    nargs="+",
+    metavar="SUBNET",
+    help="VPC subnet(s) that can reach the access point's mount target (NFS/2049)",
+)
+parser.add_argument(
+    "--security-group-ids",
+    required=True,
+    nargs="+",
+    metavar="SG",
+    help="Security group(s) allowing NFS (2049) to the mount target",
+)
+parser.add_argument(
+    "--mount-path",
+    default=DEFAULT_MOUNT_PATH,
+    metavar="PATH",
+    help=f"Where to mount the wiki inside the VM (default: {DEFAULT_MOUNT_PATH})",
+)
+parser.add_argument(
+    "--op",
+    choices=["all", "ingest", "query", "lint"],
+    default="all",
+    help="Which operation to run (default: all — bootstrap, ingest, query, lint)",
+)
+parser.add_argument(
+    "--message", "-m", default="How does the LLM wiki pattern differ from RAG?", help="Question for the query operation"
+)
+parser.add_argument(
+    "--model", default=DEFAULT_MODEL, metavar="MODEL_ID", help=f"Bedrock model ID (default: {DEFAULT_MODEL})"
+)
+parser.add_argument(
+    "--role-arn",
+    default=None,
+    metavar="ARN",
+    help="Use an existing IAM execution role (must already allow the access point)",
+)
 parser.add_argument("--skip-cleanup", action="store_true", help="Keep the harness after the demo")
 parser.add_argument("--raw-events", action="store_true", help="Print raw JSON streaming events")
 
@@ -136,9 +158,12 @@ parser.add_argument("--raw-events", action="store_true", help="Print raw JSON st
 def attach_s3_files_policy(role_name, access_point_arn):
     """Allow the execution role to validate and mount the S3 Files access point.
 
-    * `s3files:GetAccessPoint` on `*` — the runtime validates this at harness
-      create time. Keep it unscoped; a scoped/conditioned form is rejected at
-      create with "Ensure the role has s3files:GetAccessPoint".
+    * `s3files:GetAccessPoint` **and `s3files:ListMountTargets`** on `*` — the
+      runtime validates both while creating the harness, so both must be
+      unscoped. `ListMountTargets` is easy to miss: it takes a file-system ID
+      rather than an access point, and without it CreateHarness accepts the
+      request and then lands in CREATE_FAILED with "Execution role is missing
+      required permissions. Ensure the role has s3files:ListMountTargets".
     * `s3files:ClientMount`/`ClientWrite` — used when the microVM mounts the
       access point; scoped to the file system with an AccessPointArn condition.
     """
@@ -150,7 +175,7 @@ def attach_s3_files_policy(role_name, access_point_arn):
             {
                 "Sid": "S3FilesValidate",
                 "Effect": "Allow",
-                "Action": ["s3files:GetAccessPoint"],
+                "Action": ["s3files:GetAccessPoint", "s3files:ListMountTargets"],
                 "Resource": "*",
             },
             {
@@ -162,26 +187,8 @@ def attach_s3_files_policy(role_name, access_point_arn):
             },
         ],
     }
-    iam.put_role_policy(RoleName=role_name, PolicyName=S3_FILES_POLICY_NAME,
-                        PolicyDocument=json.dumps(policy))
+    iam.put_role_policy(RoleName=role_name, PolicyName=S3_FILES_POLICY_NAME, PolicyDocument=json.dumps(policy))
     print(f"  Attached S3 Files access policy: {S3_FILES_POLICY_NAME}")
-
-
-def poll_harness_status(control, harness_id, target_status="READY", timeout=HARNESS_POLL_TIMEOUT):
-    """Poll until a Harness reaches the target status or times out."""
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = control.get_harness(harnessId=harness_id)
-        status = resp["harness"]["status"]
-        print(f"  Harness status: {status}")
-        if status == target_status:
-            return resp
-        if status in ("FAILED", "DELETE_FAILED"):
-            reason = resp["harness"].get("failureReason", "")
-            raise RuntimeError(f"Harness entered {status}. {reason}")
-        if time.monotonic() > deadline:
-            raise TimeoutError(f"Harness not {target_status} after {timeout}s (current: {status})")
-        time.sleep(HARNESS_POLL_INTERVAL)
 
 
 def stream_turn(client, harness_arn, message, model_id, mount, raw=False):
@@ -207,6 +214,11 @@ def stream_turn(client, harness_arn, message, model_id, mount, raw=False):
         for event in response["stream"]:
             if raw:
                 print(json.dumps(event, default=str))
+                # Accumulate in raw mode too, so the guard below can tell a
+                # stream that produced content from one that produced none.
+                delta = event.get("contentBlockDelta", {}).get("delta", {})
+                if "text" in delta:
+                    full_text += delta["text"]
                 continue
             if "contentBlockStart" in event:
                 start = event["contentBlockStart"].get("start", {})
@@ -221,7 +233,15 @@ def stream_turn(client, harness_arn, message, model_id, mount, raw=False):
                 print()
             elif "internalServerException" in event:
                 print(f"\n  Error: {event['internalServerException']}")
-    except botocore.exceptions.EventStreamError:
+    # A mid-stream failure is raised out of the iterator, not delivered as an
+    # event: a modeled service error (EventStreamError/ClientError — throttling,
+    # access denied) or a transport error (read timeout, connection reset — a
+    # BotoCoreError). Wiki turns are long-running filesystem work, so the quiet
+    # stretches that trigger a read timeout are routine here. Catching only
+    # EventStreamError let those abort the run and lose the answer already in
+    # hand, with a traceback that named nothing useful.
+    except (BotoCoreError, ClientError) as e:
+        print(f"\n  Stream error: {e}")
         if not full_text:
             raise
     return full_text
@@ -232,23 +252,52 @@ def seed_sources(client, harness_arn, mount):
     session_id = str(uuid.uuid4()).upper()
 
     def run(cmd):
+        """Run one shell command on the VM, raising if it did not succeed.
+
+        The command stream reports the outcome two ways that both have to be
+        read: `contentStop.exitCode` for a command that ran and failed, and a
+        modeled error event (accessDenied/validation/...) for one that never
+        ran at all. Printing only `stderr` and returning caught neither, so a
+        mount that was not writable — the failure this sample is most likely to
+        hit — still ended with "Seeded 2 source(s)" and the wiki steps then
+        worked on an empty directory.
+        """
         resp = client.invoke_agent_runtime_command(
             agentRuntimeArn=harness_arn, runtimeSessionId=session_id, body={"command": cmd}
         )
+        exit_code = None
+        stderr = ""
         for event in resp["stream"]:
             if "chunk" in event and "contentDelta" in event["chunk"]:
                 d = event["chunk"]["contentDelta"]
                 if "stderr" in d:
+                    stderr += d["stderr"]
                     print(d["stderr"], end="")
+            elif "chunk" in event and "contentStop" in event["chunk"]:
+                exit_code = event["chunk"]["contentStop"].get("exitCode")
+            else:
+                # Any other member of this event stream is one of the modeled
+                # exceptions; none of them carry an exitCode.
+                for name, payload in event.items():
+                    if name != "chunk":
+                        raise RuntimeError(f"Command failed ({name}): {payload.get('message', payload)}")
+        if exit_code:
+            raise RuntimeError(f"Command exited {exit_code}: {cmd}\n{stderr.strip()}")
+        if exit_code is None:
+            # No contentStop at all: the stream ended without ever reporting an
+            # outcome, so there is nothing that says the write landed. Treating
+            # that as success is the same false pass as ignoring a nonzero exit.
+            raise RuntimeError(f"Command returned no exit status: {cmd}\n{stderr.strip()}")
 
     run(f"mkdir -p {mount}/sources {mount}/pages")
     for name, body in SOURCES.items():
         # base64 to avoid any shell-quoting issues with the markdown body
-        import base64
         b64 = base64.b64encode(body.encode()).decode()
         run(f"echo {b64} | base64 -d > {mount}/sources/{name}")
     # Bootstrap schema/index/log only if not present (idempotent for re-runs)
-    run(f"test -f {mount}/AGENTS.md || printf '# Wiki Schema\\n\\nsources/ raw inputs. pages/ LLM pages. index.md catalog. log.md history.\\n' > {mount}/AGENTS.md")
+    run(
+        f"test -f {mount}/AGENTS.md || printf '# Wiki Schema\\n\\nsources/ raw inputs. pages/ LLM pages. index.md catalog. log.md history.\\n' > {mount}/AGENTS.md"
+    )
     run(f"test -f {mount}/index.md || printf '# Index\\n' > {mount}/index.md")
     run(f"test -f {mount}/log.md || printf '# Log\\n' > {mount}/log.md")
     print(f"  Seeded {len(SOURCES)} source(s) and bootstrapped schema under {mount}")
@@ -266,6 +315,7 @@ def main(args=None):
     client = get_agentcore_client()
     mount = args.mount_path.rstrip("/")
     harness_id = None
+    created_role = False
 
     try:
         # ── Step 0: IAM role (with S3 access) ─────────────────────────
@@ -278,6 +328,7 @@ def main(args=None):
             print("  (ensure it can access the S3 Files access point)")
         else:
             role_arn = create_harness_role()
+            created_role = True
             attach_s3_files_policy(ROLE_NAME, args.access_point_arn)
             print("  Waiting for IAM propagation...")
             time.sleep(10)
@@ -324,12 +375,15 @@ def main(args=None):
             print("Step 3: INGEST — integrate sources into the wiki")
             print("=" * 60 + "\n")
             stream_turn(
-                client, harness_arn,
+                client,
+                harness_arn,
                 f"Ingest every file in {mount}/sources that isn't represented yet. For each, create or "
                 f"update concise pages under {mount}/pages (concept/entity pages), cross-link with "
                 f"[[links]], update {mount}/index.md, and append a line to {mount}/log.md. "
                 "Summarize what you ingested and which pages you touched.",
-                args.model, mount, raw=args.raw_events,
+                args.model,
+                mount,
+                raw=args.raw_events,
             )
             time.sleep(5)
 
@@ -340,11 +394,14 @@ def main(args=None):
             print("=" * 60)
             print(f"  Question: {args.message}\n")
             stream_turn(
-                client, harness_arn,
-                f"Using only the wiki under {mount}/pages, answer: \"{args.message}\". Cite the wiki "
+                client,
+                harness_arn,
+                f'Using only the wiki under {mount}/pages, answer: "{args.message}". Cite the wiki '
                 f"pages you used. Then file your answer as a new page under {mount}/pages and link it "
                 f"from {mount}/index.md so the exploration compounds.",
-                args.model, mount, raw=args.raw_events,
+                args.model,
+                mount,
+                raw=args.raw_events,
             )
             time.sleep(5)
 
@@ -354,11 +411,14 @@ def main(args=None):
             print("Step 5: LINT — check the wiki for issues (fresh session)")
             print("=" * 60 + "\n")
             stream_turn(
-                client, harness_arn,
+                client,
+                harness_arn,
                 f"Lint the wiki under {mount}: list any contradictions, stale claims, "
                 f"orphan pages (not linked from {mount}/index.md), or broken [[links]]. Report findings; "
                 "fix trivial issues directly.",
-                args.model, mount, raw=args.raw_events,
+                args.model,
+                mount,
+                raw=args.raw_events,
             )
 
         print("\n" + "=" * 60)
@@ -366,13 +426,21 @@ def main(args=None):
         print("=" * 60)
 
     finally:
-        if not args.skip_cleanup and harness_id:
+        if not args.skip_cleanup:
             print("\nCleaning up...")
-            try:
-                control.delete_harness(harnessId=harness_id)
-                print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
-                print(f"  Warning: failed to delete harness: {e}")
+            if harness_id:
+                try:
+                    control.delete_harness(harnessId=harness_id)
+                    print(f"  Deleted harness: {harness_id}")
+                except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                    print(f"  Warning: failed to delete harness: {e}")
+            # The role and its two inline policies were left behind on every run,
+            # including successful ones — and the role name is shared by every
+            # sample in this folder, so the leftovers broke the next sample too.
+            # Only delete the role when this run created it; a --role-arn passed
+            # in by the caller belongs to them.
+            if created_role:
+                delete_harness_role()
             print("  Note: the S3 bucket, access point, AND the wiki it holds are left intact.")
 
 


### PR DESCRIPTION
## What this fixes

`14-s3-filesystem` could not create a harness at all. The execution-role policy
omitted `s3files:ListMountTargets`, which the runtime validates while creating the
harness — `CreateHarness` accepts the request, then the harness lands in
`CREATE_FAILED` with *"Execution role is missing required permissions. Ensure the
role has s3files:ListMountTargets"*. It is easy to miss because it authorizes
against a **file-system ID** rather than an access point, so it has to stay
unscoped alongside `GetAccessPoint` while the mount permissions stay scoped.

Fixing that surfaced the rest: a leaked execution role, and several guards that
reported success when the underlying operation had failed.

## Correctness

1. **Missing `s3files:ListMountTargets`** — added to the unscoped validate
   statement in both scripts. Without it the sample never reaches `READY`.
2. **Leaked execution role.** `HarnessExecutionRole` and its two inline policies
   survived every run, including successful ones. The role name is shared by every
   sample in this folder, so the leftovers broke the *next* sample too. Now
   deleted only when the run created it — a `--role-arn` you pass in is yours and
   is left alone.
3. **A failed VM command reported success.** `seed_sources()` printed `stderr` and
   returned, ignoring `contentStop.exitCode`. A mount that wasn't writable — the
   most likely failure in this sample — still printed "Seeded 2 source(s)" and the
   wiki steps then worked on an empty directory.
4. **A command that never ran also reported success.** The modeled error events
   (`accessDenied`, `validationException`, …) carry no `exitCode`, so they slipped
   through the same check. Now raised with the event name and message.
5. **No `contentStop` at all reported success.** A stream that ended without ever
   reporting an outcome says nothing about whether the write landed; treating that
   as a pass is the same false pass as ignoring a nonzero exit.
6. **A mid-stream read timeout discarded a complete answer.** Only
   `EventStreamError` was caught, but a transport-level read timeout arrives as a
   `BotoCoreError`. Wiki turns are long-running filesystem work, so the quiet
   stretches that trigger a read timeout are routine. Both scripts now catch
   `BotoCoreError`/`ClientError` and re-raise only if nothing had streamed yet.
7. **`--raw-events` bypassed that guard** by `continue`-ing before accumulating,
   so the "did anything arrive?" check always saw an empty buffer and aborted a
   run that had in fact completed.

## Docs

8. **Bucket versioning is a hard requirement.** `CreateFileSystem` rejects an
   unversioned bucket with *"Your bucket must have versioning enabled to create a
   file system."* — undocumented, and not covered by `acceptBucketWarning`.
9. **The IAM scope claim was wrong.** The README said the role "only needs access
   to the single access point"; two actions must be on `"*"`, and it now says why.
10. **VPC-mode create time.** Roughly 2–3 minutes of `CREATING`, so the wait
    doesn't read as a hang.
11. **Undocumented flags.** `--model`, `--op`, `--message`, `--filename`,
    `--role-arn`, `--skip-cleanup`, `--raw-events` were all absent from the README.
12. **Credentials/model-access prerequisite** added, and the role-cleanup
    behaviour stated where the reader will look for it.

## Testing

Live in `us-west-2` on a **fresh account footprint** (nothing pre-existing
reused), against real S3 Files infrastructure created for the run and torn down
after:

- `s3_filesystem.py` — session A writes under the mount, session B (a new microVM)
  reads it back. Verified the file is in S3, not on the VM disk.
- `s3_llm_wiki.py --op ingest --raw-events` — 651 stream events / 549 text deltas
  / 0 errors, with the agent creating and cross-linking wiki pages on the mount.
- Role cleanup confirmed by `GetRole` returning `NoSuchEntity` afterwards.
- Failure paths exercised deliberately: the missing-permission `CREATE_FAILED`
  reproduced before the fix and gone after; a non-writable mount now fails loudly
  at the seed step instead of printing "Seeded 2 source(s)".
- 20 offline assertions over both scripts × `raw=True/False` covering the stream
  and command-guard paths. Every `raw=True` case fails on the pre-fix code.
- `ruff check` and `ruff format --check` clean on both changed files.
