### PR TITLE
fix(harness/02-webapp-visual-testing): save truncated screenshots as failures, not successes

### DIFF
--- a/01-features/01-harness/02-use-cases/02-webapp-visual-testing/README.md
+++ b/01-features/01-harness/02-use-cases/02-webapp-visual-testing/README.md
@@ -42,8 +42,8 @@ webapp_visual_testing.py
 ├── Part 3: invoke_harness → agent writes /tmp/test.mjs
 │              └─ Puppeteer: launch chromium, screenshots, todos, checkboxes
 │
-└── Part 4: ExecuteCommand → base64 screenshots → decode → save locally
-               └─ /tmp/screenshot_1.png, _2.png, _3.png
+└── Part 4: ExecuteCommand → base64 screenshots → verify size+MD5 → save locally
+               └─ /tmp/webapp_screenshots/screenshot_1.png, _2.png, _3.png
 ```
 
 ## Sample Prompts
@@ -66,7 +66,7 @@ webapp_visual_testing.py
 
 **Agent-written tests**: Instead of writing test scripts yourself, you describe the test steps in natural language. The agent generates the Puppeteer script, runs it, and handles errors.
 
-**Screenshot transfer**: Screenshots are binary files on the agent's VM. Use `base64` + `invoke_agent_runtime_command` to transfer them to your local machine.
+**Screenshot transfer**: Screenshots are binary files on the agent's VM. Use `base64` + `invoke_agent_runtime_command` to transfer them to your local machine — and **verify what arrives**. The command stream has been observed delivering a short payload for a ~500 KB file intermittently, with no error event and a zero exit code, so the script reads the file's size and MD5 on the VM first and retries a transfer that does not match. A truncated PNG still has a valid header, so it opens as an image and only looks wrong (a grey band where the missing rows should be) — nothing but an integrity check catches it.
 
 **Production pipeline pattern**:
 ```
@@ -79,13 +79,16 @@ Pull screenshots → upload to S3 or attach to PR
 ## Troubleshooting
 
 ### Issue: Chromium not found at `/usr/bin/chromium`
-**Solution**: The install command uses `apt-get install chromium`. On some Node.js base images, the path may differ. Run `which chromium || which chromium-browser` via ExecuteCommand to find it, then update the Puppeteer launch path.
+**Solution**: The script no longer hardcodes the path — after installing, it resolves Chromium with `command -v chromium || command -v chromium-browser` and passes whatever it finds into the test prompt. If the install itself fails the run stops there with apt-get's own error, instead of going on to write Puppeteer tests against a browser that was never installed.
+
+### Issue: A screenshot opens but has a grey band across the bottom
+**Solution**: The transfer was truncated. A short payload decodes into a PNG that still has a valid header, so it opens as an image and nothing reports an error. Checking the base64 length is not enough on its own: it is a multiple of four for any complete file, but a truncated payload can be four-aligned too, and was in the run that exposed this. The script therefore compares the decoded size **and MD5** against the file on the VM and retries, so a partial transfer is reported as a failure rather than saved. If you write your own transfer, verify it the same way; do not pad or trim the payload to make it decode.
 
 ### Issue: Screenshots are all blank or black
 **Solution**: Chromium in headless mode may need `--no-sandbox --disable-setuid-sandbox` flags. Ensure the Puppeteer launch options include these. The test prompt explicitly requests them.
 
 ### Issue: Server not responding on port 3000
-**Solution**: Check `/tmp/server.log` for errors via `run_command(harness_arn, session_id, "cat /tmp/server.log")`. The `npx serve` command requires network access to download on first run.
+**Solution**: `npx -y serve` downloads the package on first use, so the port is not open the moment the command returns. The script polls for an HTTP 200 (up to 60s) rather than sleeping a fixed interval, and if it never answers it prints the tail of `/tmp/server.log` and stops — the later steps all depend on that server. To inspect it yourself, run `run_command(harness_arn, session_id, "cat /tmp/server.log")`.
 
 ## AgentCore CLI
 
@@ -126,9 +129,9 @@ python webapp_visual_testing.py
 python webapp_visual_testing.py --skip-cleanup
 ```
 
-Screenshots are saved to `/tmp/screenshot_1.png`, `/tmp/screenshot_2.png`, `/tmp/screenshot_3.png`.
+Screenshots are saved under `/tmp/webapp_screenshots/` (`screenshot_1.png`, `screenshot_2.png`, `screenshot_3.png`), each verified against its size and MD5 on the VM before being written.
 
 Open with:
 ```bash
-open /tmp/screenshot_1.png  # macOS
+open /tmp/webapp_screenshots/screenshot_1.png  # macOS
 ```

--- a/01-features/01-harness/02-use-cases/02-webapp-visual-testing/webapp_visual_testing.py
+++ b/01-features/01-harness/02-use-cases/02-webapp-visual-testing/webapp_visual_testing.py
@@ -33,6 +33,8 @@ Prerequisites:
 
 import argparse
 import base64
+import binascii
+import hashlib
 import sys
 import time
 import uuid
@@ -55,6 +57,39 @@ args = parser.parse_args()
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 NODE_CONTAINER = "public.ecr.aws/docker/library/node:20-slim"
 
+# Local directory for the screenshots pulled off the VM. Deliberately not the
+# same paths the VM uses (/tmp/screenshot_N.png): keeping them apart makes it
+# obvious which side of the transfer a file came from, and a stale local file
+# can no longer be mistaken for a freshly pulled one.
+LOCAL_SCREENSHOT_DIR = Path("/tmp/webapp_screenshots")  # nosec B108
+
+# A screenshot is binary, so a short read cannot be spotted by eye — it has to be
+# checked. Transfers are retried this many times before the file is reported as
+# failed rather than saved.
+FETCH_ATTEMPTS = 3
+
+# Error members of the InvokeAgentRuntimeCommand event stream (per the boto3
+# model). They arrive as ordinary events instead of raising, so a loop that only
+# reads chunks treats a command that never ran as one that produced no output.
+COMMAND_ERROR_KEYS = (
+    "accessDeniedException",
+    "internalServerException",
+    "resourceNotFoundException",
+    "serviceQuotaExceededException",
+    "throttlingException",
+    "validationException",
+    "runtimeClientError",
+)
+
+# The InvokeHarness stream carries a smaller set (it has no accessDenied /
+# resourceNotFound / serviceQuotaExceeded / throttling members of its own — those
+# surface as a ClientError on the call).
+STREAM_ERROR_KEYS = (
+    "internalServerException",
+    "validationException",
+    "runtimeClientError",
+)
+
 # ── Setup ─────────────────────────────────────────────────────────────────────
 control = get_agentcore_control_client()
 client = get_agentcore_client()
@@ -63,24 +98,152 @@ account_id = boto3.client("sts").get_caller_identity()["Account"]
 print(f"Account: {account_id}")
 
 
-def run_command(harness_arn, session_id, cmd):
-    """Run a command on the agent's remote microVM."""
+def run_command(harness_arn, session_id, cmd, echo=True):
+    """Run a command on the agent's remote microVM.
+
+    Returns (stdout, exit_code). stdout is streamed to the console as it arrives
+    unless `echo` is False, so callers must not print the return value again.
+
+    The stream reports failure two different ways and both have to be read: a
+    command that ran and failed reports it in `contentStop.exitCode`, while a
+    command that never ran at all arrives as one of the modeled error events.
+    Reading neither made a failed step look exactly like a successful one.
+    """
     print(f"$ {cmd}")
     output = ""
+    exit_code = None
     resp = client.invoke_agent_runtime_command(
         agentRuntimeArn=harness_arn,
         runtimeSessionId=session_id,
         body={"command": cmd},
     )
     for event in resp["stream"]:
-        if "chunk" in event and "contentDelta" in event["chunk"]:
-            delta = event["chunk"]["contentDelta"]
-            if "stdout" in delta:
-                print(delta["stdout"], end="", flush=True)
-                output += delta["stdout"]
-            if "stderr" in delta:
-                print(delta["stderr"], end="", flush=True)
+        if "chunk" in event:
+            chunk = event["chunk"]
+            if "contentDelta" in chunk:
+                delta = chunk["contentDelta"]
+                if "stdout" in delta:
+                    output += delta["stdout"]
+                    if echo:
+                        print(delta["stdout"], end="", flush=True)
+                if "stderr" in delta:
+                    print(delta["stderr"], end="", flush=True)
+            elif "contentStop" in chunk:
+                exit_code = chunk["contentStop"].get("exitCode")
+        else:
+            err = next((event[k] for k in COMMAND_ERROR_KEYS if k in event), None)
+            if err is not None:
+                raise RuntimeError(f"Command stream error ({cmd}): {err}")
+    if echo and output and not output.endswith("\n"):
+        print()
+    return output, exit_code
+
+
+def run_checked(harness_arn, session_id, cmd, echo=True):
+    """Run a command and raise unless it reported success. Returns stdout.
+
+    A missing exit code is treated as a failure too: the stream ended without
+    ever saying how the command finished, so nothing confirms it did.
+    """
+    output, exit_code = run_command(harness_arn, session_id, cmd, echo=echo)
+    if exit_code is None:
+        raise RuntimeError(f"Command returned no exit status: {cmd}")
+    if exit_code != 0:
+        raise RuntimeError(f"Command exited {exit_code}: {cmd}")
     return output
+
+
+def stream_agent_turn(harness_arn, session_id, prompt, show_tools=False):
+    """Send one prompt to the agent and stream the reply. Returns the text.
+
+    Raises on a stream error event so a turn that failed part-way cannot be
+    mistaken for one that finished — the steps that follow depend on the files
+    this turn is supposed to leave on the VM.
+    """
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+        messages=[{"role": "user", "content": [{"text": prompt}]}],
+    )
+    full_text = ""
+    for event in response["stream"]:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if show_tools and "toolUse" in start:
+                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+                full_text += delta["text"]
+        elif "messageStop" in event:
+            print()
+        else:
+            err = next((event[k] for k in STREAM_ERROR_KEYS if k in event), None)
+            if err is not None:
+                raise RuntimeError(f"Harness stream error: {err}")
+    return full_text
+
+
+def fetch_binary(harness_arn, session_id, remote_path):
+    """Copy one binary file off the VM, verified. Returns bytes, or None.
+
+    The transfer is checked against the file's real size and MD5 on the VM
+    because the command stream has been observed delivering a *short* payload
+    for a large file — intermittently, with no error event and a zero exit code.
+
+    Only the size/MD5 comparison catches that. Base64 of a complete file is
+    always a multiple of four characters, so a length that is not means the
+    payload is incomplete — but the converse does not hold, and a truncated
+    payload stayed four-aligned in the run that exposed this. The result was a
+    PNG with a valid header, no end marker, and a grey band where the missing
+    rows should be: a corrupt screenshot that reported itself as a success.
+    """
+    meta, exit_code = run_command(
+        harness_arn,
+        session_id,
+        f"stat -c %s {remote_path} && md5sum {remote_path} | cut -d' ' -f1",
+        echo=False,
+    )
+    if exit_code != 0:
+        print(f"⚠️  {remote_path}: not readable on the VM (exit {exit_code})")
+        return None
+    try:
+        size_text, md5_expected = meta.split()
+        size_expected = int(size_text)
+    except ValueError:
+        print(f"⚠️  {remote_path}: could not read size/MD5 from {meta.strip()!r}")
+        return None
+
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        # Wrapped base64 (the default) is what the stream handles reliably; the
+        # single-line `base64 -w0` form has been seen to fail the whole stream
+        # with an InternalFailure on a payload this size.
+        encoded, exit_code = run_command(harness_arn, session_id, f"base64 {remote_path}", echo=False)
+        if exit_code != 0:
+            print(f"⚠️  {remote_path}: base64 exited {exit_code}")
+            return None
+
+        cleaned = "".join(encoded.split())
+        if len(cleaned) % 4:
+            reason = f"payload truncated mid-quartet ({len(cleaned)} chars)"
+        else:
+            try:
+                data = base64.b64decode(cleaned)
+            except binascii.Error as e:
+                reason = f"undecodable payload ({e})"
+            else:
+                digest = hashlib.md5(data, usedforsecurity=False).hexdigest()
+                if len(data) == size_expected and digest == md5_expected:
+                    return data
+                reason = f"got {len(data):,} of {size_expected:,} bytes"
+
+        if attempt < FETCH_ATTEMPTS:
+            print(f"   retrying {remote_path} — {reason} (attempt {attempt}/{FETCH_ATTEMPTS})")
+
+    print(f"⚠️  {remote_path}: transfer failed after {FETCH_ATTEMPTS} attempts — {reason}")
+    return None
 
 
 harness_id = None
@@ -121,84 +284,88 @@ try:
     session_id = str(uuid.uuid4()).upper()
     print(f"Session ID: {session_id}\n")
 
-    print("Installing git, curl, and Chromium...")
-    out = run_command(
+    print("Installing git, curl, and Chromium (takes ~1 minute)...")
+    # apt-get is noisy (dpkg prints ~1000 lines here), so its output goes to a log
+    # on the VM and only the tail is shown, and *only on failure*. The point is to
+    # stop checking the exit code — the original sent everything to /dev/null and
+    # never looked, so a failed install slid straight into writing Puppeteer tests
+    # against a Chromium that was never there.
+    _, exit_code = run_command(
         harness_arn,
         session_id,
-        "apt-get update -qq && apt-get install -y -qq git curl chromium > /dev/null 2>&1 && echo 'done'",
+        "apt-get update -qq && apt-get install -y -qq git curl chromium > /tmp/apt.log 2>&1",
+        echo=False,
     )
-    print(out.strip())
+    if exit_code != 0:
+        log_tail, _ = run_command(harness_arn, session_id, "tail -20 /tmp/apt.log")
+        raise RuntimeError(f"Package install failed (exit {exit_code}). /tmp/apt.log:\n{log_tail}")
+    chromium_path = run_checked(
+        harness_arn,
+        session_id,
+        "command -v chromium || command -v chromium-browser",
+        echo=False,
+    ).strip()
+    print(f"✅ Chromium at {chromium_path}")
 
     # Ask the agent to generate a TodoMVC app
     print("\nAsking agent to create TodoMVC app...")
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "text": "Create a single-file TodoMVC app at /tmp/todomvc/index.html. "
-                        "It should be a complete, self-contained HTML file with inline CSS and JS. "
-                        "Features: add todos, toggle complete, filter (All/Active/Completed), delete. "
-                        "Use a clean modern design. No external dependencies."
-                    }
-                ],
-            }
-        ],
-    )
-    for event in response["stream"]:
-        if "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                print(delta["text"], end="", flush=True)
-        elif "messageStop" in event:
-            print()
-
-    out = run_command(
+    stream_agent_turn(
         harness_arn,
         session_id,
-        "ls -la /tmp/todomvc/index.html 2>/dev/null || echo 'NOT CREATED'",
+        "Create a single-file TodoMVC app at /tmp/todomvc/index.html. "
+        "It should be a complete, self-contained HTML file with inline CSS and JS. "
+        "Features: add todos, toggle complete, filter (All/Active/Completed), delete. "
+        "Use a clean modern design. No external dependencies.",
     )
-    print(out.strip())
+
+    # Fail here rather than serving an empty directory: `npx serve` is perfectly
+    # happy to serve a directory with no index.html, so without this check the
+    # visual tests ran against a 404 page and still produced screenshots.
+    run_checked(harness_arn, session_id, "test -s /tmp/todomvc/index.html && wc -c < /tmp/todomvc/index.html")
 
     # Start web server
     print("\nStarting web server on port 3000...")
     run_command(
         harness_arn,
         session_id,
-        "mkdir -p /tmp/todomvc && cd /tmp/todomvc && nohup npx -y serve -l 3000 > /tmp/server.log 2>&1 &",
+        "cd /tmp/todomvc && nohup npx -y serve -l 3000 > /tmp/server.log 2>&1 &",
     )
-    time.sleep(5)
-    out = run_command(
-        harness_arn,
-        session_id,
-        "curl -s -o /dev/null -w '%{http_code}' http://localhost:3000 || echo 'FAIL'",
-    )
-    print(f"Server status code: {out.strip()}")
 
-    # Install Puppeteer
+    # `npx -y serve` downloads the package on first use, so the port is not open
+    # the moment the command returns. Poll instead of sleeping a fixed 5s, and
+    # stop the run if it never answers — every later step needs this server.
+    print("Waiting for the server to answer on port 3000...")
+    for _ in range(30):
+        status_code, _ = run_command(
+            harness_arn,
+            session_id,
+            "curl -s -o /dev/null -w '%{http_code}' http://localhost:3000",
+            echo=False,
+        )
+        if status_code.strip() == "200":
+            break
+        time.sleep(2)
+    else:
+        log_tail, _ = run_command(harness_arn, session_id, "tail -20 /tmp/server.log")
+        raise RuntimeError(f"Web server never returned 200 on port 3000. /tmp/server.log:\n{log_tail}")
+    print("✅ Server responding with 200")
+
+    # Install Puppeteer. The output is trimmed here rather than with `| tail -3`
+    # on the VM, because a pipeline reports the *last* command's status — piping
+    # npm into tail replaced npm's exit code with tail's, which is always 0.
     print("\nInstalling puppeteer-core (this takes ~1 minute)...")
-    out = run_command(harness_arn, session_id, "cd /tmp && npm install puppeteer-core 2>&1 | tail -3")
-    print(out)
+    npm_out = run_checked(harness_arn, session_id, "cd /tmp && npm install puppeteer-core 2>&1", echo=False)
+    print("\n".join(npm_out.strip().splitlines()[-3:]))
     print("✅ Environment ready")
 
     # ── Part 3: Agent Writes and Runs Puppeteer Tests ─────────────────────────
     print("\n=== Part 3: Agent Writes Puppeteer Tests ===")
     print("Asking agent to write and run visual tests...\n")
 
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "text": """There is a TodoMVC web app running at http://localhost:3000 and puppeteer-core is installed at /tmp/node_modules/puppeteer-core. Chromium is at /usr/bin/chromium.
+    stream_agent_turn(
+        harness_arn,
+        session_id,
+        f"""There is a TodoMVC web app running at http://localhost:3000 and puppeteer-core is installed at /tmp/node_modules/puppeteer-core. Chromium is at {chromium_path}.
 
 Write a Puppeteer test script at /tmp/test.mjs and run it. The script should:
 
@@ -211,73 +378,43 @@ Write a Puppeteer test script at /tmp/test.mjs and run it. The script should:
 7. Close the browser
 
 Use import from '/tmp/node_modules/puppeteer-core/lib/esm/puppeteer/puppeteer-core.js' or require('/tmp/node_modules/puppeteer-core').
+Note: `page.waitForTimeout` no longer exists in current Puppeteer — use `await new Promise(r => setTimeout(r, ms))` instead.
 After writing the script, run it with: node /tmp/test.mjs
-Then list the screenshots: ls -la /tmp/screenshot_*.png"""
-                    }
-                ],
-            }
-        ],
+Then list the screenshots: ls -la /tmp/screenshot_*.png""",
+        show_tools=True,
     )
-
-    for event in response["stream"]:
-        if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
-            if "toolUse" in start:
-                print(f"\n[Tool: {start['toolUse'].get('name', '?')}]", flush=True)
-        elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                print(delta["text"], end="", flush=True)
-        elif "messageStop" in event:
-            print()
 
     # ── Part 4: Pull Screenshots ──────────────────────────────────────────────
     print("\n=== Part 4: Pull Screenshots ===")
-    out = run_command(
-        harness_arn,
-        session_id,
-        "ls -la /tmp/screenshot_*.png 2>/dev/null || echo 'No screenshots found'",
-    )
-    print(out)
+    # Ask the VM which screenshots exist instead of probing screenshot_1..9 and
+    # stopping at the first gap: that loop retrieved nothing at all if the agent
+    # happened to name the first file differently, and it cost six extra
+    # round-trips for files that were never requested.
+    listing, _ = run_command(harness_arn, session_id, "ls -1 /tmp/screenshot_*.png 2>/dev/null")
+    remote_paths = [line.strip() for line in listing.splitlines() if line.strip().endswith(".png")]
+    if not remote_paths:
+        print("⚠️  The agent left no screenshots on the VM")
 
+    LOCAL_SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
     screenshots_saved = []
-    for i in range(1, 10):
-        b64 = ""
-        resp = client.invoke_agent_runtime_command(
-            agentRuntimeArn=harness_arn,
-            runtimeSessionId=session_id,
-            body={"command": f"base64 /tmp/screenshot_{i}.png 2>/dev/null"},
-        )
-        for event in resp["stream"]:
-            if "chunk" in event and "contentDelta" in event["chunk"]:
-                delta = event["chunk"]["contentDelta"]
-                if "stdout" in delta:
-                    b64 += delta["stdout"]
+    for remote_path in remote_paths:
+        img_bytes = fetch_binary(harness_arn, session_id, remote_path)
+        if img_bytes is None:
+            continue
+        local_path = LOCAL_SCREENSHOT_DIR / Path(remote_path).name
+        local_path.write_bytes(img_bytes)
+        screenshots_saved.append(local_path)
+        print(f"✅ {local_path.name}: {len(img_bytes):,} bytes (verified) → {local_path}")
 
-        if not b64.strip():
-            break
-
-        b64_clean = b64.strip().replace("\n", "").replace("\r", "").replace(" ", "")
-        # Pad base64 to multiple of 4
-        remainder = len(b64_clean) % 4
-        if remainder:
-            b64_clean = b64_clean[:-remainder]
-
-        try:
-            img_bytes = base64.b64decode(b64_clean)
-            local_path = f"/tmp/screenshot_{i}.png"  # nosec B108
-            with open(local_path, "wb") as f:
-                f.write(img_bytes)
-            screenshots_saved.append(local_path)
-            print(f"✅ Screenshot {i}: {len(img_bytes):,} bytes → {local_path}")
-        except Exception as e:  # noqa: BLE001 - a bad screenshot must not abort the rest
-            print(f"⚠️  Screenshot {i}: decode failed — {e}")
-
-    print(f"\nRetrieved {len(screenshots_saved)} screenshots")
+    print(f"\nRetrieved {len(screenshots_saved)} of {len(remote_paths)} screenshots")
     if screenshots_saved:
         print("Open them with:")
         for path in screenshots_saved:
             print(f"  open {path}")
+    if len(screenshots_saved) != len(remote_paths):
+        # Say so instead of printing a success line for a partial result: a
+        # missing screenshot is the whole output of a visual-QA run.
+        raise RuntimeError(f"Only {len(screenshots_saved)} of {len(remote_paths)} screenshots transferred intact")
 
 finally:
     if not args.skip_cleanup:


### PR DESCRIPTION

## What this fixes

The sample ends with `✅` and three saved screenshots even when the transfer lost part of each
file, and several of its steps cannot report failure at all.

### Screenshots are saved truncated, and reported as successes

`base64` output for a large screenshot intermittently arrives **short** on the command stream —
no error event, exit code 0. The old code discarded the misaligned tail and decoded anyway, so
the run reported success for a corrupt file. From a live run of the sample as it stands today:

```
# on the VM     # saved        # printed
514,041 bytes   485,136 bytes  ✅ Screenshot 1: 485,136 bytes → /tmp/screenshot_1.png
513,992 bytes   485,136 bytes  ✅ Screenshot 2: 485,136 bytes → /tmp/screenshot_2.png
514,455 bytes   514,455 bytes  ✅ Screenshot 3: 514,455 bytes → /tmp/screenshot_3.png
```

Two of three lost ~29 KB (5.6%) and both printed `✅`. A truncated PNG keeps a valid header, so
`file` reports `PNG image data, 1280 x 1024` and a viewer opens it — it just has a grey band
across the bottom. Only a strict decode catches it (`OSError: image file is truncated`); the
`IEND` terminator is gone.

The existing `len % 4` check could not have caught this: the truncated payload was 646,848
characters, an exact multiple of 4. Base64 is 4-aligned for every complete file, but the
converse doesn't hold — with 76-column wrapping a cut lands 4-aligned about a quarter of the
time. Only comparing against the real file works.

Fix: `fetch_binary()` reads the file's size and MD5 on the VM, decodes, verifies **both**, and
retries up to three times; if it still doesn't match it reports the file as failed instead of
writing it, and the run ends with an error — a missing screenshot is the entire output of a
visual-QA run.

Two measurements behind that choice: it is **not a size cap** (a probe moved 50 KB–900 KB
payloads MD5-clean, and in the failing run a *larger* third file came through whole), and
`base64 -w0` is **not** a safe alternative (single-line output hung ~9 min on a ~500 KB file,
then failed the stream with `EventStreamError: ... InternalFailure`), so the fix keeps wrapped
base64.

### Steps that couldn't report failure

- **`run_command` discarded the shell exit code** and ignored the stream's error events, so a
  command that failed — or never ran — looked like one that produced no output. It now returns
  `contentStop.exitCode` and raises on all seven modeled error members; a new `run_checked`
  raises on a nonzero *or missing* exit code.
- **Both `invoke_harness` loops were unguarded**, so a turn that died mid-stream looked
  finished. Now one `stream_agent_turn` helper that raises, as the sibling samples already do.
- **`apt-get ... > /dev/null 2>&1 && echo 'done'`** hid install errors and never checked the
  result, so a failed Chromium install went on to write Puppeteer tests against a browser that
  was never there. Output goes to `/tmp/apt.log`, the exit code is checked, and the tail is
  shown only on failure — the check is added without adding noise.
- **`npm install ... | tail -3`** replaced npm's exit status with `tail`'s, always 0. Trimmed
  locally instead.
- **`mkdir -p /tmp/todomvc && ... npx serve`** created the directory if the agent hadn't written
  `index.html`, and `npx serve` will serve an empty directory — so tests ran against a 404 page
  and still produced screenshots. Now `test -s /tmp/todomvc/index.html` before serving.
- **The server start was raced**: `npx -y serve` downloads on first use, so the old fixed 5 s
  sleep could pass before the port opened, and the status code (including `FAIL`) was printed
  but never acted on. Now polls for HTTP 200 up to 60 s, else stops with the server-log tail.
- **Retrieval probed `screenshot_1..9` and stopped at the first gap**, retrieving *nothing* if
  the agent named the first file differently. Now driven by `ls -1`.

### Smaller corrections

- `/usr/bin/chromium` was hardcoded in the prompt; now resolved with `command -v` after install.
- The prompt asked for `page.waitForTimeout`, removed from current Puppeteer — replaced with the
  `setTimeout` promise form the agent otherwise has to recover from mid-run.
- `run_command` echoed stdout *and* returned it, and five callers printed it again — every
  command's output appeared twice. An `echo` flag lets consumers suppress the live echo.
- Local screenshots were written to the VM's own paths (`/tmp/screenshot_N.png`); they now go to
  `/tmp/webapp_screenshots/`, so a stale local file can't pass for a freshly pulled one.

### README

Rewrote the screenshot-transfer concept (verify what arrives, and why a length check isn't
enough), the Chromium and server troubleshooting entries (both described behaviour the script no
longer has), added an entry for the grey-band symptom, and updated the architecture diagram and
saved-screenshot paths.

## User experience

**Before**: `Retrieved 3 screenshots` with three `✅` lines, two of them silently truncated. A
failed `apt-get` or `npm install`, a server that never came up, an agent turn that died
mid-stream, or any nonzero exit all look like success. Every command's output prints twice.

**After**: each screenshot is verified against its size and MD5 on the VM and retried if it
doesn't match; the run fails loudly if any file can't be transferred intact. Failed steps stop
the run and name the cause. Output prints once.

## Testing

Two full live runs on a fresh execution role, each ending `Retrieved 3 of 3 screenshots` with
clean teardown; every saved PNG passes a strict decode, is `IEND`-terminated, and matches the
VM's size exactly. The numbers above come from a **baseline run of the unmodified sample** in
the same account, not from reading the code. The transfer's three paths were also exercised
offline against a simulated short stream (clean / recovers on retry / reported as failed rather
than saved). Account left at baseline after each run — no harness, execution role, or
auto-provisioned memory. `ruff check` and `ruff format --check` clean with the repo's
`pyproject.toml`, and the change applies and lints clean on a pristine checkout of `main`.

## Scope

Only the two files in `01-features/01-harness/02-use-cases/02-webapp-visual-testing/`; no shared
files. No overlap with #1866 — the poll loops it replaced are already the shared poller here and
are left alone.
