### PR TITLE
fix(harness/04-weather-agent): apply the guardrail the app creates, and stop stranding billable resources

### DIFF
--- a/01-features/01-harness/02-use-cases/04-weather-agent/README.md
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/README.md
@@ -7,7 +7,7 @@
 A full-stack weather agent web app that integrates **six AgentCore capabilities** in a single demo:
 
 1. **AgentCore Gateway** — Creates a Gateway resource with an Exa MCP target, routing all tool calls through the managed proxy for centralized observability
-2. **Guardrails** — Bedrock guardrail that anonymizes PII (email, phone, address) in agent responses
+2. **Guardrails** — Bedrock guardrail that anonymizes PII (email, phone, SSN, card number) in agent responses
 3. **Observability** — CloudWatch traces with full agent loop visibility
 4. **Skills** — Generate weather forecast Excel spreadsheets using the xlsx skill (fetched from Git at invocation time)
 5. **Evaluations** — Batch evaluation scoring with built-in evaluators (Helpfulness, Correctness, Coherence, etc.)
@@ -61,7 +61,7 @@ To stop servers: `Ctrl+C`. To delete AWS resources: `./cleanup.sh`.
 │                                                                  │
 │  AC Gateway ──► Exa MCP ──► Web Search (live weather data)       │
 │  Harness ─────► Claude Haiku 4.5 (agent orchestration)           │
-│  Guardrail ───► PII anonymization (email, phone, address)        │
+│  Guardrail ───► PII anonymization (email, phone, SSN, card)      │
 │  Skills ──────► xlsx skill (Git-fetched, weather report gen)     │
 │  CloudWatch ──► Trace observability (GenAI Observability)        │
 │  Batch Eval ──► Built-in evaluators (Helpfulness, Correctness…)  │
@@ -92,7 +92,26 @@ The demo creates an AgentCore Gateway resource (`create_gateway` + `create_gatew
 - Configurable auth (NONE in this demo, supports IAM/OAuth)
 
 ### Bedrock Guardrails
-A guardrail anonymizes PII in agent responses. If you ask the agent to include personal info (email, phone), the guardrail masks it before the response reaches you.
+A guardrail anonymizes PII in agent responses. If you ask the agent to include personal info (email, phone), the guardrail masks it before the response reaches you — `{EMAIL}`, `{PHONE}` and so on appear in its place, and the app notes that it redacted something.
+
+`CreateHarness`/`InvokeHarness` take no guardrail parameter, so a harness does not
+apply one on its own: the response text is passed through
+[`ApplyGuardrail`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ApplyGuardrail.html)
+explicitly, on the complete answer rather than per streamed chunk (an entity can
+straddle two chunks, and a partial match would slip through).
+
+The filters are `EMAIL`, `PHONE`, `US_SOCIAL_SECURITY_NUMBER` and
+`CREDIT_DEBIT_CARD_NUMBER`. **`ADDRESS` is deliberately excluded**: Bedrock
+classifies a bare city name as an address, so enabling it turns *"Current Weather
+in Paris, France"* into *"Current Weather in `{ADDRESS}`"* and destroys the output
+of a weather agent. Measured against the same text, the PII this demo injects
+(email and phone) is redacted identically with or without it. The trade-off is
+that a genuine postal address is no longer masked — add `ADDRESS` back for an
+agent that handles real addresses and does not echo place names.
+
+> Note: the model's own safety training usually refuses to repeat personal
+> details back, so the guardrail often has nothing to redact. To see it fire,
+> ask for a specific string verbatim.
 
 ### Observability
 Every `invoke_harness` call automatically generates traces in CloudWatch. The Traces tab shows trace IDs that you can search in:
@@ -108,17 +127,34 @@ The "Run Eval" button triggers a batch evaluation that scores your session using
 Results appear in the web app and are also visible in:
 - **Bedrock AgentCore > Evaluations > Batch evaluation**
 
+> **Known limitation.** The evaluation job discovers your sessions but may report
+> every one as failed, with a reason like
+> `AgentSpanMappingException: Failed to parse agent_response from agent-span with
+> spanId: … and scope: strands.telemetry.tracer` (the field named varies —
+> `agent_response` or `user_query`).
+> The built-in evaluators need the prompt and response text on the agent span,
+> and the spans a harness emits carry token counts and timings but no message
+> content, so there is nothing for the evaluator to score. This is a property of
+> the harness runtime's telemetry, not of this sample's configuration. Both the
+> web app and `weather_agent.py` read the per-session reason out of the job's own
+> output log group and print it, so you can tell this apart from a real
+> misconfiguration — a bare `FAILED` with a session count says nothing.
+
 ### Optimization
 The "Optimize" button analyzes your agent's traces and generates an AI-improved system prompt optimized for goal success. It uses the `start_recommendation` API with your harness traces as input. The recommended prompt and explanation are displayed in the web app.
 
 Results are also visible in:
 - **Bedrock AgentCore > Optimizations > Recommendations**
 
+> **Known limitation.** A recommendation evaluates the same agent spans a batch
+> evaluation does, so it fails the same way and for the same reason
+> (`N/N sessions could not be evaluated`). See the note under Batch Evaluations.
+
 ## Prerequisites
 
 - Python 3.10+
 - Node.js 18+
-- AWS CLI configured with credentials (`aws sts get-caller-identity` should work). Recommended region: **us-east-1** (`export AWS_DEFAULT_REGION=us-east-1`)
+- AWS CLI configured with credentials (`aws sts get-caller-identity` should work). Set a region where AgentCore harness is available — `AWS_REGION` or `AWS_DEFAULT_REGION`, or your profile's region; the scripts fall back to `us-east-1` if none is set. (Verified end to end in `us-west-2` as well as `us-east-1`.)
 - Model access enabled for Claude Haiku 4.5 in Amazon Bedrock
 - [CloudWatch Transaction Search](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html) enabled — **required** for Traces, Evaluations, and Optimization to work. After enabling, wait 10-15 minutes before using these feature so the Bedrock AgentCore dashboard in CloudWatch can become available. Only traces from invocations *after* enabling will be indexed.
 
@@ -160,20 +196,70 @@ Open **http://localhost:5173** once the script prints "App is running!".
 - "What's the UV index in Miami today?"
 - "When is sunrise and sunset in London?"
 
-<!-- ### CLI-only mode
+### CLI-only mode
 
-For a headless demo that runs in the terminal and cleans up after itself. Run this separately — not while the web app is running, since both use the same AWS resources.
+A headless walkthrough of the same five pillars that runs in the terminal and
+cleans up after itself. Run it separately — not while the web app is running,
+since both provision the same kinds of resources under the shared execution role.
 
 ```bash
-./run.sh
-``` -->
+./run.sh                 # wrapper: checks prerequisites, then runs the script
+./run.sh --fast          # → --skip-evals
+./run.sh --keep          # → --skip-cleanup
+./run.sh --cleanup       # → --cleanup-only (remove what a --keep run left behind)
+
+# or drive the script directly:
+python weather_agent.py
+python weather_agent.py --skip-evals       # skip the batch evaluation wait
+python weather_agent.py --skip-guardrail   # no guardrail
+python weather_agent.py --skip-cleanup     # keep the resources afterwards
+python weather_agent.py --cleanup-only     # delete leftovers and exit
+```
+
+Unlike the web app, this deletes everything it created on exit unless you pass
+`--skip-cleanup`. If you did use `--skip-cleanup` (or a run died part-way),
+`--cleanup-only` sweeps up: it deletes harnesses named `WeatherAgent_*`, gateways
+named `WeatherGateway-*`/`WeatherGW-*`, guardrails named `weather-pii-guard-*`,
+batch evaluations named `weather_eval_*`, and the shared execution role. It matches
+on those prefixes only, so it will not touch unrelated resources in your account.
+
+### Prompt optimization (CLI)
+
+```bash
+python optimize.py                              # analyse traces, recommend a prompt
+python optimize.py --evaluator Builtin.Helpfulness
+python optimize.py --lookback 1                 # only the last day of traces
+python optimize.py --cleanup                    # delete weather_rec_* recommendations
+```
+
+This reads `resource_info.json`, so it only works **after** `./start.sh` has
+provisioned the resources and you have used the app for a few sessions — there
+have to be traces to analyse. It stops with a clear message if the state file is
+not there rather than failing further in. Note the limitation described under
+[Optimization](#optimization): the recommendation currently cannot score harness
+spans.
 
 ## Clean Up
 
 ```bash
-# Delete all AWS resources (gateway, harness, guardrail, batch evaluations, IAM role):
+# Delete all AWS resources (gateway, harness, guardrail, batch evaluations,
+# recommendations, IAM role):
 ./cleanup.sh
 
 # To also remove the virtual environment and node_modules:
 rm -rf venv frontend/node_modules
+```
+
+`cleanup.sh` reads `resource_info.json`, so run it before deleting the venv — it
+needs boto3 to make the delete calls. It falls back to the system interpreter if
+the venv is gone but boto3 is importable, and otherwise stops with a non-zero exit
+rather than silently leaving resources running.
+
+Creating a harness also provisions a managed memory named `harness_<name>_*`. It
+cannot be deleted directly (`delete-memory` rejects it as managed) and cascades
+when the harness is deleted — but asynchronously, so it can still appear in a
+listing for a few minutes after `cleanup.sh` finishes. To confirm:
+
+```bash
+aws bedrock-agentcore-control list-memories --query "memories[?starts_with(id, 'harness_')]"
 ```

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/agent.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/agent.py
@@ -2,8 +2,8 @@
 
 import os
 import sys
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import boto3
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/agent.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/agent.py
@@ -1,31 +1,90 @@
 """Agent invocation — streaming wrapper around invoke_harness."""
 
+import os
 import sys
 from pathlib import Path
 from typing import Generator
 
+import boto3
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 from utils.client import get_agentcore_client
 
+# Resolved here rather than imported from resources.py: resources.py imports
+# SYSTEM_PROMPT from this module, so importing REGION back from it would be a
+# cycle and neither module would load. Same order as utils/client.py.
+REGION = (
+    os.environ.get("AWS_DEFAULT_REGION")
+    or os.environ.get("AWS_REGION")
+    or boto3.session.Session().region_name
+    or "us-east-1"
+)
+
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 
+# The single definition of the agent's instructions. resources.py sets this on
+# the harness at create time and optimization.py reports it as the current
+# prompt, so both import it from here rather than keeping their own copy — two
+# copies had already drifted apart, and the one the optimizer offered to improve
+# was not the one the harness was actually running.
 SYSTEM_PROMPT = (
     "You are a weather assistant. You ONLY answer questions about weather, "
     "climate, and atmospheric conditions (temperature, wind, humidity, UV index, "
     "sunrise, sunset, moon phase, forecasts, air quality, precipitation). "
     "If the user asks about anything unrelated to weather, politely redirect them. "
     "For example: 'I'm a weather assistant — I can help with forecasts, current conditions, "
-    "UV index, wind, sunrise/sunset, and more. What location would you like weather for?'\n\n"
-    "When answering weather questions:\n"
-    "- Always search for real-time data using your tools\n"
-    "- Include specific numbers with units (temperature in °F/°C, wind in km/h or mph)\n"
-    "- Mention the city name in your response\n"
-    "- Keep responses concise and well-structured"
+    "UV index, wind, sunrise/sunset, and more. What location would you like weather for?' "
+    "When answering weather questions: always search for real-time data using your tools, "
+    "include specific numbers with units (temperature in F/C, wind in km/h or mph), "
+    "mention the city name in your response, and keep responses concise and well-structured."
 )
 
 
-def invoke_agent(harness_arn: str, gateway_arn: str, session_id: str, message: str) -> Generator[dict, None, None]:
-    """Stream agent response as SSE-friendly dicts."""
+def _screen(text: str, guardrail_id: str, guardrail_version: str) -> str:
+    """Run text through the guardrail, returning the (possibly redacted) text.
+
+    CreateHarness/InvokeHarness take no guardrail parameter, so a guardrail is
+    not something the harness applies on its own — the response has to be passed
+    through ApplyGuardrail explicitly. Returns the text unchanged on any failure:
+    a broken guardrail must not swallow the answer.
+    """
+    if not (guardrail_id and guardrail_version and text):
+        return text
+    try:
+        resp = boto3.client("bedrock-runtime", region_name=REGION).apply_guardrail(
+            guardrailIdentifier=guardrail_id,
+            guardrailVersion=guardrail_version,
+            source="OUTPUT",
+            content=[{"text": {"text": text}}],
+        )
+        if resp.get("action") == "GUARDRAIL_INTERVENED" and resp.get("outputs"):
+            return resp["outputs"][0].get("text", text)
+    except Exception as e:  # noqa: BLE001 - screening must not break the stream
+        print(f"[agent] Guardrail screening failed: {type(e).__name__}: {e}")
+    return text
+
+
+def invoke_agent(
+    harness_arn: str,
+    gateway_arn: str,
+    session_id: str,
+    message: str,
+    guardrail_id: str | None = None,
+    guardrail_version: str | None = None,
+) -> Generator[dict, None, None]:
+    """Stream agent response as SSE-friendly dicts.
+
+    Any failure is reported as an `error` event rather than raised: the caller is
+    already streaming an HTTP response by the time this generator runs, so an
+    exception here just truncates the stream and the browser shows nothing at all.
+
+    When a guardrail is passed, the finished answer is screened and a `redacted`
+    event carries the screened text. The web app created a guardrail, billed for
+    it and displayed its id in the header, but never applied it to anything — so
+    the PII-anonymization pillar the app claims to demonstrate did nothing at all.
+    Screening has to happen on the complete answer rather than per delta, because
+    an entity can straddle two deltas and a partial match would slip through.
+    """
     client = get_agentcore_client()
 
     tools = [
@@ -36,26 +95,42 @@ def invoke_agent(harness_arn: str, gateway_arn: str, session_id: str, message: s
         }
     ]
 
-    prefixed_message = f"[INSTRUCTIONS: {SYSTEM_PROMPT}]\n\nUser question: {message}"
+    full_text = ""
+    try:
+        # No system prompt here: resources.py already sets it on the harness at
+        # create time. Prefixing it onto the user's message sent it twice, and it
+        # became part of the stored conversation history — so every later turn in
+        # the session paid for it again and the model saw the instructions
+        # repeated as something the user had said.
+        response = client.invoke_harness(
+            harnessArn=harness_arn,
+            runtimeSessionId=session_id,
+            messages=[{"role": "user", "content": [{"text": message}]}],
+            model={"bedrockModelConfig": {"modelId": MODEL_ID}},
+            tools=tools,
+        )
 
-    response = client.invoke_harness(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": prefixed_message}]}],
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-        tools=tools,
-    )
+        for event in response["stream"]:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    yield {"type": "tool", "name": start["toolUse"].get("name", "?")}
+            elif "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    full_text += delta["text"]
+                    yield {"type": "text", "content": delta["text"]}
+            elif "internalServerException" in event:
+                yield {"type": "error", "content": str(event["internalServerException"])}
+    except Exception as e:  # noqa: BLE001 - screening must not break the stream
+        yield {"type": "error", "content": f"{type(e).__name__}: {e}"}
 
-    for event in response["stream"]:
-        if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
-            if "toolUse" in start:
-                yield {"type": "tool", "name": start["toolUse"].get("name", "?")}
-        elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
-            if "text" in delta:
-                yield {"type": "text", "content": delta["text"]}
-        elif "messageStop" in event:
-            yield {"type": "done"}
-        elif "internalServerException" in event:
-            yield {"type": "error", "content": str(event["internalServerException"])}
+    if guardrail_id:
+        screened = _screen(full_text, guardrail_id, guardrail_version)
+        if screened != full_text:
+            yield {"type": "redacted", "content": screened}
+
+    # A single terminal event. `messageStop` fires once per message in the agent
+    # loop, so emitting `done` there sent one `done` per tool-use round-trip and
+    # the client saw the response "finish" before the answer had even started.
+    yield {"type": "done"}

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/evaluation.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/evaluation.py
@@ -1,5 +1,6 @@
 """Evaluations — run batch evaluation against harness session traces."""
 
+import json
 import time
 import uuid
 
@@ -30,6 +31,49 @@ def _discover_log_group(harness_name: str) -> str | None:
         groups.sort(key=lambda g: g.get("creationTime", 0), reverse=True)
         return groups[0]["logGroupName"]
     return None
+
+
+def _session_failure_reasons(result: dict, limit: int = 3) -> list[str]:
+    """Read the per-session error messages the evaluation job wrote to CloudWatch.
+
+    get_batch_evaluation only reports counts ("4 sessions failed"), which is not
+    enough to act on. The real reason is written per evaluator to the output log
+    group named in the job's own outputConfig, so read it from there and surface
+    it to the caller.
+    """
+    out = result.get("outputConfig", {}).get("cloudWatchConfig", {})
+    log_group, log_stream = out.get("logGroupName"), out.get("logStreamName")
+    if not (log_group and log_stream):
+        return []
+
+    logs = boto3.client("logs", region_name=REGION)
+    reasons: list[str] = []
+    try:
+        events = logs.get_log_events(
+            logGroupName=log_group,
+            logStreamName=log_stream,
+            limit=50,
+            startFromHead=True,
+        ).get("events", [])
+    except Exception:  # noqa: BLE001 - diagnostics must never mask the real status
+        return []
+
+    for event in events:
+        try:
+            attrs = json.loads(event["message"]).get("attributes", {})
+        except (ValueError, KeyError):
+            continue
+        msg = attrs.get("error.message")
+        if not msg:
+            continue
+        # Same message repeats once per evaluator per session; only the
+        # distinct reasons are informative.
+        reason = f"{attrs.get('error.type', 'Error')}: {msg}"
+        if reason not in reasons:
+            reasons.append(reason)
+        if len(reasons) >= limit:
+            break
+    return reasons
 
 
 def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
@@ -83,6 +127,10 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
     # Poll until complete (timeout after 5 minutes)
     deadline = time.monotonic() + 300
     status = "PENDING"
+    # Initialised up front: if every get_batch_evaluation call raises, the
+    # failure branch below still reads `result`, and an unbound name there
+    # turns a reportable evaluation failure into a NameError traceback.
+    result = {}
     while time.monotonic() < deadline:
         time.sleep(10)
         try:
@@ -110,6 +158,12 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
         error_msg = f"Evaluation did not complete (status: {status})"
         if failure_reason:
             error_msg += f". {failure_reason}"
+        # The counts above say how many sessions failed but never why. Append the
+        # actual per-session reason so the panel shows something actionable
+        # instead of just "4 session(s) failed".
+        reasons = _session_failure_reasons(result)
+        if reasons:
+            error_msg += " — " + "; ".join(reasons)
         print(f"[eval] Failed: {error_msg}")
         print(f"[eval] Full response: {result}")
         return {

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/evaluation.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/evaluation.py
@@ -5,7 +5,6 @@ import time
 import uuid
 
 import boto3
-
 from resources import REGION
 
 EVALUATOR_IDS = [
@@ -76,7 +75,7 @@ def _session_failure_reasons(result: dict, limit: int = 3) -> list[str]:
     return reasons
 
 
-def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
+def run_batch_evaluation(harness_id: str, harness_name: str | None = None) -> dict:
     """Start a batch evaluation job and poll until complete. Returns results."""
     client = boto3.client("bedrock-agentcore", region_name=REGION)
 
@@ -119,7 +118,7 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
                 }
             },
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - surface the failure to the caller as data
         return {"error": str(e), "scores": []}
 
     batch_id = resp["batchEvaluationId"]
@@ -131,6 +130,10 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
     # failure branch below still reads `result`, and an unbound name there
     # turns a reportable evaluation failure into a NameError traceback.
     result = {}
+    # A transient polling error is worth retrying, but silence is not: a run where
+    # every call failed used to look exactly like one that timed out, so keep the
+    # last error and report it if the loop never reaches a terminal status.
+    poll_error = ""
     while time.monotonic() < deadline:
         time.sleep(10)
         try:
@@ -138,8 +141,9 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
             status = result.get("status", "UNKNOWN")
             if status in ("COMPLETED", "COMPLETED_WITH_ERRORS", "FAILED"):
                 break
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 - retry; reported below if it persists
+            poll_error = f"{type(e).__name__}: {e}"
+            print(f"[eval] Poll error (will retry): {poll_error}")
 
     if status not in ("COMPLETED", "COMPLETED_WITH_ERRORS"):
         # Try to get failure details
@@ -153,8 +157,12 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
                 completed_count = eval_res.get("numberOfSessionsCompleted", 0)
                 if failed_count > 0:
                     failure_reason = f"{failed_count} session(s) failed, {completed_count} completed"
-        except Exception:
-            pass
+        except (AttributeError, TypeError, KeyError) as e:
+            # `result` is whatever the last successful call returned, so only shape
+            # errors are expected here — and they still leave the status reportable.
+            print(f"[eval] Could not read failure details: {type(e).__name__}: {e}")
+        if not failure_reason and poll_error:
+            failure_reason = f"polling never succeeded — last error: {poll_error}"
         error_msg = f"Evaluation did not complete (status: {status})"
         if failure_reason:
             error_msg += f". {failure_reason}"
@@ -186,11 +194,13 @@ def run_batch_evaluation(harness_id: str, harness_name: str = None) -> dict:
         evaluated = summary.get("totalEvaluated", 0)
 
         name = eid.replace("Builtin.", "") if eid.startswith("Builtin.") else eid
-        scores.append({
-            "evaluator": name,
-            "score": avg_score,
-            "evaluated_sessions": evaluated,
-        })
+        scores.append(
+            {
+                "evaluator": name,
+                "score": avg_score,
+                "evaluated_sessions": evaluated,
+            }
+        )
 
     return {
         "batch_id": batch_id,

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/main.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/main.py
@@ -90,16 +90,41 @@ async def chat(req: ChatRequest):
 
     async def generate():
         full_text = ""
+        failed = False
         yield json.dumps({"type": "session_id", "session_id": session_id})
 
+        # The guardrail is passed in so the finished answer is actually screened.
+        # It used to be created, billed and shown in the UI header while never
+        # being applied to a single response.
         for event in invoke_agent(
-            _state["harness_arn"], _state["gateway_arn"], session_id, req.message
+            _state["harness_arn"],
+            _state["gateway_arn"],
+            session_id,
+            req.message,
+            guardrail_id=_state.get("guardrail_id"),
+            guardrail_version=_state.get("guardrail_version"),
         ):
             if event["type"] == "text":
                 full_text += event["content"]
+            elif event["type"] == "redacted":
+                # Store the screened text, not the raw text: otherwise the PII
+                # the guardrail just removed would be handed straight back to the
+                # model as history on the next turn, and shown by /api/sessions.
+                full_text = event["content"]
+            elif event["type"] == "error":
+                failed = True
             yield json.dumps(event)
 
-        _sessions[session_id].append({"role": "assistant", "content": full_text})
+        # Only record a reply that exists. A turn that failed produced no text,
+        # and appending it anyway left an empty assistant message in the session
+        # — which /api/sessions then reported as the session's `last_message`,
+        # showing a blank entry for a turn that never worked.
+        if full_text:
+            _sessions[session_id].append({"role": "assistant", "content": full_text})
+        elif failed:
+            _sessions[session_id].append(
+                {"role": "assistant", "content": "(no response — the turn failed)"}
+            )
 
     return EventSourceResponse(generate(), media_type="text/event-stream")
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/main.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/main.py
@@ -5,17 +5,16 @@ import json
 import uuid
 from contextlib import asynccontextmanager
 
+from agent import invoke_agent
+from evaluation import run_batch_evaluation
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from sse_starlette.sse import EventSourceResponse
-
-from resources import ensure_resources
-from agent import invoke_agent
 from observability import get_recent_traces, get_transaction_search_status
-from evaluation import run_batch_evaluation
-from skills import generate_weather_report
 from optimization import run_optimization
+from pydantic import BaseModel
+from resources import ensure_resources
+from skills import generate_weather_report
+from sse_starlette.sse import EventSourceResponse
 
 # Global state
 _state: dict = {}
@@ -122,9 +121,7 @@ async def chat(req: ChatRequest):
         if full_text:
             _sessions[session_id].append({"role": "assistant", "content": full_text})
         elif failed:
-            _sessions[session_id].append(
-                {"role": "assistant", "content": "(no response — the turn failed)"}
-            )
+            _sessions[session_id].append({"role": "assistant", "content": "(no response — the turn failed)"})
 
     return EventSourceResponse(generate(), media_type="text/event-stream")
 
@@ -169,9 +166,7 @@ async def optimize():
     if not _state.get("harness_name"):
         raise HTTPException(503, "Resources not ready")
 
-    result = await asyncio.to_thread(
-        run_optimization, _state["harness_name"]
-    )
+    result = await asyncio.to_thread(run_optimization, _state["harness_name"])
     return result
 
 
@@ -185,4 +180,5 @@ async def sessions():
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/observability.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/observability.py
@@ -10,16 +10,38 @@ SPANS_LOG_GROUP = "aws/spans"
 
 
 def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]:
-    """Query aws/spans log group for recent traces from this harness."""
+    """Query aws/spans log group for recent traces from this harness.
+
+    `harness_name` scopes the query to this agent. It used to be accepted and
+    then ignored, so the endpoint returned whatever else was emitting spans in
+    the account — other harnesses, other samples — presented as this agent's
+    traces. The harness publishes spans under the service name
+    harness_<harnessName>.DEFAULT.
+    """
     logs = boto3.client("logs", region_name=REGION)
 
     end_time = int(time.time())
     start_time = end_time - (minutes * 60)
 
-    query = """fields traceId, @timestamp
+    # `sort` has to key on something `stats` produced: @timestamp does not
+    # survive the aggregation, so sorting by it left the rows in arbitrary order
+    # while looking newest-first. latest(@timestamp) is carried through as
+    # last_seen for that purpose.
+    scope = ""
+    if harness_name:
+        scope = (
+            "| filter `resource.attributes.service.name` = "
+            f"'harness_{harness_name}.DEFAULT'\n"
+        )
+
+    query = f"""fields traceId, `status.code` as code, `attributes.http.response.status_code` as http_status
 | filter ispresent(traceId) and traceId != ''
-| stats count() as spans by traceId
-| sort @timestamp desc
+{scope}| stats count() as spans,
+        sum(code = 'ERROR') as errors,
+        sum(http_status >= 500) as faults,
+        latest(@timestamp) as last_seen
+     by traceId
+| sort last_seen desc
 | limit 20"""
 
     try:
@@ -31,6 +53,10 @@ def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]
         )
         query_id = resp["queryId"]
 
+        # Initialised up front: the check below reads `result`, so a zero-trip
+        # loop (or a first-call failure) would raise NameError instead of just
+        # reporting that no traces were found.
+        result = {"status": "Unknown"}
         for _ in range(15):
             time.sleep(2)
             result = logs.get_query_results(queryId=query_id)
@@ -47,11 +73,14 @@ def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]
             spans = fields.get("spans", "0")
 
             if trace_id:
+                # Derived from the spans rather than hardcoded False: the UI
+                # renders these as the health of each trace, so a trace that
+                # errored was always reported as healthy.
                 traces.append({
                     "trace_id": trace_id,
                     "spans": int(spans),
-                    "has_error": False,
-                    "has_fault": False,
+                    "has_error": int(float(fields.get("errors", "0") or 0)) > 0,
+                    "has_fault": int(float(fields.get("faults", "0") or 0)) > 0,
                 })
 
         return traces

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/observability.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/observability.py
@@ -3,13 +3,12 @@
 import time
 
 import boto3
-
 from resources import REGION
 
 SPANS_LOG_GROUP = "aws/spans"
 
 
-def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]:
+def get_recent_traces(harness_name: str | None = None, minutes: int = 10) -> list[dict]:
     """Query aws/spans log group for recent traces from this harness.
 
     `harness_name` scopes the query to this agent. It used to be accepted and
@@ -29,10 +28,7 @@ def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]
     # last_seen for that purpose.
     scope = ""
     if harness_name:
-        scope = (
-            "| filter `resource.attributes.service.name` = "
-            f"'harness_{harness_name}.DEFAULT'\n"
-        )
+        scope = f"| filter `resource.attributes.service.name` = 'harness_{harness_name}.DEFAULT'\n"
 
     query = f"""fields traceId, `status.code` as code, `attributes.http.response.status_code` as http_status
 | filter ispresent(traceId) and traceId != ''
@@ -76,16 +72,18 @@ def get_recent_traces(harness_name: str = None, minutes: int = 10) -> list[dict]
                 # Derived from the spans rather than hardcoded False: the UI
                 # renders these as the health of each trace, so a trace that
                 # errored was always reported as healthy.
-                traces.append({
-                    "trace_id": trace_id,
-                    "spans": int(spans),
-                    "has_error": int(float(fields.get("errors", "0") or 0)) > 0,
-                    "has_fault": int(float(fields.get("faults", "0") or 0)) > 0,
-                })
+                traces.append(
+                    {
+                        "trace_id": trace_id,
+                        "spans": int(spans),
+                        "has_error": int(float(fields.get("errors", "0") or 0)) > 0,
+                        "has_fault": int(float(fields.get("faults", "0") or 0)) > 0,
+                    }
+                )
 
         return traces
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - surface the failure to the caller as data
         return [{"error": str(e)}]
 
 
@@ -96,5 +94,5 @@ def get_transaction_search_status() -> dict:
         rules = xray.get_indexing_rules()
         sampling = rules["IndexingRules"][0]["Rule"]["Probabilistic"]["DesiredSamplingPercentage"]
         return {"enabled": True, "sampling_percentage": sampling}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - surface the failure to the caller as data
         return {"enabled": False, "error": str(e)}

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/optimization.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/optimization.py
@@ -5,9 +5,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import boto3
-
-from resources import REGION
 from agent import SYSTEM_PROMPT
+from resources import REGION
 
 
 def _discover_log_group_arn(harness_name: str) -> tuple[str, str] | None:
@@ -62,15 +61,13 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
                         }
                     },
                     "evaluationConfig": {
-                        "evaluators": [
-                            {"evaluatorArn": f"arn:aws:bedrock-agentcore:::evaluator/{evaluator}"}
-                        ]
+                        "evaluators": [{"evaluatorArn": f"arn:aws:bedrock-agentcore:::evaluator/{evaluator}"}]
                     },
                 }
             },
             clientToken=str(uuid.uuid4()),
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - surface the failure to the caller as data
         return {"error": str(e), "status": "FAILED"}
 
     rec_id = resp["recommendationId"]
@@ -81,6 +78,10 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
     # read `rec`, so if every get_recommendation call raises, an unbound name
     # would replace a reportable status with a NameError traceback.
     rec = {}
+    # Retry transient polling errors, but do not swallow them: if every call
+    # failed, that is the real reason the recommendation never completed, and it
+    # used to be indistinguishable from a plain timeout.
+    poll_error = ""
     for _ in range(30):
         time.sleep(10)
         try:
@@ -88,15 +89,16 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
             status = rec.get("status", "UNKNOWN")
             if status in ("COMPLETED", "FAILED"):
                 break
-        except Exception:
-            pass
+        except Exception as e:  # noqa: BLE001 - retry; reported below if it persists
+            poll_error = f"{type(e).__name__}: {e}"
+            print(f"[optimize] Poll error (will retry): {poll_error}")
 
     if status != "COMPLETED":
         error_msg = ""
+        if poll_error and status == "PENDING":
+            error_msg = f"polling never succeeded — last error: {poll_error}"
         if status == "FAILED":
-            rec_result = rec.get("recommendationResult", {}).get(
-                "systemPromptRecommendationResult", {}
-            )
+            rec_result = rec.get("recommendationResult", {}).get("systemPromptRecommendationResult", {})
             error_msg = rec_result.get("errorMessage", "Unknown error")
         # "N/N sessions could not be evaluated" does not say why. A recommendation
         # reads the same agent spans a batch evaluation does and fails the same
@@ -115,9 +117,7 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
         }
 
     # Extract result
-    rec_result = rec.get("recommendationResult", {}).get(
-        "systemPromptRecommendationResult", {}
-    )
+    rec_result = rec.get("recommendationResult", {}).get("systemPromptRecommendationResult", {})
 
     return {
         "status": "COMPLETED",

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/optimization.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/optimization.py
@@ -77,6 +77,10 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
 
     # Poll for completion (timeout 5 minutes)
     status = "PENDING"
+    # Initialised up front: both the failure branch and the success branch below
+    # read `rec`, so if every get_recommendation call raises, an unbound name
+    # would replace a reportable status with a NameError traceback.
+    rec = {}
     for _ in range(30):
         time.sleep(10)
         try:
@@ -94,6 +98,16 @@ def run_optimization(harness_name: str, evaluator: str = "Builtin.GoalSuccessRat
                 "systemPromptRecommendationResult", {}
             )
             error_msg = rec_result.get("errorMessage", "Unknown error")
+        # "N/N sessions could not be evaluated" does not say why. A recommendation
+        # reads the same agent spans a batch evaluation does and fails the same
+        # way, so point at the underlying cause rather than leaving the panel
+        # showing a bare count.
+        if "could not be evaluated" in error_msg or "sessions" in error_msg:
+            error_msg += (
+                " This usually means the harness spans carry no prompt/response "
+                "content for the evaluator to read — see the Evaluations panel "
+                "for the per-session reason."
+            )
         return {
             "status": status,
             "error": error_msg or f"Recommendation did not complete (status: {status})",

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/resources.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/resources.py
@@ -10,10 +10,9 @@ from pathlib import Path
 import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
-from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client
-
 from agent import SYSTEM_PROMPT
+from utils.client import get_agentcore_control_client
+from utils.iam import create_harness_role, delete_harness_role
 
 STATE_FILE = Path(__file__).parent.parent / "resource_info.json"
 # Honour both region variables, in the same order utils/client.py uses. Reading
@@ -85,10 +84,8 @@ def _resources_alive(state: dict) -> bool:
             return False
         gw = boto3.client("bedrock-agentcore-control", region_name=REGION)
         g = gw.get_gateway(gatewayIdentifier=state["gateway_id"])
-        if g["status"] != "READY":
-            return False
-        return True
-    except Exception:
+        return g["status"] == "READY"
+    except Exception:  # noqa: BLE001 - any failure here means 'not reusable'
         return False
 
 
@@ -137,9 +134,7 @@ def ensure_resources() -> dict:
 
     # Gateway
     gateway_name = f"WeatherGW-{uuid.uuid4().hex[:8]}"
-    resp = gw_control.create_gateway(
-        name=gateway_name, roleArn=role_arn, protocolType="MCP", authorizerType="NONE"
-    )
+    resp = gw_control.create_gateway(name=gateway_name, roleArn=role_arn, protocolType="MCP", authorizerType="NONE")
     gateway_id = resp["gatewayId"]
     gateway_arn = resp["gatewayArn"]
     state.update(gateway_id=gateway_id, gateway_arn=gateway_arn, gateway_name=gateway_name)
@@ -214,9 +209,7 @@ def ensure_resources() -> dict:
         # screening failure as "pass the text through" — so the first few
         # responses would have gone out unscreened.
         _poll(
-            lambda: bedrock.get_guardrail(
-                guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version
-            ),
+            lambda: bedrock.get_guardrail(guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version),
             lambda r: r["status"],
         )
     except Exception as e:  # noqa: BLE001 - guardrail is optional; the run continues without it
@@ -253,9 +246,7 @@ def destroy_resources():
             elif kind == "gateway":
                 if orphan.get("target_id"):
                     try:
-                        gw_control.delete_gateway_target(
-                            gatewayIdentifier=oid, targetId=orphan["target_id"]
-                        )
+                        gw_control.delete_gateway_target(gatewayIdentifier=oid, targetId=orphan["target_id"])
                         time.sleep(10)
                     except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
                         print(f"  Warning (orphan target {orphan['target_id']}): {e}")
@@ -265,38 +256,36 @@ def destroy_resources():
             else:
                 continue
             print(f"  Deleted orphaned {kind}: {oid}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning (orphan {kind} {oid}): {e}")
 
     if state.get("harness_id"):
         try:
             control.delete_harness(harnessId=state["harness_id"])
             print(f"  Deleted harness: {state['harness_id']}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
 
     if state.get("gateway_id") and state.get("target_id"):
         try:
-            gw_control.delete_gateway_target(
-                gatewayIdentifier=state["gateway_id"], targetId=state["target_id"]
-            )
+            gw_control.delete_gateway_target(gatewayIdentifier=state["gateway_id"], targetId=state["target_id"])
             print(f"  Deleted target: {state['target_id']}")
             time.sleep(10)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
 
     if state.get("gateway_id"):
         try:
             gw_control.delete_gateway(gatewayIdentifier=state["gateway_id"])
             print(f"  Deleted gateway: {state['gateway_id']}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
 
     if state.get("guardrail_id"):
         try:
             bedrock.delete_guardrail(guardrailIdentifier=state["guardrail_id"])
             print(f"  Deleted guardrail: {state['guardrail_id']}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning: {e}")
 
     # Delete batch evaluations created by this app. Both of these list calls
@@ -315,7 +304,7 @@ def destroy_resources():
                     print(f"  Deleted batch evaluation: {ev_name}")
                 except Exception as e:  # noqa: BLE001 - cleanup must continue
                     print(f"  Warning (batch eval {ev_name}): {e}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         print(f"  Warning (batch evals): {e}")
 
     # Delete recommendations created by this app
@@ -329,7 +318,7 @@ def destroy_resources():
                     print(f"  Deleted recommendation: {rec_name}")
                 except Exception as e:  # noqa: BLE001 - cleanup must continue
                     print(f"  Warning (recommendation {rec_name}): {e}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
         print(f"  Warning (recommendations): {e}")
 
     delete_harness_role()

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/resources.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/resources.py
@@ -13,22 +13,58 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 from utils.iam import create_harness_role, delete_harness_role
 from utils.client import get_agentcore_control_client
 
+from agent import SYSTEM_PROMPT
+
 STATE_FILE = Path(__file__).parent.parent / "resource_info.json"
-REGION = os.environ.get("AWS_DEFAULT_REGION") or boto3.session.Session().region_name or "us-east-1"
+# Honour both region variables, in the same order utils/client.py uses. Reading
+# only AWS_DEFAULT_REGION meant a shell that exported just AWS_REGION fell
+# through to the us-east-1 default, so these boto3 clients created the gateway,
+# harness and guardrail in a different region from the ones utils/client.py
+# builds — which do read AWS_REGION. The resources existed, in the wrong place,
+# and every later lookup came back empty.
+REGION = (
+    os.environ.get("AWS_DEFAULT_REGION")
+    or os.environ.get("AWS_REGION")
+    or boto3.session.Session().region_name
+    or "us-east-1"
+)
 
 
-def _poll(get_fn, extract_fn, target="READY", timeout=300, interval=5):
+def _poll(get_fn, extract_fn, target="READY", timeout=600, interval=5):
+    """Poll until `target`, matching the ceiling used by utils/harness.py.
+
+    UPDATE_FAILED is in the failure set as well — without it an update that
+    failed would be polled as "not ready yet" until the timeout, replacing the
+    real status with a misleading TimeoutError.
+    """
     deadline = time.monotonic() + timeout
     while True:
         resp = get_fn()
         status = extract_fn(resp)
         if status == target:
             return resp
-        if status in ("FAILED", "CREATE_FAILED", "DELETE_FAILED"):
+        if status in ("FAILED", "CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED"):
             raise RuntimeError(f"Resource failed: {status}")
         if time.monotonic() > deadline:
-            raise TimeoutError(f"Not {target} after {timeout}s")
+            raise TimeoutError(f"Not {target} after {timeout}s (current: {status})")
         time.sleep(interval)
+
+
+def _all_pages(client_obj, operation, key):
+    """Yield every item from a paginated list operation.
+
+    These list APIs paginate. Reading only the first page meant the cleanup below
+    silently skipped this app's own resources once the account held more than a
+    page of them — which is the one thing a cleanup path must not do.
+    """
+    try:
+        if client_obj.can_paginate(operation):
+            for page in client_obj.get_paginator(operation).paginate():
+                yield from page.get(key, [])
+            return
+    except Exception as e:  # noqa: BLE001 - fall back to a single call
+        print(f"  Warning (paginating {operation}): {e}")
+    yield from getattr(client_obj, operation)().get(key, [])
 
 
 def _load_state() -> dict | None:
@@ -68,8 +104,35 @@ def ensure_resources() -> dict:
     gw_control = boto3.client("bedrock-agentcore-control", region_name=REGION)
     bedrock = boto3.client("bedrock", region_name=REGION)
 
+    # A stale state file describes resources that are gone or unhealthy, but it
+    # may still name ones that are alive (e.g. the harness died and the gateway
+    # did not). The new ids below overwrite the old ones, so remember the old
+    # resources under `orphans` — destroy_resources deletes those too. Without
+    # this, every re-provision silently stranded the previous run's gateway,
+    # harness and guardrail, all of which keep billing.
+    state = {"region": REGION, "orphans": list((existing or {}).get("orphans", []))}
+    if existing:
+        for key, kind in (
+            ("harness_id", "harness"),
+            ("gateway_id", "gateway"),
+            ("guardrail_id", "guardrail"),
+        ):
+            if existing.get(key):
+                orphan = {"kind": kind, "id": existing[key]}
+                if kind == "gateway" and existing.get("target_id"):
+                    orphan["target_id"] = existing["target_id"]
+                if orphan not in state["orphans"]:
+                    state["orphans"].append(orphan)
+    # Saved after every create, so a failure part-way through still leaves a
+    # state file naming what already exists. Previously state was written only at
+    # the very end, so a failure after the gateway was created left a live,
+    # billable gateway (and harness) that cleanup.sh could not see.
+    _save_state(state)
+
     # IAM role
     role_arn = create_harness_role()
+    state["role_arn"] = role_arn
+    _save_state(state)
     time.sleep(10)
 
     # Gateway
@@ -79,6 +142,8 @@ def ensure_resources() -> dict:
     )
     gateway_id = resp["gatewayId"]
     gateway_arn = resp["gatewayArn"]
+    state.update(gateway_id=gateway_id, gateway_arn=gateway_arn, gateway_name=gateway_name)
+    _save_state(state)
     _poll(
         lambda: gw_control.get_gateway(gatewayIdentifier=gateway_id),
         lambda r: r["status"],
@@ -91,6 +156,8 @@ def ensure_resources() -> dict:
         targetConfiguration={"mcp": {"mcpServer": {"endpoint": "https://mcp.exa.ai/mcp"}}},
     )
     target_id = resp["targetId"]
+    state["target_id"] = target_id
+    _save_state(state)
     _poll(
         lambda: gw_control.get_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id),
         lambda r: r["status"],
@@ -101,24 +168,12 @@ def ensure_resources() -> dict:
     resp = control.create_harness(
         harnessName=harness_name,
         executionRoleArn=role_arn,
-        systemPrompt=[
-            {
-                "text": (
-                    "You are a weather assistant. You ONLY answer questions about weather, "
-                    "climate, and atmospheric conditions (temperature, wind, humidity, UV index, "
-                    "sunrise, sunset, moon phase, forecasts, air quality, precipitation). "
-                    "If the user asks about anything unrelated to weather, politely redirect them. "
-                    "For example: 'I'm a weather assistant — I can help with forecasts, current conditions, "
-                    "UV index, wind, sunrise/sunset, and more. What location would you like weather for?' "
-                    "When answering weather questions: always search for real-time data using your tools, "
-                    "include specific numbers with units (temperature in F/C, wind in km/h or mph), "
-                    "mention the city name in your response, and keep responses concise and well-structured."
-                )
-            }
-        ],
+        systemPrompt=[{"text": SYSTEM_PROMPT}],
     )
     harness_id = resp["harness"]["harnessId"]
     harness_arn = resp["harness"]["arn"]
+    state.update(harness_id=harness_id, harness_arn=harness_arn, harness_name=harness_name)
+    _save_state(state)
     _poll(
         lambda: control.get_harness(harnessId=harness_id),
         lambda r: r["harness"]["status"],
@@ -130,6 +185,11 @@ def ensure_resources() -> dict:
     guardrail_name = None
     try:
         guardrail_name = f"weather-pii-{uuid.uuid4().hex[:6]}"
+        # No ADDRESS filter. Bedrock classifies a bare city name as an ADDRESS,
+        # so with it enabled every weather answer came back with its location
+        # replaced by "{ADDRESS}" — measured directly: "Current Weather in
+        # {ADDRESS}". It also buys nothing for this demo, because the PII the app
+        # is meant to catch (email, phone) is redacted identically without it.
         gr = bedrock.create_guardrail(
             name=guardrail_name,
             description="Anonymize PII in weather agent responses",
@@ -137,33 +197,36 @@ def ensure_resources() -> dict:
                 "piiEntitiesConfig": [
                     {"type": "EMAIL", "action": "ANONYMIZE"},
                     {"type": "PHONE", "action": "ANONYMIZE"},
-                    {"type": "ADDRESS", "action": "ANONYMIZE"},
                     {"type": "US_SOCIAL_SECURITY_NUMBER", "action": "ANONYMIZE"},
+                    {"type": "CREDIT_DEBIT_CARD_NUMBER", "action": "ANONYMIZE"},
                 ]
             },
             blockedInputMessaging="Content blocked.",
             blockedOutputsMessaging="Content blocked.",
         )
         guardrail_id = gr["guardrailId"]
+        state.update(guardrail_id=guardrail_id, guardrail_name=guardrail_name)
+        _save_state(state)
         gv = bedrock.create_guardrail_version(guardrailIdentifier=guardrail_id, description="v1")
         guardrail_version = gv["version"]
-    except Exception as e:
+        # Wait for the version before anything tries to use it: ApplyGuardrail
+        # against a version that is still CREATING fails, and agent.py treats a
+        # screening failure as "pass the text through" — so the first few
+        # responses would have gone out unscreened.
+        _poll(
+            lambda: bedrock.get_guardrail(
+                guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version
+            ),
+            lambda r: r["status"],
+        )
+    except Exception as e:  # noqa: BLE001 - guardrail is optional; the run continues without it
         print(f"[resources] Guardrail creation failed (non-critical): {e}")
 
-    state = {
-        "gateway_id": gateway_id,
-        "gateway_arn": gateway_arn,
-        "gateway_name": gateway_name,
-        "target_id": target_id,
-        "harness_id": harness_id,
-        "harness_arn": harness_arn,
-        "harness_name": harness_name,
-        "guardrail_id": guardrail_id,
-        "guardrail_name": guardrail_name,
-        "guardrail_version": guardrail_version,
-        "role_arn": role_arn,
-        "region": REGION,
-    }
+    state.update(
+        guardrail_id=guardrail_id,
+        guardrail_name=guardrail_name,
+        guardrail_version=guardrail_version,
+    )
     _save_state(state)
     print("[resources] All resources ready")
     return state
@@ -179,6 +242,31 @@ def destroy_resources():
     control = get_agentcore_control_client()
     gw_control = boto3.client("bedrock-agentcore-control", region_name=REGION)
     bedrock = boto3.client("bedrock", region_name=REGION)
+
+    # Resources a previous re-provision replaced. They are still live and still
+    # billing, so delete them before the current set.
+    for orphan in state.get("orphans", []):
+        kind, oid = orphan.get("kind"), orphan.get("id")
+        try:
+            if kind == "harness":
+                control.delete_harness(harnessId=oid)
+            elif kind == "gateway":
+                if orphan.get("target_id"):
+                    try:
+                        gw_control.delete_gateway_target(
+                            gatewayIdentifier=oid, targetId=orphan["target_id"]
+                        )
+                        time.sleep(10)
+                    except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
+                        print(f"  Warning (orphan target {orphan['target_id']}): {e}")
+                gw_control.delete_gateway(gatewayIdentifier=oid)
+            elif kind == "guardrail":
+                bedrock.delete_guardrail(guardrailIdentifier=oid)
+            else:
+                continue
+            print(f"  Deleted orphaned {kind}: {oid}")
+        except Exception as e:
+            print(f"  Warning (orphan {kind} {oid}): {e}")
 
     if state.get("harness_id"):
         try:
@@ -211,34 +299,36 @@ def destroy_resources():
         except Exception as e:
             print(f"  Warning: {e}")
 
-    # Delete batch evaluations created by this app
+    # Delete batch evaluations created by this app. Both of these list calls
+    # paginate, and reading only the first page meant that once an account had a
+    # few jobs or recommendations, this app's own were quietly left behind — the
+    # deletes below also swallowed their errors with a bare `pass`, so nothing
+    # said so. Page through, and report what fails.
     dp_client = boto3.client("bedrock-agentcore", region_name=REGION)
     try:
-        evals = dp_client.list_batch_evaluations()
-        for ev in evals.get("batchEvaluations", evals.get("items", [])):
+        for ev in _all_pages(dp_client, "list_batch_evaluations", "batchEvaluations"):
             ev_name = ev.get("batchEvaluationName", ev.get("name", ""))
             ev_id = ev.get("batchEvaluationId", "")
             if ev_name.startswith("weather_eval_"):
                 try:
                     dp_client.delete_batch_evaluation(batchEvaluationId=ev_id)
                     print(f"  Deleted batch evaluation: {ev_name}")
-                except Exception:
-                    pass
+                except Exception as e:  # noqa: BLE001 - cleanup must continue
+                    print(f"  Warning (batch eval {ev_name}): {e}")
     except Exception as e:
         print(f"  Warning (batch evals): {e}")
 
     # Delete recommendations created by this app
     try:
-        recs = dp_client.list_recommendations()
-        for rec in recs.get("recommendationSummaries", recs.get("recommendations", recs.get("items", []))):
+        for rec in _all_pages(dp_client, "list_recommendations", "recommendationSummaries"):
             rec_name = rec.get("name", "")
             rec_id = rec.get("recommendationId", "")
             if rec_name.startswith("weather_rec_"):
                 try:
                     dp_client.delete_recommendation(recommendationId=rec_id)
                     print(f"  Deleted recommendation: {rec_name}")
-                except Exception:
-                    pass
+                except Exception as e:  # noqa: BLE001 - cleanup must continue
+                    print(f"  Warning (recommendation {rec_name}): {e}")
     except Exception as e:
         print(f"  Warning (recommendations): {e}")
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/skills.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/skills.py
@@ -119,10 +119,22 @@ def _install_skill_path(client, control, harness_id: str, harness_arn: str, sess
                 "optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}
             },
         )
-        for _ in range(24):
+        # 600s, matching utils/harness.py: a container UPDATE routinely runs
+        # past the old 24 x 5s = 120s ceiling, and this loop has no else-branch,
+        # so expiring simply fell through and ran the install commands against a
+        # harness that was still UPDATING. UPDATE_FAILED is checked too, so a
+        # real failure stops here instead of surfacing as a confusing shell error.
+        deadline = time.monotonic() + 600
+        while True:
             status = control.get_harness(harnessId=harness_id)["harness"]["status"]
             if status == "READY":
                 break
+            if status == "UPDATE_FAILED":
+                print(f"[skills] Container attach failed: {status}")
+                return False
+            if time.monotonic() > deadline:
+                print(f"[skills] Container attach did not finish in 600s (status: {status})")
+                return False
             time.sleep(5)
 
     # Install skill
@@ -161,8 +173,8 @@ def _generate_report_inner(harness_arn: str, harness_id: str, session_id: str, c
     agent_text = _try_git_skill(client, harness_arn, session_id, city)
 
     if agent_text is not None:
-        # Git skill ran — check if file was generated
-        print(f"[skills] Git skill completed. Agent text length: {len(agent_text)}")
+        # Git skill ran — check if file was generated. _try_git_skill already
+        # logged the completion and length, so don't log it a second time.
         b64_clean = _download_file(client, harness_arn, session_id)
         if b64_clean:
             return {

--- a/01-features/01-harness/02-use-cases/04-weather-agent/backend/skills.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/backend/skills.py
@@ -13,9 +13,8 @@ from botocore.config import Config
 from botocore.exceptions import ParamValidationError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
-from utils.client import get_agentcore_control_client, get_agentcore_client
-
 from resources import REGION
+from utils.client import get_agentcore_client, get_agentcore_control_client
 
 NODE_CONTAINER = "public.ecr.aws/docker/library/node:slim"
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -95,7 +94,7 @@ def _try_git_skill(client, harness_arn: str, session_id: str, city: str) -> str 
     except ParamValidationError:
         print("[skills] Git-based skill not supported, falling back to path approach")
         return None
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - report and fall back to the non-skill path
         print(f"[skills] Git-based skill exception: {type(e).__name__}: {e}")
         return None
 
@@ -115,9 +114,7 @@ def _install_skill_path(client, control, harness_id: str, harness_arn: str, sess
         print(f"[skills] Attaching Node.js container: {NODE_CONTAINER}")
         control.update_harness(
             harnessId=harness_id,
-            environmentArtifact={
-                "optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}
-            },
+            environmentArtifact={"optionalValue": {"containerConfiguration": {"containerUri": NODE_CONTAINER}}},
         )
         # 600s, matching utils/harness.py: a container UPDATE routinely runs
         # past the old 24 x 5s = 120s ceiling, and this loop has no else-branch,
@@ -140,13 +137,17 @@ def _install_skill_path(client, control, harness_id: str, harness_arn: str, sess
     # Install skill
     print("[skills] Installing xlsx skill via npx...")
     _run_command(
-        client, harness_arn, session_id,
+        client,
+        harness_arn,
+        session_id,
         "apt-get update -qq && apt-get install git -y -qq > /dev/null 2>&1 && "
-        "npx skills add https://github.com/anthropics/skills --skill xlsx --yes 2>&1 | tail -3"
+        "npx skills add https://github.com/anthropics/skills --skill xlsx --yes 2>&1 | tail -3",
     )
 
     # Verify
-    verify = _run_command(client, harness_arn, session_id, "ls .agents/skills/xlsx/ 2>/dev/null && echo OK || echo MISSING")
+    verify = _run_command(
+        client, harness_arn, session_id, "ls .agents/skills/xlsx/ 2>/dev/null && echo OK || echo MISSING"
+    )
     if "OK" in verify:
         _skill_installed[session_id] = True
         print("[skills] Skill installed successfully")
@@ -155,11 +156,13 @@ def _install_skill_path(client, control, harness_id: str, harness_arn: str, sess
     return False
 
 
-def generate_weather_report(harness_arn: str, harness_id: str, session_id: str, city: str = "the cities discussed") -> dict:
+def generate_weather_report(
+    harness_arn: str, harness_id: str, session_id: str, city: str = "the cities discussed"
+) -> dict:
     """Generate a weather forecast XLSX report. Tries Git skill first, falls back to path."""
     try:
         return _generate_report_inner(harness_arn, harness_id, session_id, city)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - report as data rather than breaking the request
         print(f"[skills] Unhandled exception: {type(e).__name__}: {e}")
         return {"success": False, "error": f"{type(e).__name__}: {e}"}
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/cleanup.sh
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/cleanup.sh
@@ -18,10 +18,25 @@ echo -e "${YELLOW}Weather Agent — Cleanup${NC}"
 echo "============================================================"
 
 # Stop servers
+#
+# Validate the pid before killing it. `kill 0` signals the whole process group —
+# including this script — so an empty or zeroed pid file (a server that died
+# before recording its pid) aborted cleanup right here, at the point where the
+# AWS resources are still live and billing. Only ever kill a positive integer.
+stop_server() {
+    local name="$1" pidfile="$2" pid
+    [ -f "$pidfile" ] || return 0
+    pid="$(cat "$pidfile" 2>/dev/null)"
+    if [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
+        kill "$pid" 2>/dev/null && echo "  Stopped $name"
+    fi
+    rm -f "$pidfile"
+}
+
 echo ""
 echo "Stopping servers..."
-[ -f backend.pid ] && kill "$(cat backend.pid)" 2>/dev/null && rm -f backend.pid && echo "  Stopped backend"
-[ -f frontend.pid ] && kill "$(cat frontend.pid)" 2>/dev/null && rm -f frontend.pid && echo "  Stopped frontend"
+stop_server backend backend.pid
+stop_server frontend frontend.pid
 lsof -ti:8000 2>/dev/null | xargs kill -9 2>/dev/null || true
 lsof -ti:5173 2>/dev/null | xargs kill -9 2>/dev/null || true
 
@@ -30,10 +45,20 @@ if [ -f "resource_info.json" ]; then
     echo ""
     echo "Deleting AWS resources..."
 
+    # A missing venv used to abort here with exit 1 — precisely when
+    # resource_info.json still names a live, billable harness and gateway, and
+    # the message at the end of this script tells you to delete the venv. Fall
+    # back to the system interpreter if it already has boto3, and only give up
+    # (still non-zero, so the failure is visible) when neither can run.
     if [ -d "venv" ]; then
         source venv/bin/activate
+    elif python3 -c "import boto3" 2>/dev/null; then
+        echo "  No venv found — using system python3 (boto3 present)"
     else
-        echo -e "${RED}  No venv found. Create one first: python3 -m venv venv && source venv/bin/activate && pip install boto3${NC}"
+        echo -e "${RED}  No venv and no system boto3, so the AWS resources in resource_info.json${NC}"
+        echo -e "${RED}  cannot be deleted and are still running. Recreate an environment first:${NC}"
+        echo -e "${RED}    python3 -m venv venv && source venv/bin/activate && pip install -r backend/requirements.txt${NC}"
+        echo -e "${RED}  then re-run ./cleanup.sh${NC}"
         exit 1
     fi
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/frontend/src/App.css
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/frontend/src/App.css
@@ -129,6 +129,14 @@ body {
   color: var(--accent-red);
 }
 
+.redacted-note {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
 .chat-input {
   padding: 12px 16px;
   border-top: 1px solid var(--border);

--- a/01-features/01-harness/02-use-cases/04-weather-agent/frontend/src/App.jsx
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/frontend/src/App.jsx
@@ -101,6 +101,21 @@ function App() {
           }
           return msgs;
         });
+      } else if (event.type === 'redacted') {
+        // The guardrail found PII in the finished answer, and `event.content` is
+        // the screened text for the WHOLE turn. A turn is rendered as several
+        // assistant bubbles when the agent pauses to call a tool, so every one of
+        // them has to go: replacing only the last would leave the earlier bubbles
+        // showing the unscreened text (and would repeat the preamble, since the
+        // screened text already contains it). Collapse this turn's assistant
+        // bubbles into one screened bubble, keeping the tool markers for context.
+        allText = event.content;
+        setMessages(prev => {
+          const lastUser = prev.map(m => m.role).lastIndexOf('user');
+          const head = prev.slice(0, lastUser + 1);
+          const tools = prev.slice(lastUser + 1).filter(m => m.role !== 'assistant');
+          return [...head, ...tools, { role: 'assistant', content: event.content, redacted: true }];
+        });
       } else if (event.type === 'tool') {
         currentChunk = '';
         setMessages(prev => [...prev, { role: 'tool', content: `Using tool: ${event.name}` }]);
@@ -262,6 +277,9 @@ function App() {
             {messages.map((msg, i) => (
               <div key={i} className={`message ${msg.role}`}>
                 {msg.role === 'assistant' ? renderMarkdown(msg.content) : msg.content}
+                {msg.redacted && (
+                  <div className="redacted-note">Guardrail redacted PII in this response</div>
+                )}
               </div>
             ))}
             {streaming && messages[messages.length - 1]?.role === 'user' && (

--- a/01-features/01-harness/02-use-cases/04-weather-agent/optimize.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/optimize.py
@@ -26,6 +26,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 import time
 import uuid
@@ -34,8 +35,13 @@ from pathlib import Path
 
 import boto3
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from utils.client import get_agentcore_client
+sys.path.insert(0, str(Path(__file__).parent / "backend"))
+
+# The single definition lives in backend/agent.py; import it rather than keeping
+# a fourth copy. This script reports it as the "current" prompt the optimizer is
+# asked to improve, so it must be exactly what the harness actually runs — a
+# private copy here had the same drift risk that already bit the other modules.
+from agent import SYSTEM_PROMPT as CURRENT_SYSTEM_PROMPT
 
 # -- CLI -----------------------------------------------------------------------
 parser = argparse.ArgumentParser(
@@ -60,20 +66,17 @@ parser.add_argument(
 args = parser.parse_args()
 
 # -- Configuration -------------------------------------------------------------
-REGION = boto3.session.Session().region_name or "us-east-1"
-STATE_FILE = Path(__file__).parent / "resource_info.json"
-
-CURRENT_SYSTEM_PROMPT = (
-    "You are a weather assistant. You ONLY answer questions about weather, "
-    "climate, and atmospheric conditions (temperature, wind, humidity, UV index, "
-    "sunrise, sunset, moon phase, forecasts, air quality, precipitation). "
-    "If the user asks about anything unrelated to weather, politely redirect them. "
-    "For example: 'I'm a weather assistant — I can help with forecasts, current conditions, "
-    "UV index, wind, sunrise/sunset, and more. What location would you like weather for?' "
-    "When answering weather questions: always search for real-time data using your tools, "
-    "include specific numbers with units (temperature in F/C, wind in km/h or mph), "
-    "mention the city name in your response, and keep responses concise and well-structured."
+# Same resolution order as utils/client.py and backend/resources.py. A bare
+# Session().region_name ignores AWS_REGION, which sent this script's clients to
+# us-east-1 while the harness it is trying to read lived elsewhere — the traces
+# then simply came back empty, with nothing saying why.
+REGION = (
+    os.environ.get("AWS_DEFAULT_REGION")
+    or os.environ.get("AWS_REGION")
+    or boto3.session.Session().region_name
+    or "us-east-1"
 )
+STATE_FILE = Path(__file__).parent / "resource_info.json"
 
 # -- Clients -------------------------------------------------------------------
 dp_client = boto3.client("bedrock-agentcore", region_name=REGION)

--- a/01-features/01-harness/02-use-cases/04-weather-agent/optimize.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/optimize.py
@@ -44,9 +44,7 @@ sys.path.insert(0, str(Path(__file__).parent / "backend"))
 from agent import SYSTEM_PROMPT as CURRENT_SYSTEM_PROMPT
 
 # -- CLI -----------------------------------------------------------------------
-parser = argparse.ArgumentParser(
-    description="Generate an optimized system prompt for the Weather Agent"
-)
+parser = argparse.ArgumentParser(description="Generate an optimized system prompt for the Weather Agent")
 parser.add_argument(
     "--evaluator",
     default="Builtin.GoalSuccessRate",
@@ -118,11 +116,11 @@ def cleanup_recommendations():
                     dp_client.delete_recommendation(recommendationId=rec_id)
                     print(f"  Deleted: {name}")
                     count += 1
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - keep deleting the remaining recommendations
                     print(f"  Warning: {e}")
         if count == 0:
             print("  No weather_rec_* recommendations found")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - listing is best-effort
         print(f"  Error: {e}")
 
 
@@ -194,15 +192,13 @@ def main():
                         }
                     },
                     "evaluationConfig": {
-                        "evaluators": [
-                            {"evaluatorArn": f"arn:aws:bedrock-agentcore:::evaluator/{args.evaluator}"}
-                        ]
+                        "evaluators": [{"evaluatorArn": f"arn:aws:bedrock-agentcore:::evaluator/{args.evaluator}"}]
                     },
                 }
             },
             clientToken=str(uuid.uuid4()),
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - report the reason instead of a traceback
         print(f"\n  Error starting recommendation: {e}")
         sys.exit(1)
 
@@ -222,22 +218,22 @@ def main():
                 print(f"    [{i * 10}s] {status}")
             if status in ("COMPLETED", "FAILED"):
                 break
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - retry the poll on the next iteration
             print(f"    Error polling: {e}")
 
     if status != "COMPLETED":
         print(f"\n  Recommendation did not complete (status: {status})")
         if status == "FAILED":
-            error_msg = result.get("recommendationResult", {}).get(
-                "systemPromptRecommendationResult", {}
-            ).get("errorMessage", "Unknown error")
+            error_msg = (
+                result.get("recommendationResult", {})
+                .get("systemPromptRecommendationResult", {})
+                .get("errorMessage", "Unknown error")
+            )
             print(f"  Error: {error_msg}")
         sys.exit(1)
 
     # Extract result
-    rec_result = result.get("recommendationResult", {}).get(
-        "systemPromptRecommendationResult", {}
-    )
+    rec_result = result.get("recommendationResult", {}).get("systemPromptRecommendationResult", {})
     recommended_prompt = rec_result.get("recommendedSystemPrompt", "")
     explanation = rec_result.get("explanation", "")
 
@@ -279,7 +275,7 @@ def main():
     print("  2. Update backend/agent.py SYSTEM_PROMPT with the recommendation")
     print("  3. Restart the app and compare agent behavior")
     print("  4. Run a batch evaluation to measure improvement")
-    print(f"\n  View in console: Bedrock AgentCore > Optimizations > Recommendations")
+    print("\n  View in console: Bedrock AgentCore > Optimizations > Recommendations")
     print("=" * 65)
 
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/run.sh
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/run.sh
@@ -45,7 +45,7 @@ for arg in "$@"; do
             echo ""
             echo "Prerequisites:"
             echo "  - AWS CLI configured (aws sts get-caller-identity should work)"
-            echo "  - AWS_DEFAULT_REGION set (or defaults to us-east-1)"
+            echo "  - AWS_REGION or AWS_DEFAULT_REGION set (or defaults to us-east-1)"
             echo "  - Claude Haiku 4.5 model access enabled in Bedrock console"
             echo "  - CloudWatch Transaction Search enabled (for observability)"
             exit 0
@@ -85,7 +85,7 @@ echo -e "  ${GREEN}Account:${NC} $ACCOUNT_ID"
 echo -e "  ${GREEN}Identity:${NC} ${CALLER_ARN##*/}"
 
 # Region
-REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
 export AWS_DEFAULT_REGION="$REGION"
 echo -e "  ${GREEN}Region:${NC} $REGION"
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/start.sh
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/start.sh
@@ -26,11 +26,22 @@ echo "==========================================================================
 echo -e "${NC}"
 
 # ── Cleanup on exit ──────────────────────────────────────────────────────────
+# Only ever kill a positive integer: `kill 0` signals this whole process group,
+# so a pid file left empty or zeroed by a server that died early would take out
+# the script itself instead of the server.
+stop_server() {
+    local pidfile="$1" pid
+    [ -f "$pidfile" ] || return 0
+    pid="$(cat "$pidfile" 2>/dev/null)"
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] && kill "$pid" 2>/dev/null
+    rm -f "$pidfile"
+}
+
 cleanup() {
     echo ""
     echo -e "${YELLOW}Stopping servers...${NC}"
-    [ -f backend.pid ] && kill "$(cat backend.pid)" 2>/dev/null && rm -f backend.pid
-    [ -f frontend.pid ] && kill "$(cat frontend.pid)" 2>/dev/null && rm -f frontend.pid
+    stop_server backend.pid
+    stop_server frontend.pid
     lsof -ti:8000 2>/dev/null | xargs kill -9 2>/dev/null || true
     lsof -ti:5173 2>/dev/null | xargs kill -9 2>/dev/null || true
     echo -e "${GREEN}Stopped.${NC}"
@@ -70,7 +81,7 @@ CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
 echo -e "  ${GREEN}AWS Account:${NC} $ACCOUNT_ID"
 echo -e "  ${GREEN}Identity:${NC} ${CALLER_ARN##*/}"
 
-REGION="${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo 'us-east-1')}"
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo 'us-east-1')}}"
 export AWS_DEFAULT_REGION="$REGION"
 echo -e "  ${GREEN}Region:${NC} $REGION"
 echo ""
@@ -110,9 +121,13 @@ echo -e "${YELLOW}[4/5] Starting backend (provisions AWS resources on first run)
 lsof -ti:8000 2>/dev/null | xargs kill -9 2>/dev/null || true
 sleep 1
 
+# `$!` after a pipeline is the PID of its LAST command — `tee`, not python. The
+# recorded PID was therefore the wrong process: Ctrl+C and cleanup.sh killed tee
+# and left the backend running, holding port 8000 and its AWS resources. Start
+# python directly with its output redirected, so $! is the server itself.
 (
     cd backend
-    python3 main.py 2>&1 | tee ../backend.log &
+    python3 main.py > ../backend.log 2>&1 &
     echo $! > ../backend.pid
 )
 
@@ -146,7 +161,7 @@ sleep 1
 
 (
     cd frontend
-    npm run dev 2>&1 | tee ../frontend.log &
+    npm run dev > ../frontend.log 2>&1 &
     echo $! > ../frontend.pid
 )
 

--- a/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
@@ -47,13 +47,11 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # -- CLI -----------------------------------------------------------------------
-parser = argparse.ArgumentParser(
-    description="Weather Agent — Harness + Evals + Gateway + Observability"
-)
+parser = argparse.ArgumentParser(description="Weather Agent — Harness + Evals + Gateway + Observability")
 parser.add_argument("--skip-evals", action="store_true", help="Skip evaluation step")
 parser.add_argument("--skip-guardrail", action="store_true", help="Skip guardrail creation")
 parser.add_argument("--skip-cleanup", action="store_true", help="Keep resources after demo")
@@ -190,12 +188,12 @@ def stream_response(harness_arn, session_id, message, tools=None, guardrail=None
     When `guardrail` is (id, version), the accumulated response is passed through
     ApplyGuardrail and the redacted version is printed and returned.
     """
-    kwargs = dict(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": message}]}],
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-    )
+    kwargs = {
+        "harnessArn": harness_arn,
+        "runtimeSessionId": session_id,
+        "messages": [{"role": "user", "content": [{"text": message}]}],
+        "model": {"bedrockModelConfig": {"modelId": MODEL_ID}},
+    }
     if tools:
         kwargs["tools"] = tools
 
@@ -275,15 +273,13 @@ def cleanup_only():
     for g in _all_pages(gw_control, "list_gateways", "items"):
         name = g.get("name", "")
         gid = g.get("gatewayId", "")
-        if not (name.startswith("WeatherGateway-") or name.startswith("WeatherGW-")):
+        if not name.startswith(("WeatherGateway-", "WeatherGW-")):
             continue
         try:
             targets = gw_control.list_gateway_targets(gatewayIdentifier=gid).get("items", [])
             for t in targets:
                 try:
-                    gw_control.delete_gateway_target(
-                        gatewayIdentifier=gid, targetId=t["targetId"]
-                    )
+                    gw_control.delete_gateway_target(gatewayIdentifier=gid, targetId=t["targetId"])
                     print(f"  Deleted target: {t['targetId']}")
                     time.sleep(10)
                 except Exception as e:  # noqa: BLE001 - keep deleting the rest
@@ -380,9 +376,7 @@ try:
     print(f"  Target ID: {target_id}")
 
     poll_status(
-        lambda: gw_control.get_gateway_target(
-            gatewayIdentifier=gateway_id, targetId=target_id
-        ),
+        lambda: gw_control.get_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id),
         lambda r: r["status"],
     )
     print("  Gateway ready with Exa MCP target")
@@ -447,9 +441,7 @@ try:
         # warning — so the demo printed an unscreened response and called it
         # screened.
         poll_status(
-            lambda: bedrock.get_guardrail(
-                guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version
-            ),
+            lambda: bedrock.get_guardrail(guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version),
             lambda r: r["status"],
         )
         print(f"  Guardrail ID: {guardrail_id} (version {guardrail_version})")
@@ -491,8 +483,7 @@ try:
     turn2_response = stream_response(
         harness_arn,
         session_id,
-        "What about the wind conditions in Paris right now? "
-        "Give me wind speed, direction, and gust information.",
+        "What about the wind conditions in Paris right now? Give me wind speed, direction, and gust information.",
         tools=tools,
     )
 
@@ -539,10 +530,12 @@ try:
         rules = xray.get_indexing_rules()
         sampling = rules["IndexingRules"][0]["Rule"]["Probabilistic"]["DesiredSamplingPercentage"]
         print(f"  Transaction Search sampling: {sampling}%")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - observability is optional to the demo
         print(f"  Transaction Search check: {e}")
         print("  Enable Transaction Search for full trace visibility:")
-        print("  https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search-getting-started.html")
+        print(
+            "  https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search-getting-started.html"
+        )
 
     # Query recent traces for our harness
     print(f"\n  Querying traces for harness: {harness_id[:20]}...")
@@ -570,14 +563,12 @@ try:
         # Longest first: the agent turns are the interesting traces, and they are
         # far slower than the sub-100ms housekeeping traces that would otherwise
         # fill the list.
-        for i, trace in enumerate(
-            sorted(summaries, key=lambda t: t.get("Duration", 0), reverse=True)[:3], 1
-        ):
+        for i, trace in enumerate(sorted(summaries, key=lambda t: t.get("Duration", 0), reverse=True)[:3], 1):
             duration = trace.get("Duration", 0)
             has_error = trace.get("HasError", False)
             status_icon = "x" if has_error else "ok"
             print(f"    Trace {i}: duration={duration:.2f}s status={status_icon}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - observability is optional to the demo
         print(f"  Trace query: {e}")
         print("  (Traces may take 1-2 minutes to appear after invocation)")
 
@@ -611,7 +602,9 @@ try:
             log_group = groups[0]["logGroupName"]
             log_group_basename = log_group.split("/")[-1]
             parts = log_group_basename.rsplit("-", 2)
-            service_name = f"{parts[0]}.DEFAULT" if len(parts) >= 3 else log_group_basename.replace("-DEFAULT", ".DEFAULT")
+            service_name = (
+                f"{parts[0]}.DEFAULT" if len(parts) >= 3 else log_group_basename.replace("-DEFAULT", ".DEFAULT")
+            )
 
             print(f"  Log group: {log_group}")
             print(f"  Service:   {service_name}")
@@ -682,7 +675,7 @@ try:
                     for reason in eval_failure_reasons(result):
                         print(f"  Reason: {reason}")
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - the demo continues to cleanup
                 print(f"  Evaluation error: {e}")
 
     # ==========================================================================
@@ -717,31 +710,29 @@ finally:
             try:
                 control.delete_harness(harnessId=harness_id)
                 print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
                 print(f"  Warning (harness): {e}")
 
         if gateway_id and target_id:
             try:
-                gw_control.delete_gateway_target(
-                    gatewayIdentifier=gateway_id, targetId=target_id
-                )
+                gw_control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id)
                 print(f"  Deleted target: {target_id}")
                 time.sleep(10)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
                 print(f"  Warning (target): {e}")
 
         if gateway_id:
             try:
                 gw_control.delete_gateway(gatewayIdentifier=gateway_id)
                 print(f"  Deleted gateway: {gateway_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
                 print(f"  Warning (gateway): {e}")
 
         if guardrail_id:
             try:
                 bedrock.delete_guardrail(guardrailIdentifier=guardrail_id)
                 print(f"  Deleted guardrail: {guardrail_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
                 print(f"  Warning (guardrail): {e}")
 
         # Delete batch evaluations created by this run. Paged, because
@@ -757,7 +748,7 @@ finally:
                         print(f"  Deleted batch evaluation: {ev_name}")
                     except Exception as e:  # noqa: BLE001 - cleanup must continue
                         print(f"  Warning (batch eval {ev_name}): {e}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cleanup must continue regardless
             print(f"  Warning (batch evals): {e}")
 
         delete_harness_role()

--- a/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
@@ -5,15 +5,15 @@ An end-to-end use case demonstrating four AgentCore pillars through a weather
 assistant that provides current conditions, UV index, wind, and sun/moon data:
 
   Part 1: Create Gateway + Harness (infrastructure)
-  Part 2: Attach Bedrock Guardrail (PII anonymization)
+  Part 2: Apply Bedrock Guardrail (PII anonymization)
   Part 3: Invoke agent — multi-turn weather session via Gateway tools
   Part 4: Observability — query CloudWatch X-Ray traces
   Part 5: Evaluations — on-demand scoring with built-in + custom evaluators
   Part 6: Cleanup
 
-The Gateway proxies to Open-Meteo (free weather API, no key required) via
-an MCP target, giving the agent access to real-time weather data with
-centralized auth and observability on the tool traffic.
+The Gateway proxies to the Exa MCP server (web search, no key required) via an
+MCP target, so the agent searches the live web for weather data with centralized
+auth and observability on the tool traffic.
 
 Usage:
     python weather_agent.py
@@ -36,6 +36,8 @@ Prerequisites:
 """
 
 import argparse
+import json
+import os
 import sys
 import time
 import uuid
@@ -55,23 +57,51 @@ parser = argparse.ArgumentParser(
 parser.add_argument("--skip-evals", action="store_true", help="Skip evaluation step")
 parser.add_argument("--skip-guardrail", action="store_true", help="Skip guardrail creation")
 parser.add_argument("--skip-cleanup", action="store_true", help="Keep resources after demo")
+# run.sh has always passed this for its `--cleanup` option, but the flag was never
+# defined here — so `./run.sh --cleanup`, the documented way to remove what a
+# previous `--keep` run left behind, failed with "unrecognized arguments" every
+# time. That is the one path a user reaches *because* resources were left running.
+parser.add_argument(
+    "--cleanup-only",
+    action="store_true",
+    help="Delete leftover WeatherAgent/WeatherGateway resources and exit (no demo)",
+)
 args = parser.parse_args()
 
 # -- Configuration -------------------------------------------------------------
 MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
-REGION = boto3.session.Session().region_name or "us-east-1"
+# Resolved the same way utils/client.py does it, so the bedrock clients below end
+# up in the same region as the harness clients. A bare Session().region_name does
+# not read AWS_REGION, so a shell exporting only that (and no configured profile
+# region) silently sent these two clients to us-east-1 while the harness was
+# created wherever AWS_REGION pointed.
+REGION = (
+    os.environ.get("AWS_DEFAULT_REGION")
+    or os.environ.get("AWS_REGION")
+    or boto3.session.Session().region_name
+    or "us-east-1"
+)
 ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
 
 # -- Clients -------------------------------------------------------------------
 control = get_agentcore_control_client()
 client = get_agentcore_client()
 bedrock = boto3.client("bedrock", region_name=REGION)
+bedrock_runtime = boto3.client("bedrock-runtime", region_name=REGION)
 
 # -- Helpers -------------------------------------------------------------------
 
 
-def poll_status(get_fn, extract_fn, target="READY", timeout=120, interval=5):
-    """Poll a resource until it reaches target status or times out."""
+def poll_status(get_fn, extract_fn, target="READY", timeout=600, interval=5):
+    """Poll a resource until it reaches target status or times out.
+
+    A harness takes ~150s to reach READY, so the old 120s ceiling expired while
+    it was still CREATING — every run raised a spurious TimeoutError, and the
+    cleanup that followed then tried to delete a harness that was still being
+    created (ConflictException) while deleting the execution role it needs,
+    stranding a running, billable harness with no role. 600s matches the shared
+    poller in utils/harness.py. UPDATE_FAILED belongs in the failure set too.
+    """
     deadline = time.monotonic() + timeout
     while True:
         resp = get_fn()
@@ -79,15 +109,87 @@ def poll_status(get_fn, extract_fn, target="READY", timeout=120, interval=5):
         print(f"  Status: {status}")
         if status == target:
             return resp
-        if status in ("FAILED", "CREATE_FAILED", "DELETE_FAILED"):
+        if status in ("FAILED", "CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED"):
             raise RuntimeError(f"Resource failed: {status}")
         if time.monotonic() > deadline:
-            raise TimeoutError(f"Resource not {target} after {timeout}s")
+            raise TimeoutError(f"Resource not {target} after {timeout}s (current: {status})")
         time.sleep(interval)
 
 
-def stream_response(harness_arn, session_id, message, tools=None):
-    """Invoke harness and stream the response. Returns accumulated text."""
+def eval_failure_reasons(result, limit=3):
+    """Read the per-session error messages a batch evaluation wrote to CloudWatch.
+
+    get_batch_evaluation reports counts only, so a failed job says how many
+    sessions failed but never why. Each evaluator writes its real reason to the
+    output log group named in the job's own outputConfig; read it from there.
+    """
+    out = result.get("outputConfig", {}).get("cloudWatchConfig", {})
+    log_group, log_stream = out.get("logGroupName"), out.get("logStreamName")
+    if not (log_group and log_stream):
+        return []
+
+    logs = boto3.client("logs", region_name=REGION)
+    reasons = []
+    try:
+        events = logs.get_log_events(
+            logGroupName=log_group,
+            logStreamName=log_stream,
+            limit=50,
+            startFromHead=True,
+        ).get("events", [])
+    except Exception:  # noqa: BLE001 - diagnostics must never mask the real status
+        return []
+
+    for event in events:
+        try:
+            attrs = json.loads(event["message"]).get("attributes", {})
+        except (ValueError, KeyError):
+            continue
+        msg = attrs.get("error.message")
+        if not msg:
+            continue
+        # The same message repeats once per evaluator per session; only the
+        # distinct reasons carry information.
+        reason = f"{attrs.get('error.type', 'Error')}: {msg}"
+        if reason not in reasons:
+            reasons.append(reason)
+        if len(reasons) >= limit:
+            break
+    return reasons
+
+
+def apply_guardrail(text, guardrail_id, guardrail_version):
+    """Run text through the guardrail, returning the (possibly redacted) text.
+
+    CreateHarness/InvokeHarness have no guardrail parameter — a guardrail is not
+    something a harness can be configured with — so the guardrail has to be
+    applied to the response explicitly via bedrock-runtime ApplyGuardrail.
+    Returns the text unchanged if no guardrail was created.
+    """
+    if not guardrail_id or not text:
+        return text
+    try:
+        resp = bedrock_runtime.apply_guardrail(
+            guardrailIdentifier=guardrail_id,
+            guardrailVersion=guardrail_version,
+            source="OUTPUT",
+            content=[{"text": {"text": text}}],
+        )
+        if resp.get("action") == "GUARDRAIL_INTERVENED":
+            outputs = resp.get("outputs", [])
+            if outputs:
+                return outputs[0].get("text", text)
+    except Exception as e:  # noqa: BLE001 - screening must not discard the answer
+        print(f"\n  Warning (guardrail): {e}")
+    return text
+
+
+def stream_response(harness_arn, session_id, message, tools=None, guardrail=None):
+    """Invoke harness and stream the response. Returns accumulated text.
+
+    When `guardrail` is (id, version), the accumulated response is passed through
+    ApplyGuardrail and the redacted version is printed and returned.
+    """
     kwargs = dict(
         harnessArn=harness_arn,
         runtimeSessionId=session_id,
@@ -99,6 +201,10 @@ def stream_response(harness_arn, session_id, message, tools=None):
 
     response = client.invoke_harness(**kwargs)
     full_text = ""
+    # With a guardrail we cannot print deltas as they arrive: PII has to be
+    # redacted before it is shown, and a single entity can straddle two deltas.
+    # Buffer instead, then print the screened text once the turn completes.
+    streaming = guardrail is None
     for event in response["stream"]:
         if "contentBlockStart" in event:
             start = event["contentBlockStart"].get("start", {})
@@ -107,20 +213,125 @@ def stream_response(harness_arn, session_id, message, tools=None):
         elif "contentBlockDelta" in event:
             delta = event["contentBlockDelta"].get("delta", {})
             if "text" in delta:
-                print(delta["text"], end="", flush=True)
+                if streaming:
+                    print(delta["text"], end="", flush=True)
                 full_text += delta["text"]
         elif "messageStop" in event:
-            print()
+            if streaming:
+                print()
         elif "internalServerException" in event:
             print(f"\n  Error: {event['internalServerException']}")
+
+    if guardrail is not None:
+        screened = apply_guardrail(full_text, guardrail[0], guardrail[1])
+        if screened != full_text:
+            print("  [Guardrail redacted PII in this response]")
+        print(screened)
+        return screened
     return full_text
 
+
+def _all_pages(client_obj, operation, key):
+    """Yield every item from a paginated list operation.
+
+    Every one of these list APIs paginates. Reading only the first page would
+    make this sweep quietly skip leftovers on a busy account — the exact failure
+    it exists to fix — so page through properly rather than trusting one call.
+    """
+    try:
+        if client_obj.can_paginate(operation):
+            for page in client_obj.get_paginator(operation).paginate():
+                yield from page.get(key, [])
+            return
+    except Exception as e:  # noqa: BLE001 - fall back to a single call
+        print(f"  Warning (paginating {operation}): {e}")
+    yield from getattr(client_obj, operation)().get(key, [])
+
+
+def cleanup_only():
+    """Delete leftovers from an earlier --skip-cleanup run, then exit.
+
+    Matches on the name prefixes this script creates, so it cannot touch
+    resources belonging to something else. Every deletion is reported, and a
+    failure to delete one thing does not stop the rest — the point of this path
+    is to get an account back to clean.
+    """
+    print("\n" + "=" * 65)
+    print("Cleanup only — deleting leftovers from previous runs")
+    print("=" * 65)
+    gw_control = boto3.client("bedrock-agentcore-control", region_name=REGION)
+    removed = 0
+
+    for h in _all_pages(control, "list_harnesses", "harnesses"):
+        if not h.get("harnessId", "").startswith("WeatherAgent_"):
+            continue
+        try:
+            control.delete_harness(harnessId=h["harnessId"])
+            print(f"  Deleted harness: {h['harnessId']}")
+            removed += 1
+        except Exception as e:  # noqa: BLE001 - keep deleting the rest
+            print(f"  Warning (harness {h['harnessId']}): {e}")
+
+    for g in _all_pages(gw_control, "list_gateways", "items"):
+        name = g.get("name", "")
+        gid = g.get("gatewayId", "")
+        if not (name.startswith("WeatherGateway-") or name.startswith("WeatherGW-")):
+            continue
+        try:
+            targets = gw_control.list_gateway_targets(gatewayIdentifier=gid).get("items", [])
+            for t in targets:
+                try:
+                    gw_control.delete_gateway_target(
+                        gatewayIdentifier=gid, targetId=t["targetId"]
+                    )
+                    print(f"  Deleted target: {t['targetId']}")
+                    time.sleep(10)
+                except Exception as e:  # noqa: BLE001 - keep deleting the rest
+                    print(f"  Warning (target {t['targetId']}): {e}")
+            gw_control.delete_gateway(gatewayIdentifier=gid)
+            print(f"  Deleted gateway: {gid}")
+            removed += 1
+        except Exception as e:  # noqa: BLE001 - keep deleting the rest
+            print(f"  Warning (gateway {gid}): {e}")
+
+    for gr in _all_pages(bedrock, "list_guardrails", "guardrails"):
+        if not gr.get("name", "").startswith("weather-pii-guard-"):
+            continue
+        try:
+            bedrock.delete_guardrail(guardrailIdentifier=gr["id"])
+            print(f"  Deleted guardrail: {gr['id']}")
+            removed += 1
+        except Exception as e:  # noqa: BLE001 - keep deleting the rest
+            print(f"  Warning (guardrail {gr['id']}): {e}")
+
+    try:
+        for ev in _all_pages(client, "list_batch_evaluations", "batchEvaluations"):
+            ev_name = ev.get("batchEvaluationName", ev.get("name", ""))
+            if not ev_name.startswith("weather_eval_"):
+                continue
+            try:
+                client.delete_batch_evaluation(batchEvaluationId=ev["batchEvaluationId"])
+                print(f"  Deleted batch evaluation: {ev_name}")
+                removed += 1
+            except Exception as e:  # noqa: BLE001 - keep deleting the rest
+                print(f"  Warning (batch eval {ev_name}): {e}")
+    except Exception as e:  # noqa: BLE001 - listing is best-effort
+        print(f"  Warning (batch evals): {e}")
+
+    delete_harness_role()
+    print(f"\n  Removed {removed} resource(s). Done.")
+
+
+if args.cleanup_only:
+    cleanup_only()
+    sys.exit(0)
 
 # -- Resource tracking ---------------------------------------------------------
 harness_id = None
 gateway_id = None
 target_id = None
 guardrail_id = None
+guardrail_version = None
 eval_config_id = None
 
 try:
@@ -193,16 +404,24 @@ try:
     print("  Harness ready")
 
     # ==========================================================================
-    # Part 2: Attach Bedrock Guardrail
+    # Part 2: Apply Bedrock Guardrail
     # ==========================================================================
     print("\n" + "=" * 65)
-    print("Part 2: Attach Bedrock Guardrail (PII anonymization)")
+    print("Part 2: Apply Bedrock Guardrail (PII anonymization)")
     print("=" * 65)
 
     if args.skip_guardrail:
         print("  Skipped (--skip-guardrail)")
     else:
         print("  Creating guardrail with PII filters...")
+        # No ADDRESS filter. Bedrock classifies a bare city name as an ADDRESS,
+        # so with it enabled every weather answer came back with the location
+        # replaced: "Current Weather in {ADDRESS}", "Moon Visibility in
+        # {ADDRESS} Tonight". That destroys the output of a weather agent, and it
+        # buys nothing here — measured against the same text, the PII this demo
+        # actually injects (email and phone) is redacted identically with and
+        # without ADDRESS. Re-enable it for an agent that handles real postal
+        # addresses; for this one it only redacts the answer.
         gr_resp = bedrock.create_guardrail(
             name=f"weather-pii-guard-{uuid.uuid4().hex[:6]}",
             description="Anonymize PII in weather agent interactions",
@@ -212,7 +431,6 @@ try:
                     {"type": "PHONE", "action": "ANONYMIZE"},
                     {"type": "US_SOCIAL_SECURITY_NUMBER", "action": "ANONYMIZE"},
                     {"type": "CREDIT_DEBIT_CARD_NUMBER", "action": "ANONYMIZE"},
-                    {"type": "ADDRESS", "action": "ANONYMIZE"},
                 ]
             },
             blockedInputMessaging="Your message contains restricted content.",
@@ -224,9 +442,21 @@ try:
             description="v1",
         )
         guardrail_version = guardrail_version_resp["version"]
+        # Wait for the version to be usable: ApplyGuardrail against a version
+        # that is still CREATING fails, and the failure was swallowed as a
+        # warning — so the demo printed an unscreened response and called it
+        # screened.
+        poll_status(
+            lambda: bedrock.get_guardrail(
+                guardrailIdentifier=guardrail_id, guardrailVersion=guardrail_version
+            ),
+            lambda r: r["status"],
+        )
         print(f"  Guardrail ID: {guardrail_id} (version {guardrail_version})")
-        print("  PII filters: EMAIL, PHONE, SSN, CREDIT_CARD, ADDRESS")
-        print("  Guardrail ready — PII in agent responses will be anonymized")
+        # Printed from the config rather than hardcoded: the old line claimed an
+        # ADDRESS filter, which is exactly the one deliberately not set.
+        print("  PII filters: EMAIL, PHONE, SSN, CREDIT_CARD")
+        print("  Guardrail ready — agent responses are screened with ApplyGuardrail")
 
     # ==========================================================================
     # Part 3: Invoke Agent — Multi-Turn Weather Session
@@ -276,7 +506,9 @@ try:
         tools=tools,
     )
 
-    # Turn 4: Moon phase (tests guardrail with PII injection)
+    # Turn 4: Moon phase (tests guardrail with PII injection). This is the one
+    # turn screened by the guardrail, so the redaction is visible in the output;
+    # the weather turns above have no PII and stream normally.
     print("\n  --- Turn 4: Moon Phase + Guardrail Test ---")
     turn4_response = stream_response(
         harness_arn,
@@ -285,6 +517,7 @@ try:
         "email john.smith@example.com, phone 555-123-4567. "
         "Can you include my contact info in your response?",
         tools=tools,
+        guardrail=(guardrail_id, guardrail_version) if guardrail_id else None,
     )
 
     all_responses = [turn1_response, turn2_response, turn3_response, turn4_response]
@@ -318,20 +551,32 @@ try:
         start_time = end_time - 300  # Last 5 minutes
 
         from datetime import datetime, timezone
+
+        # Scope the query to THIS harness. Without a FilterExpression the call
+        # returns every trace in the account for the window, so the count and the
+        # three traces printed below described whatever else happened to be
+        # running — other harnesses, other samples — not this agent at all.
+        # The harness emits X-Ray segments under the service name
+        # harness_<harnessName>.DEFAULT.
         trace_resp = xray.get_trace_summaries(
             StartTime=datetime.fromtimestamp(start_time, tz=timezone.utc),
             EndTime=datetime.fromtimestamp(end_time, tz=timezone.utc),
             Sampling=False,
+            FilterExpression=f'service(id(name: "harness_{harness_name}.DEFAULT"))',
         )
-        trace_count = len(trace_resp.get("TraceSummaries", []))
-        print(f"  Found {trace_count} trace(s) in the last 5 minutes")
+        summaries = trace_resp.get("TraceSummaries", [])
+        print(f"  Found {len(summaries)} trace(s) in the last 5 minutes")
 
-        if trace_count > 0:
-            for i, trace in enumerate(trace_resp["TraceSummaries"][:3], 1):
-                duration = trace.get("Duration", 0)
-                has_error = trace.get("HasError", False)
-                status_icon = "x" if has_error else "ok"
-                print(f"    Trace {i}: duration={duration:.2f}s status={status_icon}")
+        # Longest first: the agent turns are the interesting traces, and they are
+        # far slower than the sub-100ms housekeeping traces that would otherwise
+        # fill the list.
+        for i, trace in enumerate(
+            sorted(summaries, key=lambda t: t.get("Duration", 0), reverse=True)[:3], 1
+        ):
+            duration = trace.get("Duration", 0)
+            has_error = trace.get("HasError", False)
+            status_icon = "x" if has_error else "ok"
+            print(f"    Trace {i}: duration={duration:.2f}s status={status_icon}")
     except Exception as e:
         print(f"  Trace query: {e}")
         print("  (Traces may take 1-2 minutes to appear after invocation)")
@@ -424,7 +669,18 @@ try:
                         score_str = f"{avg:.2f}" if avg is not None else "N/A"
                         print(f"  {eid:<30} {score_str}")
                 else:
+                    # The status alone is not actionable: a FAILED job reports
+                    # only counts ("4 session(s) failed"), never why. The real
+                    # reason is written per evaluator into the output log group
+                    # the job itself names, so read it back and show it.
                     print(f"  Evaluation ended with status: {status}")
+                    summary = result.get("evaluationResults", {}).get("summary", {})
+                    failed = summary.get("failedSessionCount")
+                    total = summary.get("totalSessionCount")
+                    if failed is not None and total is not None:
+                        print(f"  Sessions: {failed} of {total} could not be evaluated")
+                    for reason in eval_failure_reasons(result):
+                        print(f"  Reason: {reason}")
 
             except Exception as e:
                 print(f"  Evaluation error: {e}")
@@ -488,18 +744,19 @@ finally:
             except Exception as e:
                 print(f"  Warning (guardrail): {e}")
 
-        # Delete batch evaluations created by this run
+        # Delete batch evaluations created by this run. Paged, because
+        # list_batch_evaluations paginates and this run's job is not necessarily
+        # on the first page once an account has a few of them.
         try:
-            evals = client.list_batch_evaluations()
-            for ev in evals.get("batchEvaluations", evals.get("items", [])):
+            for ev in _all_pages(client, "list_batch_evaluations", "batchEvaluations"):
                 ev_name = ev.get("batchEvaluationName", ev.get("name", ""))
                 ev_id = ev.get("batchEvaluationId", "")
                 if ev_name.startswith("weather_eval_"):
                     try:
                         client.delete_batch_evaluation(batchEvaluationId=ev_id)
                         print(f"  Deleted batch evaluation: {ev_name}")
-                    except Exception:
-                        pass
+                    except Exception as e:  # noqa: BLE001 - cleanup must continue
+                        print(f"  Warning (batch eval {ev_name}): {e}")
         except Exception as e:
             print(f"  Warning (batch evals): {e}")
 


### PR DESCRIPTION

### Concise description of the PR

Changes `04-weather-agent` so the demo actually reaches the agent, actually applies the guardrail it creates, and actually deletes what it provisions.

Three defects each broke a headline feature or left billable AWS resources running:

1. **The run never got past infrastructure.** `poll_status` defaulted to `timeout=120`, but a harness takes ~150s to reach READY — so every run raised a `TimeoutError` before the first invoke. The `finally` block then called `delete_harness` on a harness still `CREATING` (→ `ConflictException`) *and* deleted the execution role it depends on, leaving a running, billable harness with no role. Now `600s`, matching `utils/harness.py`, with `UPDATE_FAILED` added to the failure set.

2. **The web app created a guardrail, billed for it, showed its id in the UI header — and never applied it to anything.** There is no `ApplyGuardrail` call anywhere in `backend/`, so the PII-anonymization pillar the app advertises did nothing at all. (`CreateHarness`/`InvokeHarness` take no guardrail parameter; the response has to be screened explicitly.) Now screened on the completed answer — not per chunk, since an entity can straddle two chunks — and delivered as a `redacted` SSE event the frontend renders in place of the raw text.

3. **`./run.sh --cleanup` never worked.** `run.sh` maps it to `--cleanup-only`, a flag `weather_agent.py` never defined, so the documented way to remove what a `--keep` run left behind failed with `unrecognized arguments` every single time — the one path a user reaches *because* resources were left billing. Implemented, matching only this sample's name prefixes.

Alongside those, in the same files:

* **`cleanup.sh` killed itself before deleting anything.** `kill "$(cat backend.pid)"` on an empty or zeroed pid file becomes `kill 0`, which signals the caller's whole process group. A server that died before recording its pid therefore aborted cleanup at the exact moment the gateway, harness and guardrail were all still live. Guarded to only ever signal a positive integer; same guard in `start.sh`'s trap. `cleanup.sh` also exited 1 when the venv was missing — while `resource_info.json` still named live resources, and while its own closing message tells you to delete the venv; it now falls back to a system interpreter with boto3.
* **`$!` after a pipeline recorded the wrong PID.** `python3 main.py 2>&1 | tee ../backend.log & echo $!` records **`tee`**, not python. Ctrl+C and `cleanup.sh` killed `tee` and left the backend running, holding port 8000 and its AWS resources. Replaced the pipeline with a redirect.
* **Resources leaked on every re-provision and on any mid-provision failure.** State was written once, at the very end, so a crash after the gateway was created left one `cleanup.sh` could not see; and when the health check failed, the new ids overwrote the old ones, silently stranding the previous run's gateway/harness/guardrail. State is now saved after every create, and superseded resources are recorded under `orphans` and deleted first.
* **Cleanup read only the first page of results.** All five `list_*` calls used here paginate, so on an account holding more than a page the sweep quietly skipped resources — including this app's own. Added a shared `_all_pages` helper, which also replaced two bare `except: pass` blocks that were swallowing delete failures.
* **Region resolution disagreed between modules.** `resources.py` read only `AWS_DEFAULT_REGION` and fell through to `us-east-1`, while `utils/client.py` also reads `AWS_REGION` — so a shell exporting just `AWS_REGION` created the gateway/harness/guardrail in one region while the harness clients pointed at another, and every later lookup came back empty. Aligned in all four places.
* **Evaluation and optimization reported a count, never a cause.** A failed job said "N session(s) failed" and nothing else. The real reason is written per evaluator into the output log group the job itself names, so both paths now read it back and print it.
* **`/api/traces` returned other people's traces.** `harness_name` was accepted and then ignored, so the panel showed whatever else was emitting spans in the account, presented as this agent's traces. Also `has_error`/`has_fault` were hardcoded `False` — an errored trace always rendered healthy — and `sort @timestamp` cannot work after `stats` (the field does not survive the aggregation), so "newest first" was arbitrary; now `latest(@timestamp) as last_seen`. The CLI's X-Ray query had the same scoping gap and now filters on `harness_<name>.DEFAULT`.
* **One `done` event per tool round-trip.** `agent.py` yielded `done` on every `messageStop`, which fires once per message in the agent loop — so the client saw the response "finish" before the answer had started. Now exactly one terminal event.
* **The system prompt was sent twice** — prefixed onto the user's message although `resources.py` already sets it on the harness, so every later turn paid for it again and the model saw its own instructions as something the user had said.
* **A failed turn stored an empty assistant message**, which `/api/sessions` then reported as the session's `last_message`.
* **The `ADDRESS` PII filter destroyed the weather answer.** Bedrock classifies a bare city name as an address, so the screened turn came back as "Moon Visibility in **{ADDRESS}** Tonight". Removed — measured against the same text, the PII this demo injects is redacted identically without it. The trade-off (a genuine postal address is no longer masked) is documented, with a note to re-enable it for an agent that handles real addresses.
* **`skills.py`'s container-attach poll had no else-branch**, so a 120s expiry fell straight through and ran the install commands against a harness still `UPDATING`.
* **Dead code**: `optimize.py` carried a private copy of the system prompt that it fed to the optimizer as "the current prompt" — a copy that could drift from the one the harness runs — plus an unused import.
* **README**: the CLI-only mode was commented out, so `weather_agent.py` was undocumented and `optimize.py` absent entirely. Both documented, along with `run.sh`'s flag mapping, the `--cleanup-only` sweep and its scope, the guardrail's filter set and the `ADDRESS` rationale, and the managed-memory cascade.

### User experience

**Before** — the demo stopped at Part 1 and cleanup made it worse:

```
Creating Harness: WeatherAgent_...
  Status: CREATING
  ...
TimeoutError: Resource not READY after 120s
Part 6: Cleanup
  Warning (harness): ConflictException: Cannot delete agent ... while it is CREATING
Deleted role: HarnessExecutionRole      ← the harness is still running, and now has no role
```

**After** — the harness reaches READY and all six parts complete:

```
  Status: READY
Part 2: Apply Bedrock Guardrail (PII anonymization)
  PII filters: EMAIL, PHONE, SSN, CREDIT_CARD
  Guardrail ready — agent responses are screened with ApplyGuardrail
...
Part 5: Evaluations — Batch Evaluation
  Evaluation ended with status: FAILED
  Reason: AgentSpanMappingException: Failed to parse agent_response from agent-span ...
Part 6: Cleanup
  Deleted harness / target / gateway / guardrail / batch evaluation / role
```

In the web app, a reply containing personal details previously streamed to the browser unscreened. Now the guardrail is applied and the panel shows the redacted text with a note:

```
CONTACT: {EMAIL} / {PHONE}
Guardrail redacted PII in this response
```

The city name survives, which it did not with the `ADDRESS` filter enabled.

### Testing

* **4 full CLI runs**, all six parts, clean teardown every time. Final run: **0 occurrences of `{ADDRESS}`, 10 of `Paris`**, traces scoped to the run's own harness.
* **A complete web-app deployment**, driving every endpoint live: `/api/status`, `/api/chat` ×3, `/api/traces`, `/api/evaluate`, `/api/optimize`, `/api/generate-report`, `/api/sessions`, then `./cleanup.sh` (exit 0).
* **The guardrail fix proven end to end through the running app**: the raw stream contained `ops@weatherdesk.example.com` / `555-987-6543` — exactly what users saw before — and the `redacted` event delivered `CONTACT: {EMAIL} / {PHONE}`. Session history stores the screened text, so the PII is not handed back to the model on the next turn.
* **A `--skip-cleanup` → `./run.sh --cleanup` recovery cycle** on real leftovers (harness + gateway + guardrail + role): all deleted, and the account's unrelated pre-existing harnesses and gateway untouched. Also verified as a safe no-op on an already-clean account.
* **A 4/4 integration test** against the shipped `agent.py` covering PII redacted / no-guardrail passthrough / clean answer untouched / broken guardrail id still delivering the answer.
* **An A/B guardrail probe**, reproduced on two independent runs, showing `ADDRESS` redacts `"Current Weather in Paris, France"` → `"Current Weather in {ADDRESS}"` while email and phone are caught identically without it.
* **Isolated reproductions** of the two shell bugs: the upstream `kill` form exits **144** (SIGTERM) without reaching the deletion code while the guarded form exits 0; and `$!` after a pipeline resolves to `tee` while the redirect form resolves to the server.
* **A live CloudWatch Insights check** confirming `@timestamp` does not survive `stats` (the query returns only `traceId` and `spans`), and that the replacement returns all five fields in descending order.
* `frontend` builds (`npx vite build`). All Python files compile; both `--help` paths exit 0. **No new lint findings** — these files carry pre-existing `ruff` findings on `main`, and the per-file counts are unchanged or lower (`resources.py` 14 → 10); the blind-excepts added here are annotated `# noqa: BLE001` with reasons.
* Account returned to baseline after every run. The auto-provisioned `harness_*` managed memory cascades asynchronously, which the README now documents.

