### PR TITLE
fix: pin mcp<2.0.0 to prevent runtime crash on FastMCP import

### DIFF
--- a/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/README.md
+++ b/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/README.md
@@ -89,7 +89,7 @@ This Terraform configuration creates:
 The `mcp-server-code/` directory contains your MCP server's source files:
 - `mcp_server.py` - MCP server implementation with three tools
 - `Dockerfile` - Container configuration
-- `requirements.txt` - Python dependencies (mcp>=1.10.0, boto3, bedrock-agentcore)
+- `requirements.txt` - Python dependencies (mcp>=1.10.0,<2.0.0, boto3, bedrock-agentcore)
 
 **Automatic Change Detection**: 
 - Terraform archives the `mcp-server-code/` directory
@@ -115,7 +115,7 @@ The `mcp-server-code/` directory contains your MCP server's source files:
 3. **Python 3.11+** (for testing scripts)
    ```bash
    python --version  # Verify Python 3.11 or later
-   pip install boto3 mcp
+   pip install boto3 "mcp<2.0.0"
    ```
 
 4. **Docker** (for local testing, optional)
@@ -244,12 +244,12 @@ Before testing, ensure you have the required packages installed:
 ```bash
 uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-uv pip install boto3 mcp  # Both required for MCP server testing
+uv pip install boto3 "mcp<2.0.0"  # Both required for MCP server testing
 ```
 
 **Option B: System-wide installation**
 ```bash
-pip install boto3 mcp  # Both required for MCP server testing
+pip install boto3 "mcp<2.0.0"  # Both required for MCP server testing
 ```
 
 **Note**: Both `boto3` (for AWS API calls) and `mcp` (for MCP protocol) are required for testing the MCP server.
@@ -361,7 +361,7 @@ def subtract_numbers(a: int, b: int) -> int:
 
 Edit `mcp-server-code/requirements.txt`:
 ```
-mcp>=1.10.0
+mcp>=1.10.0,<2.0.0
 boto3
 bedrock-agentcore
 your-new-package>=1.0.0

--- a/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/mcp-server-code/requirements.txt
+++ b/04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/mcp-server-code/requirements.txt
@@ -1,3 +1,3 @@
-mcp>=1.10.0
+mcp>=1.10.0,<2.0.0
 boto3
 bedrock-agentcore

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -129,3 +129,4 @@
 - Varun Gunda (vvargu)
 - Anil Nadiminti (aniloncloud)
 - ach1ntya
+- Scott Rojas (rukuzio)


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**: 1938

### Concise description of the PR

Pin `mcp` to `>=1.10.0,<2.0.0` in
`04-infrastructure-as-code/terraform/mcp-server-agentcore-runtime/mcp-server-code/requirements.txt`,
and update the corresponding install/reference commands in the
sample's README, because the unpinned `mcp>=1.10.0` constraint
resolves to `mcp==2.0.0`, which renamed `mcp.server.fastmcp` to
`mcp.server.mcpserver`. 

CodeBuild picks up `2.0.0` on every fresh
image build, so the deployed AgentCore runtime crashes at container
startup with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`.
The same rename also breaks the local test client, since
`test_mcp_server.py` imports `mcp.client.streamable_http.streamablehttp_client`,
which `2.0.0` renamed to `streamable_http_client`.

### User experience

**Before**: A fresh `terraform apply` of this sample deploys
successfully (CodeBuild doesn't fail, since the break is at container
runtime, not build time), but every MCP tool call against the
deployed runtime fails with:

```
mcp.shared.exceptions.McpError: An error occurred when starting the runtime. Please check your CloudWatch logs for more information.
```

with the underlying cause only visible in the runtime's CloudWatch
logs:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

**After**: The deployed MCP server starts correctly and
`test_mcp_server.py` succeeds end-to-end against a real deployment
(`add_numbers`, `multiply_numbers`, `greet_user` all return correct
results).

### Testing

Verified end-to-end against a live deployment:
1. Applied the fix, which triggered a CodeBuild rebuild (source hash
   changed) and pushed a new image to ECR.
2. Re-ran `test_mcp_server.py` against the existing AgentCore
   Runtime — MCP session initialized, tool list returned, and all
   three tools (`add_numbers`, `multiply_numbers`, `greet_user`)
   executed successfully.
3. Confirmed the prior failure mode by reproducing it first: pulled
   the crash traceback directly from the runtime's CloudWatch log
   group (`/aws/bedrock-agentcore/runtimes/<runtime-id>-DEFAULT`)
   before applying the fix.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] Add your name to CONTRIBUTORS.md
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] Are you uploading a dataset?
* [x] Have you documented Introduction, Architecture Diagram, Prerequisites, Usage, Sample Prompts, and Clean Up steps in your example README?
* [x] I agree to resolve any issues created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
