### PR TITLE
fix: remove hijacked strands-agents.readthedocs.io doc link

### DIFF
--- a/04-infrastructure-as-code/terraform/basic-runtime/README.md
+++ b/04-infrastructure-as-code/terraform/basic-runtime/README.md
@@ -391,7 +391,7 @@ For current pricing information, please refer to:
 
 - [Terraform AWS Provider Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 - [AWS Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html)
-- [Strands Agents Documentation](https://strands-agents.readthedocs.io/)
+- [Strands Agents Documentation](https://strandsagents.com/)
 - [AgentCore Samples Repository](https://github.com/aws-samples/amazon-bedrock-agentcore-samples)
 
 ## 🤝 Contributing


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

- Changes the "Strands Agents Documentation" link in `04-infrastructure-as-code/terraform/basic-runtime/README.md`
- From the unclaimed/hijacked domain `strands-agents.readthedocs.io` to the official `https://strandsagents.com/`
- An external researcher hijacked the unclaimed domain and hosted proof-of-concept content (broken-link-hijacking / supply-chain risk)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).