### PR TITLE
fix(harness/01-travel-agent): unblock the browser tool, redesign the code-interpreter step, handle stream errors

### DIFF
--- a/01-features/01-harness/02-use-cases/01-travel-agent/README.md
+++ b/01-features/01-harness/02-use-cases/01-travel-agent/README.md
@@ -35,7 +35,8 @@ travel_agent.py
 │
 └── Part 6: invoke_harness (MCP search) → invoke_harness (code_interpreter)
                ├─ remote_mcp (Exa) → tourism JSON data
-               └─ agentcore_code_interpreter → matplotlib chart
+               └─ agentcore_code_interpreter → sandboxed analysis (text)
+                     └─ VM renders /tmp/tourism_chart.html (HTML/CSS)
 ```
 
 ## Sample Prompts
@@ -74,11 +75,13 @@ Navigate to **CloudWatch → X-Ray → Traces** to see the full agent loop break
 
 **memory provisioning**: memory takes 3-5 minutes to become `ACTIVE`. The script polls with a 10-second interval. Use `--skip-memory` to bypass this during quick testing.
 
-**Same session, different tools**: Parts 6 uses two consecutive `invoke_harness` calls with the same `session_id`. The VM state (files) persists between calls, so the chart generator can read the JSON file from the search step.
+**Same session, different tools**: Part 6 uses two consecutive `invoke_harness` calls with the same `session_id`. The microVM's filesystem persists between calls, so the JSON that the search step writes to `/tmp` is still there for the analysis step to read.
+
+**The code interpreter runs in its own sandbox**: `agentcore_code_interpreter` executes in a *separate* environment from the harness microVM — it cannot read the VM's `/tmp`, and any file it writes there does not appear on the VM. Only the text it prints crosses back. That is why Part 6 passes the data to the sandbox *inline* and has it return the analysis as text, then renders the chart as a self-contained HTML/CSS page on the VM (the same way Parts 2 and 5 produce HTML). Trying to have the sandbox read `/tmp/tourism_data.json` or save a `.png` to the VM would silently produce nothing.
 
 **HTML output handling**: Instead of rendering in a notebook iframe, the script saves HTML files to `/tmp/` on your local machine. Open with `open /tmp/travel_guide.html` (macOS) or `xdg-open` (Linux).
 
-**Browser tool limitations**: The browser tool browses real websites. Results depend on network accessibility and site availability at invocation time.
+**Browser tool limitations**: The browser tool browses real websites, so it needs both the automation-stream permissions (see Troubleshooting) and the target site to be reachable at invocation time. If the permissions are missing the agent silently invents data, so treat a suspiciously fast "success" with caution.
 
 ## Troubleshooting
 
@@ -88,8 +91,8 @@ Navigate to **CloudWatch → X-Ray → Traces** to see the full agent loop break
 ### Issue: Part 4 takes too long
 **Solution**: memory provisioning takes 3-5 minutes. Use `--skip-memory` to skip the memory demo entirely.
 
-### Issue: Browser tool returns no data
-**Solution**: The `agentcore_browser` tool requires internet access from the microVM. If your AWS account uses restricted VPC configurations, outbound browsing may be blocked.
+### Issue: Browser tool returns no data (or made-up data)
+**Solution**: The execution role must allow `bedrock-agentcore:ConnectBrowserAutomationStream` and `bedrock-agentcore:ConnectBrowserLiveViewStream` on the browser resource (`arn:aws:bedrock-agentcore:*:aws:browser/aws.browser.v1` for the built-in browser, which is owned by the `aws` account — not yours). Without them the tool's CDP connection is rejected with `403 Forbidden … not authorized to access automation stream`, and the agent quietly falls back to guessing, so the run looks like it succeeded but the weather is invented. [`utils/iam.py`](../../utils/iam.py) grants these; if you supply your own role, add them there too.
 
 ## AgentCore CLI
 

--- a/01-features/01-harness/02-use-cases/01-travel-agent/travel_agent.py
+++ b/01-features/01-harness/02-use-cases/01-travel-agent/travel_agent.py
@@ -7,7 +7,7 @@ A complete travel guide agent demonstrating all core Harness features:
   Part 3: Save HTML output to file (replaces notebook iframe rendering)
   Part 4: Add AgentCore Memory — multi-turn conversation with persistence
   Part 5: Browser tool — live weather data from real websites
-  Part 6: MCP (Exa search) + Code Interpreter — data analysis & chart generation
+  Part 6: MCP (Exa search) + Code Interpreter — sandboxed analysis, HTML chart
 
 Usage:
     python travel_agent.py
@@ -25,13 +25,13 @@ Prerequisites:
 """
 
 import argparse
-import base64
 import sys
 import time
 import uuid
 from pathlib import Path
 
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -65,8 +65,27 @@ print(f"Account: {account_id}")
 # ── Helper ────────────────────────────────────────────────────────────────────
 
 
+# The three error members the InvokeHarness event stream can carry (per the
+# boto3 model). The original loop checked only internalServerException, so a
+# validationException (bad request) or runtimeClientError (e.g. the model hit its
+# token limit mid-turn) streamed by silently and the run carried on as if it had
+# succeeded — producing empty or fabricated output downstream. Errors on the call
+# itself (throttling, service unavailable) surface as ClientError instead and are
+# caught separately below.
+STREAM_ERROR_KEYS = (
+    "internalServerException",
+    "validationException",
+    "runtimeClientError",
+)
+
+
 def stream_response(harness_arn, session_id, message, tools=None):
-    """Invoke harness and stream the response. Returns accumulated text."""
+    """Invoke harness and stream the response. Returns accumulated text.
+
+    Raises RuntimeError if the stream reports an error event, and lets a
+    BotoCoreError/ClientError from the call itself propagate, so a failed turn
+    stops the demo loudly instead of leaving a later step to act on nothing.
+    """
     kwargs = {
         "harnessArn": harness_arn,
         "runtimeSessionId": session_id,
@@ -76,29 +95,40 @@ def stream_response(harness_arn, session_id, message, tools=None):
     if tools:
         kwargs["tools"] = tools
 
-    response = client.invoke_harness(**kwargs)
-    full_text = ""
-    for event in response["stream"]:
-        if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
-            if "toolUse" in start:
-                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-        elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                print(delta["text"], end="", flush=True)
-                full_text += delta["text"]
-        elif "messageStop" in event:
-            print()
-        elif "internalServerException" in event:
-            print(f"\nError: {event['internalServerException']}")
+    try:
+        response = client.invoke_harness(**kwargs)
+        full_text = ""
+        for event in response["stream"]:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+            elif "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    print(delta["text"], end="", flush=True)
+                    full_text += delta["text"]
+            elif "messageStop" in event:
+                print()
+            else:
+                err = next((event[k] for k in STREAM_ERROR_KEYS if k in event), None)
+                if err is not None:
+                    raise RuntimeError(f"Harness stream error: {err}")
+    except (BotoCoreError, ClientError) as e:
+        raise RuntimeError(f"invoke_harness failed: {e}") from e
     return full_text
 
 
 def run_command(harness_arn, session_id, cmd):
-    """Run a shell command on the agent's remote microVM."""
+    """Run a shell command on the agent's remote microVM.
+
+    Returns (stdout, exit_code). Earlier this dropped the exit code on the floor,
+    so a command that failed looked identical to one that succeeded; callers can
+    now check the code and stop treating a failed step as a pass.
+    """
     print(f"$ {cmd}")
     output = ""
+    exit_code = None
     resp = client.invoke_agent_runtime_command(
         agentRuntimeArn=harness_arn,
         runtimeSessionId=session_id,
@@ -115,14 +145,21 @@ def run_command(harness_arn, session_id, cmd):
                 if "stderr" in d:
                     print(d["stderr"], end="", flush=True)
             elif "contentStop" in chunk:
-                print(f"\n[exit: {chunk['contentStop']['exitCode']}]")
+                exit_code = chunk["contentStop"].get("exitCode")
+                print(f"\n[exit: {exit_code}]")
     print()
-    return output
+    return output, exit_code
 
 
 def fetch_file(harness_arn, session_id, remote_path):
-    """Fetch a text file from the agent's VM."""
+    """Fetch a text file from the agent's VM. Returns "" if it is missing.
+
+    Reads the exit code of `cat` rather than papering over a missing file with a
+    shell fallback, so the caller can tell "empty file" from "no file" and report
+    which one actually happened.
+    """
     content = ""
+    exit_code = None
     resp = client.invoke_agent_runtime_command(
         agentRuntimeArn=harness_arn,
         runtimeSessionId=session_id,
@@ -133,6 +170,10 @@ def fetch_file(harness_arn, session_id, remote_path):
             chunk = event["chunk"]
             if "contentDelta" in chunk and "stdout" in chunk["contentDelta"]:
                 content += chunk["contentDelta"]["stdout"]
+            elif "contentStop" in chunk:
+                exit_code = chunk["contentStop"].get("exitCode")
+    if exit_code not in (0, None):
+        return ""
     return content
 
 
@@ -311,47 +352,52 @@ try:
         ],
     )
 
-    print("\n--- Step 2: Generate chart with Code Interpreter ---")
+    print("\n--- Step 2: Analyse with Code Interpreter, render chart on the VM ---")
+    # The code_interpreter tool runs in its OWN sandbox: it cannot read the VM's
+    # /tmp, and anything it writes there never appears on the VM. So the sandbox
+    # does what it is uniquely good for — running Python on data passed inline and
+    # returning *text* (the only thing that crosses the boundary) — and the chart
+    # is rendered on the VM as a self-contained HTML page, the same way Parts 2
+    # and 5 produce their HTML. Nothing large (like a PNG's base64) is pushed back
+    # through the model, which would overflow the turn's token limit.
     stream_response(
         harness_arn,
         research_session,
-        "Read the tourism data from /tmp/tourism_data.json and create a visualization "
-        "using matplotlib. Make a bar chart or line chart showing the most interesting trends. "
-        "Use a dark theme with vibrant colors. "
-        "Save the chart as /tmp/amsterdam_tourism.png and a summary as /tmp/tourism_report.md.",
+        "The code_interpreter tool runs in a SEPARATE sandbox with its own filesystem: "
+        "it cannot read this VM's files, and any file it writes there does not appear "
+        "on this VM — only the text it prints comes back. So do NOT ask it to open "
+        "/tmp/tourism_data.json or to save an image.\n\n"
+        "1. Read /tmp/tourism_data.json from THIS VM.\n"
+        "2. Call code_interpreter with the numbers EMBEDDED INLINE in the Python source. "
+        "Compute the interesting trends (year-over-year change, peak/trough years, "
+        "recovery vs the earliest year) and print the results as plain text.\n"
+        "3. Back on THIS VM, using the sandbox's numbers, write two files:\n"
+        "   - /tmp/tourism_report.md — a short markdown summary of the analysis.\n"
+        "   - /tmp/tourism_chart.html — a single self-contained dark-themed page that "
+        "draws the visitors-by-year bar chart with pure HTML/CSS (no matplotlib, no "
+        "external scripts or images).\n"
+        "Confirm both files exist with ls -la.",
         tools=[{"type": "agentcore_code_interpreter", "name": "code_interpreter"}],
     )
 
-    report = fetch_file(
-        harness_arn,
-        research_session,
-        "/tmp/tourism_report.md 2>/dev/null || echo 'No report'",  # nosec B108
-    )
-    print("\nTourism report:")
-    print(report)
-
-    # Fetch and save the chart
-    b64_data = b""
-    resp = client.invoke_agent_runtime_command(
-        agentRuntimeArn=harness_arn,
-        runtimeSessionId=research_session,
-        body={"command": "base64 /tmp/amsterdam_tourism.png 2>/dev/null || echo 'NO_CHART'"},
-    )
-    for event in resp["stream"]:
-        if "chunk" in event:
-            chunk = event["chunk"]
-            if "contentDelta" in chunk and "stdout" in chunk["contentDelta"]:
-                b64_data += chunk["contentDelta"]["stdout"].encode()
-
-    chart_str = b64_data.decode().strip()
-    if chart_str and chart_str != "NO_CHART":
-        chart_bytes = base64.b64decode(chart_str.replace("\n", ""))
-        chart_path = "/tmp/amsterdam_tourism.png"  # nosec B108
-        with open(chart_path, "wb") as f:
-            f.write(chart_bytes)
-        print(f"✅ Chart saved to {chart_path} ({len(chart_bytes):,} bytes)")
+    report = fetch_file(harness_arn, research_session, "/tmp/tourism_report.md")  # nosec B108
+    if report:
+        print("\nTourism report:")
+        print(report)
     else:
-        print("No chart found — agent may have saved in a different format")
+        print("⚠️  No tourism_report.md generated")
+
+    # Save the chart the same way Parts 3 and 5 save their HTML — the artifact is
+    # already a complete page on the VM, so it just needs fetching, not decoding.
+    chart_html = fetch_file(harness_arn, research_session, "/tmp/tourism_chart.html")  # nosec B108
+    if chart_html:
+        chart_path = "/tmp/amsterdam_tourism.html"  # nosec B108
+        with open(chart_path, "w") as f:
+            f.write(chart_html)
+        print(f"✅ Chart saved to {chart_path} ({len(chart_html):,} chars)")
+        print(f"   Open with: open {chart_path}")
+    else:
+        print("⚠️  No chart generated — listing what the agent left on the VM:")
         run_command(
             harness_arn,
             research_session,

--- a/01-features/01-harness/02-use-cases/01-travel-agent/travel_chat/server.py
+++ b/01-features/01-harness/02-use-cases/01-travel-agent/travel_chat/server.py
@@ -32,8 +32,33 @@ from sse_starlette.sse import EventSourceResponse
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-HARNESS_ARN = os.environ["HARNESS_ARN"]
+# Fail with a usable message instead of a bare KeyError traceback on import when
+# the one required piece of configuration is missing.
+HARNESS_ARN = os.getenv("HARNESS_ARN")
+if not HARNESS_ARN:
+    raise SystemExit(
+        "HARNESS_ARN is not set. Create a harness first (e.g. run travel_agent.py), "
+        "then:\n"
+        '  export HARNESS_ARN="arn:aws:bedrock-agentcore:REGION:ACCOUNT:harness/HARNESS_ID"\n'
+        "  python server.py"
+    )
+
 REGION = os.getenv("AWS_DEFAULT_REGION")
+
+# Match the model the CLI script uses. `model` is optional on InvokeHarness, but
+# passing it explicitly keeps the chat server and travel_agent.py on the same
+# model instead of relying on a server-side default that could differ or change.
+MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+# The three error members the InvokeHarness stream can carry (per the boto3
+# model). They arrive as events rather than raising, so they are checked
+# explicitly while iterating; a failed call raises ClientError and is caught by
+# the surrounding try/except.
+STREAM_ERROR_KEYS = (
+    "internalServerException",
+    "validationException",
+    "runtimeClientError",
+)
 
 
 def make_client():
@@ -82,6 +107,7 @@ async def chat(req: dict):
                 harnessArn=HARNESS_ARN,
                 runtimeSessionId=sid,
                 messages=sessions[sid],
+                model={"bedrockModelConfig": {"modelId": MODEL_ID}},
             )
             full = ""
             for event in resp["stream"]:
@@ -90,11 +116,19 @@ async def chat(req: dict):
                     if txt:
                         full += txt
                         yield {"data": json.dumps({"type": "text_delta", "text": txt})}
+                    continue
+                # The stream carries errors as their own event members; without
+                # this the model turn could fail mid-way (bad request, or the
+                # model hitting its token limit) and the client would just see
+                # the stream end with no error and a truncated or empty reply.
+                err = next((event[k] for k in STREAM_ERROR_KEYS if k in event), None)
+                if err is not None:
+                    raise RuntimeError(str(err))
             if full:
                 sessions[sid].append({"role": "assistant", "content": [{"text": full}]})
             yield {"data": json.dumps({"type": "done"})}
         except Exception as e:
-            logger.error(str(e), exc_info=True)
+            logger.exception("invoke_harness stream failed")
             yield {"data": json.dumps({"type": "error", "message": str(e)})}
 
     return EventSourceResponse(stream())

--- a/01-features/01-harness/utils/iam.py
+++ b/01-features/01-harness/utils/iam.py
@@ -121,6 +121,28 @@ PERMISSIONS_POLICY = {
             "Resource": "*",
         },
         {
+            "Sid": "BrowserStreams",
+            "Effect": "Allow",
+            # Starting a browser session is not enough to drive it: the
+            # agentcore_browser tool opens a CDP WebSocket to the automation
+            # stream, and without these two actions that connection is refused
+            # with "403 Forbidden … not authorized to access automation stream".
+            # The agent then silently falls back to guessing, so the browser
+            # demo appears to "work" while returning fabricated data.
+            "Action": [
+                "bedrock-agentcore:ConnectBrowserAutomationStream",
+                "bedrock-agentcore:ConnectBrowserLiveViewStream",
+            ],
+            # The built-in browser is owned by the `aws` account (verified via
+            # `list-browsers --type SYSTEM`), not the caller's, so an ARN built
+            # from this account's ID would never match. The second entry covers a
+            # custom browser you create in your own account.
+            "Resource": [
+                "arn:aws:bedrock-agentcore:*:aws:browser/aws.browser.v1",
+                "arn:aws:bedrock-agentcore:*:*:browser-custom/*",
+            ],
+        },
+        {
             "Sid": "GetAgentCoreApiKeys",
             "Effect": "Allow",
             "Action": ["bedrock-agentcore:GetResourceApiKey"],


### PR DESCRIPTION
## What this fixes

Two of the six parts in the Travel Guide use case *look* like they work but silently don't,
plus some error-handling gaps. Every change below was verified with a full 6-part live run on
a fresh execution role in a real AWS account, ending in clean teardown.

### Part 5 (browser) — silently returns fabricated data

The `agentcore_browser` tool opens a CDP WebSocket to the browser automation stream, but the
execution role didn't allow it, so the connection was rejected:

```
BrowserType.connect_over_cdp: WebSocket error:
wss://.../browser-streams/aws.browser.v1/sessions/.../automation 403 Forbidden
User is not authorized to access automation stream
```

The agent then quietly fell back to guessing — a run in **August** produced *December*
weather. Nothing in the output said the browser had failed.

Fix: add `bedrock-agentcore:ConnectBrowserAutomationStream` and
`ConnectBrowserLiveViewStream` to `utils/iam.py`, scoped to the browser resource. The
built-in browser is owned by the **`aws`** account
(`arn:aws:bedrock-agentcore:*:aws:browser/aws.browser.v1`, confirmed via
`list-browsers --type SYSTEM`), not the caller's, so an ARN built from the caller's account
ID would never match. Action names were verified with `accessanalyzer validate-policy`; the
full policy returns zero Access Analyzer `ERROR`/`SECURITY_WARNING` findings.

### Part 6 (code interpreter) — structurally impossible as written

The code interpreter runs in a **separate sandbox** whose filesystem is isolated from the
harness microVM, in both directions (verified: the sandbox gets `[Errno 2] No such file or
directory` for a VM file, and a marker the sandbox writes is not visible from the VM). The
original code asked the sandbox to read `/tmp/tourism_data.json` from the VM and write a
`.png` back to it — neither crosses the boundary, so the chart/report step always failed,
papered over by `|| echo 'No report'` and `|| echo 'NO_CHART'`.

Rendering on the VM instead isn't possible as written either — the VM has no matplotlib and
no pip/uv — and bridging a PNG's base64 back through the model overflows the turn's token
limit (`runtimeClientError: Model stopped generating due to maximum token limit`).

Redesign: the sandbox does the **analysis as text**, with the data passed inline (text is the
only thing that crosses the boundary), and the VM renders a **self-contained HTML/CSS chart**
— exactly how Parts 2, 3 and 5 already emit HTML. Live result: a 13,137-char
`amsterdam_tourism.html` with real figures and zero external dependencies.

### Error handling and robustness

- **`stream_response` (and the chat server's loop) only handled `internalServerException`.**
  `validationException` and `runtimeClientError` streamed by silently, so a failed turn
  looked like a success and a later step acted on empty output. Now all three of the stream's
  error members are checked, and `BotoCoreError`/`ClientError` from the call itself is wrapped
  — a failed turn stops the demo loudly.
- **`run_command` / `fetch_file` discarded the shell `exitCode`,** so a command that failed
  was indistinguishable from one that succeeded. They now surface it, and `fetch_file` returns
  `""` on a missing file instead of relying on a shell fallback.
- **`travel_chat/server.py`**: `os.environ["HARNESS_ARN"]` raised a bare `KeyError` at import
  when unset — now a clear `SystemExit` with setup guidance (empty string handled too). Added
  the omitted `model=` so the chat server and `travel_agent.py` use the same model rather than
  a server-side default that could differ. Fixed the two pre-existing ruff findings the file
  carried (`EXE001` shebang-without-exec-bit, `G201` `exc_info=True` → `logger.exception`),
  which CI flags once the file is touched; both are behaviour-preserving.

### README

Corrected the browser troubleshooting entry (it blamed VPC/internet reachability; the real
cause is the IAM permission), corrected the "same session, different tools" note (it implied
the sandbox shares the VM's filesystem), added a sandbox-isolation Key Concept, and updated
the architecture diagram to match the new Part 6.

## User experience

**Before**: Part 5 prints a confident weather forecast that is invented — wrong season, no
indication anything failed. Part 6 prints `No report` / `NO_CHART` and produces no chart.
An `invoke_harness` turn that fails mid-stream carries on as a success. Starting the chat
server without `HARNESS_ARN` gives a bare `KeyError` traceback on import.

**After**: Part 5 reaches a real weather site and returns real temperatures. Part 6 produces
a real data-driven HTML/CSS chart plus a markdown report. A failed turn raises with the cause
named. The chat server exits with a message telling you what to set.

## Testing

- Full live run of all 6 parts on a fresh execution role; clean teardown (harness, memory and
  role all deleted, account back to baseline).
- Part 5 reached the live site, 9 browser tool calls, **0×403**, concrete temperatures.
- Part 6 produced a self-contained HTML/CSS chart (0 external dependencies) plus the report.
- `ruff check` and `ruff format --check` clean on all three Python files, run the same way CI
  runs them, with the repo's `pyproject.toml`.
- Verified against the current `main` tip: the four files are untouched upstream, and the
  change applies and lints clean on a pristine checkout.

## Note on the shared file

`utils/iam.py` is shared by the samples in `01-features/01-harness`. The addition is
Allow-only and scoped to browser ARNs, and `01-travel-agent` is the only sample in the folder
that uses `agentcore_browser` — so it is a no-op for the others.

