### PR TITLE
fix(harness/03-aws-builder-agent): verify the scaffolded files instead of reporting success over an empty listing

### DIFF
--- a/01-features/01-harness/02-use-cases/03-aws-builder-agent/README.md
+++ b/01-features/01-harness/02-use-cases/03-aws-builder-agent/README.md
@@ -44,12 +44,40 @@ control.create_harness(
 [13-aws-skills](../../01-advanced-examples/13-aws-skills) for every selection
 mode (all / glob / specific / mixed).
 
+## Architecture
+
+```
+aws_builder_agent.py
+│
+├── Step 0: create_harness_role() → IAM execution role
+│
+├── Step 1: create_harness(skills=[{"awsSkills": {"paths": [...]}}], systemPrompt=...)
+│              └─ poll_harness_status → READY (30-155s measured, with AWS Skills)
+│
+├── Step 2: invoke_harness → turn 1: DESIGN (reply only, no files)
+│              └─ [Tool: skills] — the agent reads the loaded skill bundles
+│
+├── Step 3: invoke_harness → turn 2, SAME session: SCAFFOLD
+│              └─ [Tool: file_operations] × N → /tmp/url-shortener/{lib,lambda}/...
+│                 the VM filesystem belongs to the session, so this must reuse it
+│
+└── Step 4: invoke_agent_runtime_command → list the files, and fail if there are none
+               └─ bash globstar walk (the image has no `find`), exit code checked
+```
+
+## Prerequisites
+
+- AWS credentials with permission to create a harness, an IAM role, and invoke Bedrock
+- Bedrock model access enabled for the model you pass to `--model` (default: Claude Haiku 4.5)
+- `pip install -r ../../requirements.txt`
+- A region where AgentCore harness is available — `AWS_DEFAULT_REGION`, `AWS_REGION`, or your profile's region
+
 ## What it does, end to end
 
 1. **Create** the agent — harness + `awsSkills` + a builder system prompt
 2. **Design** (turn 1) — the agent designs a serverless URL shortener (API GW + Lambda + DynamoDB)
 3. **Scaffold** (turn 2, same session) — it writes a real CDK project to the VM filesystem
-4. **Inspect** — `ExecuteCommand` lists the files the agent created
+4. **Inspect** — `ExecuteCommand` lists the files the agent created, and the run fails if it wrote none
 5. **Clean up**
 
 ## Sample Prompts
@@ -64,9 +92,27 @@ mode (all / glob / specific / mixed).
 
 **The skill is the difference**: Without `awsSkills`, a small model gives generic answers. With it, the agent applies real AWS best practices and current patterns.
 
-**Multi-turn, one VM**: Design and scaffold run in the same `session_id`, so files from the scaffold step persist and can be inspected.
+**Multi-turn, one VM**: Design and scaffold run in the same `session_id`, so files from the scaffold step persist and can be inspected. The filesystem belongs to the session — a second `session_id` gets a fresh VM where `/tmp/url-shortener` does not exist.
 
 **Agent acts, not just talks**: The harness's default filesystem + shell tools let the agent write runnable code, not placeholders.
+
+**Verify, don't narrate**: The agent's closing summary is not evidence that the files exist. Step 4 asks the VM and stops the run if the project directory is empty — for a demo of a *building* agent, that check is the point.
+
+## Troubleshooting
+
+### Issue: `find: command not found`, or Step 4 lists nothing at all
+**Solution**: The harness image (Amazon Linux 2023) has no `find` — nor `tree` or `xargs`. The original inspect step ran `find … 2>/dev/null | head -40`, and three things independently hid the failure: `2>/dev/null` discarded `find: command not found`, the exit code was never read, and the pipe made the exit code `head`'s rather than `find`'s — a pipeline reports only its **last** command's status, so the 127 surfaced as 0 and would have passed for success even if the code had checked it.
+
+The script now walks the tree with bash `globstar` (no external binary, no pipeline), checks `contentStop.exitCode`, and raises if the listing is empty. When you add inspection commands of your own: don't send stderr to `/dev/null`, do read the exit code, and avoid pipelines — or set `set -o pipefail` so the status survives the pipe.
+
+### Issue: The agent says it wrote the files but they are not there
+**Solution**: Confirm both turns used the same `session_id`. The VM belongs to the session, so a scaffold in one session is invisible to an inspect in another. If the session is right, re-run with `--skip-cleanup` and look at the VM yourself — `invoke_agent_runtime_command` with `ls -1R /tmp/url-shortener` — because a small model will sometimes summarise work it did not do.
+
+### Issue: The scaffold turn stops mid-way through writing files
+**Solution**: Look for the `⚠️  Turn ended early — stopReason: ...` line. `max_iterations_exceeded` and `timeout_exceeded` mean the agent ran out of the budget set by `maxIterations` / `timeoutSeconds` on `invoke_harness` (this sample passes `timeoutSeconds=300`); raise it, or narrow the brief. See [03-execution-limits](../../01-advanced-examples/03-execution-limits) for how those limits interact.
+
+### Issue: Harness stays `CREATING` for minutes
+**Solution**: Expected. Creation with AWS Skills was measured between 30s and 155s across seven runs, most of them near 145s, so a couple of minutes of `CREATING` is normal and not a symptom. The shared poller in [utils/harness.py](../../utils/harness.py) allows 600s. A `CREATE_FAILED` is different: `poll_harness_status` raises immediately and includes the service's `failureReason`, which usually names a missing execution-role permission.
 
 ## Clean Up
 
@@ -76,7 +122,19 @@ from utils.iam import delete_harness_role
 delete_harness_role()
 ```
 
-The script deletes the harness on exit (pass `--skip-cleanup` to keep it).
+The script deletes the harness on exit (pass `--skip-cleanup` to keep it). The
+execution role is only deleted when the script created it — passing `--role-arn`
+leaves your own role alone.
+
+Creating a harness also provisions a managed memory named `harness_<name>_*`. You
+cannot delete it directly (`delete-memory` rejects it as managed); it cascades
+when the harness is deleted, but asynchronously — so it can still be listed for a
+while after the script finishes. If one is still there once the harness is fully
+gone, check with:
+
+```bash
+aws bedrock-agentcore-control list-memories --query "memories[?starts_with(id, 'harness_')]"
+```
 
 ## Running the Python Scripts
 
@@ -94,4 +152,16 @@ python aws_builder_agent.py \
 
 # Narrow the AWS Skills the agent loads
 python aws_builder_agent.py --skill-paths core-skills/aws-cdk core-skills/aws-serverless
+
+# See all options
+python aws_builder_agent.py --help
 ```
+
+| Flag | Default | What it does |
+|:-----|:--------|:-------------|
+| `--message`, `-m` | the URL-shortener brief | Replace the design brief; the scaffold step follows automatically |
+| `--skill-paths PATH ...` | `core-skills/aws-serverless core-skills/aws-cdk` | Which AWS Skills to load |
+| `--model MODEL_ID` | `global.anthropic.claude-haiku-4-5-20251001-v1:0` | Bedrock model the harness invokes |
+| `--role-arn ARN` | *(creates one)* | Reuse an existing execution role instead of creating and deleting one |
+| `--skip-cleanup` | off | Keep the harness so you can inspect the VM |
+| `--raw-events` | off | Print the raw streaming events instead of the rendered reply |

--- a/01-features/01-harness/02-use-cases/03-aws-builder-agent/aws_builder_agent.py
+++ b/01-features/01-harness/02-use-cases/03-aws-builder-agent/aws_builder_agent.py
@@ -17,11 +17,16 @@ What it does, end to end:
     1. Create a harness with AWS Skills + a builder system prompt
     2. Turn 1 — ask the agent to DESIGN a small serverless app (architecture)
     3. Turn 2 — same session: ask it to SCAFFOLD the project (write files to the VM)
-    4. Inspect the files the agent created (ExecuteCommand)
+    4. Inspect the files the agent created (ExecuteCommand) and check there are some
     5. Clean up
 
 The point: a capable, AWS-aware coding agent in ~3 API calls. Swap the skill
 paths or the prompt and you have a different agent — that's the harness model.
+
+Step 4 is what makes this a demo of a *building* agent rather than a talking one,
+so it verifies instead of narrating: an agent that describes files it never wrote
+is exactly the failure this sample exists to rule out, and the closing "Done!"
+now depends on the VM agreeing that the files are there.
 
 Usage:
     # Build the default serverless URL-shortener agent
@@ -34,8 +39,15 @@ Usage:
     # Narrow the skills the agent loads
     python aws_builder_agent.py --skill-paths core-skills/aws-cdk core-skills/aws-serverless
 
-    # Keep the harness after the demo
+    # Keep the harness after the demo (inspect the VM yourself)
     python aws_builder_agent.py --skip-cleanup
+
+    # Pick the model, or reuse an execution role you already have
+    python aws_builder_agent.py --model global.anthropic.claude-haiku-4-5-20251001-v1:0
+    python aws_builder_agent.py --role-arn arn:aws:iam::111122223333:role/MyHarnessRole
+
+    # Print the raw streaming events instead of the rendered reply
+    python aws_builder_agent.py --raw-events
 
     # See all options
     python aws_builder_agent.py --help
@@ -43,14 +55,12 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
 import time
 import uuid
 from pathlib import Path
 
-import boto3
-import botocore.exceptions
+from botocore.exceptions import BotoCoreError, ClientError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -58,24 +68,94 @@ from utils.client import get_agentcore_client, get_agentcore_control_client
 from utils.harness import poll_harness_status
 from utils.iam import create_harness_role, delete_harness_role
 
-REGION = os.getenv("AWS_DEFAULT_REGION")
-
-
 # ── Constants ───────────────────────────────────────────────────────────────
 DEFAULT_MODEL = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_SKILL_PATHS = ["core-skills/aws-serverless", "core-skills/aws-cdk"]
 PROJECT_DIR = "/tmp/url-shortener"
 
+# Error members of the InvokeAgentRuntimeCommand event stream (per the boto3
+# model). Depending on how the service frames the message, one of these either
+# arrives as an ordinary event keyed by its member name or is raised out of the
+# iterator as an EventStreamError, so both paths have to be handled. A loop that
+# only reads chunks treats a command that never ran as one that produced no
+# output — which is precisely how this sample used to fail.
+COMMAND_ERROR_KEYS = (
+    "accessDeniedException",
+    "internalServerException",
+    "resourceNotFoundException",
+    "serviceQuotaExceededException",
+    "throttlingException",
+    "validationException",
+    "runtimeClientError",
+)
+
+# The InvokeHarness stream models a smaller set — it has no accessDenied /
+# resourceNotFound / serviceQuotaExceeded / throttling members of its own, so
+# those can only reach the caller as a ClientError raised out of the iterator.
+STREAM_ERROR_KEYS = (
+    "internalServerException",
+    "validationException",
+    "runtimeClientError",
+)
+
+# stopReason values that mean the turn was cut short rather than finished. The
+# agent hitting one of these is the normal way a scaffold step ends up with only
+# half the files written, so it has to be reported — not printed as a blank line.
+INCOMPLETE_STOP_REASONS = (
+    "max_tokens",
+    "max_output_tokens_exceeded",
+    "max_iterations_exceeded",
+    "timeout_exceeded",
+    "model_context_window_exceeded",
+    "content_filtered",
+    "malformed_model_output",
+    "malformed_tool_use",
+    "interrupted",
+    "partial_turn",
+)
+
+# Both prompts say what *not* to produce as well as what to produce. Left open,
+# the agent treated the design turn as a licence to start writing files and then
+# spent iteration after iteration generating summary documents about them —
+# measured at 45 tool calls across the two turns (25 in what was supposed to be a
+# design-only turn), most of the tail being SUMMARY.txt / INDEX.md /
+# DELIVERABLES.md churn. Bounding each turn to its own job brought the same runs
+# down to 11-15 tool calls.
 DESIGN_PROMPT = (
     "Design a minimal serverless URL shortener on AWS: API Gateway + Lambda + "
-    "DynamoDB. Describe the architecture, the data model, and the two endpoints "
-    "(create short URL, resolve short URL). Keep it to a short, concrete design."
+    "DynamoDB. Consult your AWS skills first, then describe the architecture, the "
+    "data model, and the two endpoints (create short URL, resolve short URL). "
+    "Keep it to a short, concrete design, and answer in your reply — the files "
+    "come in the next step."
 )
 SCAFFOLD_PROMPT = (
     f"Now scaffold that project under {PROJECT_DIR}. Create a CDK app (TypeScript) "
     "with the stack definition, a lambda/ directory with the two handler files, a "
     "README.md, and a package.json. Write real, runnable starter code — not "
-    "placeholders. When done, list the files you created."
+    "placeholders. When every file is written, list them once and stop — no "
+    "summary or index documents beyond the README."
+)
+
+# The `find` in the original inspect step does not exist on the harness image
+# (Amazon Linux 2023 — and neither do `tree` or `xargs`), so it failed with
+# "find: command not found" and the step listed nothing on a project the agent
+# had really written. Three separate things hid that: `2>/dev/null` swallowed the
+# message, nobody read the exit code, and `| head -40` meant the exit code was
+# `head`'s anyway — a pipeline reports its *last* command's status, so the 127
+# arrived as a 0 and would have looked like success even if it had been checked.
+#
+# Bash 5.2 is on the image, and `globstar` walks the tree without any external
+# binary. No pipeline, so the status is the command's own. `test -d` runs first so
+# a missing project directory is reported as missing rather than as an empty one,
+# and the body is `if/then/fi` rather than `[ -f "$f" ] && echo "$f"` so a final
+# glob match that happens to be a directory cannot leave a non-zero status behind
+# and fail the whole step. Verified live against a harness VM for all of: missing
+# dir, empty dir, dirs-only, nested/dotfile/spaced names, symlinks, and a plain
+# file sitting where the directory should be.
+LIST_FILES_CMD = (
+    f"test -d {PROJECT_DIR} || {{ echo 'no such directory: {PROJECT_DIR}' >&2; exit 1; }}; "
+    "shopt -s globstar dotglob nullglob; "
+    f'for f in {PROJECT_DIR}/**; do if [ -f "$f" ]; then echo "$f"; fi; done'
 )
 
 
@@ -123,7 +203,13 @@ parser.add_argument(
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 def stream_turn(client, harness_arn, session_id, message, model_id, raw=False):
-    """Invoke the harness for one conversational turn and stream the response."""
+    """Invoke the harness for one conversational turn and stream the response.
+
+    Returns (text, stop_reason). The stop reason is the only thing that says
+    whether the agent finished or was cut off part-way, and the caller needs it:
+    the scaffold turn is what puts the files on the VM, so a turn that ran out of
+    iterations or wall-clock leaves a half-written project behind.
+    """
     response = client.invoke_harness(
         harnessArn=harness_arn,
         runtimeSessionId=session_id,
@@ -133,10 +219,28 @@ def stream_turn(client, harness_arn, session_id, message, model_id, raw=False):
     )
 
     full_text = ""
+    stop_reason = None
+    # A failure mid-stream can also be raised out of the iterator instead of
+    # arriving as one of the events handled below: a modeled service error
+    # (EventStreamError and other ClientErrors — throttling, access denied) or a
+    # transport error (ReadTimeoutError, connection reset — a BotoCoreError, which
+    # this agent can trigger just by going quiet during a long file-writing tool
+    # call). Catching EventStreamError alone missed the transport half:
+    # ReadTimeoutError is not a subclass of it, so a read timeout aborted the run
+    # with a traceback that said nothing about the cause.
     try:
         for event in response["stream"]:
             if raw:
                 print(json.dumps(event, default=str))
+                # Keep reading the fields that matter in raw mode too, so the
+                # caller's checks below behave the same either way. Skipping them
+                # left full_text empty and stop_reason unset, which made every
+                # --raw-events run look like a turn that produced nothing.
+                delta = event.get("contentBlockDelta", {}).get("delta", {})
+                if "text" in delta:
+                    full_text += delta["text"]
+                if "messageStop" in event:
+                    stop_reason = event["messageStop"].get("stopReason")
                 continue
 
             if "contentBlockStart" in event:
@@ -149,32 +253,63 @@ def stream_turn(client, harness_arn, session_id, message, model_id, raw=False):
                     print(delta["text"], end="", flush=True)
                     full_text += delta["text"]
             elif "messageStop" in event:
+                stop_reason = event["messageStop"].get("stopReason")
                 print()
-            elif "internalServerException" in event:
-                print(f"\n  Error: {event['internalServerException']}")
-    except botocore.exceptions.EventStreamError:
+            else:
+                err = next((event[k] for k in STREAM_ERROR_KEYS if k in event), None)
+                if err is not None:
+                    raise RuntimeError(f"Harness stream error: {err}")
+    except (BotoCoreError, ClientError) as e:
+        # The stream can fail on close after delivering the whole answer. Say so
+        # either way, but only re-raise when nothing arrived — otherwise a
+        # cosmetic close error throws away a complete, correct response.
+        print(f"\n  Stream error: {e}")
         if not full_text:
             raise
 
-    return full_text
+    if stop_reason in INCOMPLETE_STOP_REASONS:
+        print(f"\n  ⚠️  Turn ended early — stopReason: {stop_reason}")
+
+    return full_text, stop_reason
 
 
 def run_command(client, harness_arn, session_id, command):
-    """Run a shell command on the agent's VM and print stdout/stderr."""
+    """Run a shell command on the agent's VM. Returns (stdout, exit_code).
+
+    stdout is streamed as it arrives, so callers must not print the return value
+    again. The stream reports failure two different ways and both have to be
+    read: a command that ran and failed reports it in `contentStop.exitCode`,
+    while a command that never ran arrives as one of the modeled error events.
+    Reading neither is what let `find: command not found` pass for an empty
+    project directory.
+    """
     print(f"  $ {command}")
+    output = ""
+    exit_code = None
     resp = client.invoke_agent_runtime_command(
         agentRuntimeArn=harness_arn,
         runtimeSessionId=session_id,
         body={"command": command},
     )
     for event in resp["stream"]:
-        if "chunk" in event and "contentDelta" in event["chunk"]:
-            delta = event["chunk"]["contentDelta"]
-            if "stdout" in delta:
-                print(delta["stdout"], end="")
-            if "stderr" in delta:
-                print(delta["stderr"], end="")
-    print()
+        if "chunk" in event:
+            chunk = event["chunk"]
+            if "contentDelta" in chunk:
+                delta = chunk["contentDelta"]
+                if "stdout" in delta:
+                    output += delta["stdout"]
+                    print(delta["stdout"], end="", flush=True)
+                if "stderr" in delta:
+                    print(delta["stderr"], end="", flush=True)
+            elif "contentStop" in chunk:
+                exit_code = chunk["contentStop"].get("exitCode")
+        else:
+            err = next((event[k] for k in COMMAND_ERROR_KEYS if k in event), None)
+            if err is not None:
+                raise RuntimeError(f"Command stream error ({command}): {err}")
+    if output and not output.endswith("\n"):
+        print()
+    return output, exit_code
 
 
 # ── Main ────────────────────────────────────────────────────────────────────
@@ -239,20 +374,51 @@ def main(args=None):
         print("Step 2: Design the solution")
         print("=" * 60)
         print(f"  Brief: {design_prompt[:80]}{'...' if len(design_prompt) > 80 else ''}\n")
-        stream_turn(client, harness_arn, session_id, design_prompt, args.model, raw=args.raw_events)
+        design_text, _ = stream_turn(client, harness_arn, session_id, design_prompt, args.model, raw=args.raw_events)
+        # Step 3 says "now scaffold *that* project", so it only means something if
+        # this turn actually produced a design. An empty reply here used to flow
+        # straight into a scaffold prompt with no antecedent.
+        if not design_text.strip():
+            raise RuntimeError("The design turn returned no text — nothing for the scaffold step to build on")
 
         # ── Step 3: Scaffold (same session — VM state persists) ───────
+        # Same session_id on purpose: the VM filesystem belongs to the session, so
+        # a new one would start empty and Step 4 would find nothing no matter what
+        # the agent wrote here.
         print("\n" + "=" * 60)
         print("Step 3: Scaffold the project on the agent's VM")
         print("=" * 60 + "\n")
-        stream_turn(client, harness_arn, session_id, SCAFFOLD_PROMPT, args.model, raw=args.raw_events)
+        _, scaffold_stop = stream_turn(
+            client, harness_arn, session_id, SCAFFOLD_PROMPT, args.model, raw=args.raw_events
+        )
 
         # ── Step 4: Inspect what the agent built ──────────────────────
         print("\n" + "=" * 60)
         print("Step 4: Inspect the generated project")
         print("=" * 60)
-        run_command(client, harness_arn, session_id, f"find {PROJECT_DIR} -type f 2>/dev/null | head -40")
+        listing, exit_code = run_command(client, harness_arn, session_id, LIST_FILES_CMD)
+        if exit_code is None:
+            raise RuntimeError("Inspect command returned no exit status — nothing confirms it ran")
+        if exit_code != 0:
+            raise RuntimeError(f"Could not list {PROJECT_DIR} on the VM (exit {exit_code})")
 
+        files = [line.strip() for line in listing.splitlines() if line.strip()]
+        # The agent's own account of its work is not evidence. In a run against
+        # the original script it finished by announcing "All files are in
+        # /tmp/url-shortener/ — ready to deploy now!", the inspect step returned
+        # nothing at all, and the script still printed its success line and
+        # exited 0. Whether the files are there is a question for the VM.
+        if not files:
+            # The scaffold turn's stop reason is the first thing to look at here:
+            # it distinguishes an agent that ran out of iterations or wall-clock
+            # from one that simply narrated work it never did.
+            detail = f" The scaffold turn ended with stopReason={scaffold_stop}." if scaffold_stop else ""
+            raise RuntimeError(
+                f"The agent reported success but left no files under {PROJECT_DIR}.{detail} "
+                "Re-run with --skip-cleanup and inspect the harness to see what it did instead."
+            )
+
+        print(f"\n  {len(files)} file(s) written by the agent")
         print("=" * 60)
         print("Done! The harness + AWS Skills produced a working AWS agent.")
         print("=" * 60)


### PR DESCRIPTION
### Concise description of the PR

Changes the inspect step of `03-aws-builder-agent` to actually verify what the agent built, because the default harness image has no `find` — so the step that proves this is a *building* agent rather than a talking one was a silent no-op, and the script printed "Done!" over it.

The image is Amazon Linux 2023 and ships no `find` (nor `tree`, nor `xargs` — probed live with `command -v`). Three things independently hid the resulting failure:

1. `2>/dev/null` swallowed `find: command not found`
2. `run_command` never read `contentStop.exitCode`
3. `| head -40` made the reported status **`head`'s, not `find`'s** — a pipeline yields its *last* command's status, so the `127` arrived as a `0`

Point 3 is the reason this isn't just a missing check: even code that *did* read the exit code would have read success. The listing is now a bash `globstar` walk with no pipeline and no external binary, its exit code is checked, and the run fails if the agent wrote nothing.

Alongside that, in the same two files:

* **`stopReason` was discarded** — `messageStop` was handled as a bare `print()`. It's now captured and returned, and the run warns `⚠️ Turn ended early — stopReason: …` for the values that mean a turn was cut short. That is the normal way a scaffold step ends up with only half its files written, so the empty-listing error quotes it as the first thing to check.
* **`stream_turn` caught only `EventStreamError`**, which misses the transport half of the failure surface — `ReadTimeoutError` is not a subclass of it (it's a `BotoCoreError`), and this agent can trigger one just by going quiet during a long file-writing tool call. Widened to `(BotoCoreError, ClientError)`, re-raising only when no text arrived, matching #1879.
* **`run_command` ignored every failure signal** — no exit code, no stream-error branch, returned `None`. Now returns `(stdout, exit_code)` and raises on any of the 7 modeled `InvokeAgentRuntimeCommand` error members, matching #1876.
* **`--raw-events` accumulated nothing** — it did `print(...); continue`, so `full_text` stayed empty and `stop_reason` unset for the whole turn, which also disabled the "only re-raise if no text arrived" safeguard.
* **Step 2 discarded its own result**, so an empty design turn flowed straight into `"Now scaffold **that** project"` — a prompt with no antecedent. It now fails fast.
* **Both prompts now say what *not* to produce.** Left open, the agent treated the design turn as licence to start writing files and then spent iteration after iteration generating `SUMMARY.txt` / `INDEX.md` / `DELIVERABLES.md` about work it had already done: 45 tool calls across the two turns, 25 of them in a turn meant to produce prose only. Bounded, the same runs take 11–15.
* **Removed dead code** — `REGION = os.getenv("AWS_DEFAULT_REGION")` was never read and `import boto3` was never used (`utils/client.py` resolves the region itself). Neither is catchable by CI, since `F401` is ignored repo-wide.
* **README** — added Architecture (this was the only use-case README without one), Prerequisites, Troubleshooting, and a table covering all 6 CLI flags; 2 were documented before.

### User experience

**Before** — the agent had genuinely written the project, and the demo showed nothing yet still declared success (exit 0):

```
All files are in **`/tmp/url-shortener/`** — ready to deploy now!

============================================================
Step 4: Inspect the generated project
============================================================
  $ find /tmp/url-shortener -type f 2>/dev/null | head -40

============================================================
Done! The harness + AWS Skills produced a working AWS agent.
============================================================
```

**After** — the VM is asked, and the answer is shown:

```
============================================================
Step 4: Inspect the generated project
============================================================
  $ test -d /tmp/url-shortener || { echo 'no such directory: ...' >&2; exit 1; }; shopt -s globstar dotglob nullglob; ...
/tmp/url-shortener/.gitignore
/tmp/url-shortener/README.md
/tmp/url-shortener/app.ts
/tmp/url-shortener/lambda/create_short_url.py
/tmp/url-shortener/lambda/resolve_short_url.py
/tmp/url-shortener/package.json
/tmp/url-shortener/tsconfig.json

  7 file(s) written by the agent
============================================================
Done! The harness + AWS Skills produced a working AWS agent.
============================================================
```

If the agent writes nothing, the run now stops and says so, quoting the scaffold turn's `stopReason` and pointing at `--skip-cleanup` for inspection — instead of printing the success banner.

### Testing

**6 full end-to-end runs** on the fixed script, all green: Step 4 verified **7, 7, 8, 8, 9 and 7 files** against the baseline's **zero**, `[Tool: skills]` exercised in the design turn every time, no early-stop warnings, no tracebacks, and harness + inline policy + role deleted on every run. Run 5 was `--raw-events` (306 raw events streamed, `messageStop` parsed out of them), which is what exercises the raw-mode accumulation fix — under the old code the new empty-design guard would have aborted that run.

A separate probe confirmed the baseline's files really were on the VM (`cat /tmp/url-shortener/probe.txt` → `MARKER-ABC`), so the old step was failing to see work the agent had genuinely done — a false success, not a missing feature.

The new listing command was then exercised live on a harness VM, imported from the sample rather than retyped, for: missing directory (exit 1 + message on stderr), empty directory, **directories but no files** — the case the `if/then/fi` body exists to protect, since a `[ -f "$f" ] && echo` body leaves the loop's status non-zero and would fail the step — dotfiles, names containing spaces, 3-deep nesting, valid vs broken symlinks, and a plain file sitting where the directory should be. 6/6.

