### PR TITLE
fix: prevent Cognito schema-drift error on repeated terraform apply

### DIFF
--- a/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/cognito.tf
+++ b/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/cognito.tf
@@ -20,6 +20,10 @@ resource "aws_cognito_user_pool" "mcp_user_pool" {
     mutable             = true
   }
 
+  lifecycle {
+    ignore_changes = [schema]
+  }
+
   tags = {
     Name      = "${var.stack_name}-user-pool"
     StackName = var.stack_name

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -129,3 +129,4 @@
 - Varun Gunda (vvargu)
 - Anil Nadiminti (aniloncloud)
 - ach1ntya
+- Scott Rojas (rukuzio)


### PR DESCRIPTION
Terraform's aws_cognito_user_pool resource plans against the schema block in config, but Cognito silently injects additional implicit attributes (sub, email_verified, etc.) at pool creation time. On any subsequent apply, Terraform tries to reconcile the two and Cognito rejects the request outright with "cannot modify or remove schema items" -- schema is immutable after pool creation, regardless of the caller's IAM permissions. Adding lifecycle.ignore_changes = [schema] stops Terraform from ever proposing that diff.

# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**: 1936

### Concise description of the PR

Add `lifecycle { ignore_changes = [schema] }` to
`aws_cognito_user_pool.mcp_user_pool` in
`04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/cognito.tf`,
because Terraform otherwise diffs the explicit `schema` block in config
against Cognito's implicit runtime-injected schema attributes on every
apply after the pool is created, and Cognito's API unconditionally
rejects any attempt to modify user pool schema post-creation — causing
`terraform apply` to fail on the second and every subsequent run,
independent of IAM permissions.

### User experience

**Before**: First `terraform apply` succeeds. Any later `terraform
apply` (retry, drift check, unrelated config tweak) fails with:

Error: updating Cognito User Pool (...): cannot modify or remove schema items

with no indication that this is a Terraform/Cognito schema-immutability
quirk rather than a permissions or config error — easy to mistake for
one of the several distinct `AccessDeniedException` errors this same
pattern can throw during initial setup, which sends people chasing IAM
policy fixes that don't apply here.

**After**: `terraform apply` is idempotent. Re-running it against an
existing pool with no intentional changes completes cleanly with no
schema diff proposed.

### Testing

Verified end-to-end: initial `terraform apply` followed by a second
`terraform apply` against the same state, both complete without the
schema error. Full stack (S3, ECR, CodeBuild, Cognito, IAM, AgentCore
Runtime) deploys successfully; `test_mcp_server.py` tool calls
(`add_numbers`, `multiply_numbers`, `greet_user`) succeed against the
deployed runtime.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] Add your name to CONTRIBUTORS.md
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] Are you uploading a dataset?
* [ ] Have you documented Introduction, Architecture Diagram, Prerequisites, Usage, Sample Prompts, and Clean Up steps in your example README?
* [x] I agree to resolve any issues created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
